### PR TITLE
Switch to RustCrypto and implement EcPoint on top of ProjectivePoint

### DIFF
--- a/sigma-tree/Cargo.toml
+++ b/sigma-tree/Cargo.toml
@@ -11,7 +11,8 @@ crate-type = ["cdylib", "rlib"]
 sigma-ser = { path = "../sigma-ser" }
 indexmap = "1.3.2"
 base16 = "0.2.1"
-libsecp256k1 = "0.3.5"
+k256 = "0.2.0"
+elliptic-curve = {version = "0.3.0", features = ["getrandom"]}
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.10"

--- a/sigma-tree/src/ecpoint.rs
+++ b/sigma-tree/src/ecpoint.rs
@@ -1,29 +1,78 @@
-use secp256k1::PublicKey;
+use k256::{
+    arithmetic::{AffinePoint, ProjectivePoint, Scalar},
+    PublicKey,
+};
 use sigma_ser::{
     serializer::{SerializationError, SigmaSerializable},
     vlq_encode,
 };
+use std::convert::TryInto;
 use std::io;
 
-#[derive(PartialEq, Eq, Debug)]
-pub struct EcPoint(pub PublicKey);
+#[derive(PartialEq, Debug)]
+pub struct EcPoint(ProjectivePoint);
 
 impl EcPoint {
-    pub const PUBLIC_KEY_SIZE: usize = secp256k1::util::COMPRESSED_PUBLIC_KEY_SIZE;
+    pub const GROUP_SIZE: usize = 33;
+
+    pub fn random() -> EcPoint {
+        let scalar = loop {
+            // Generate a new secret key using the operating system's
+            // cryptographically secure random number generator
+            let sk = k256::SecretKey::generate();
+            let bytes: [u8; 32] = sk
+                .secret_scalar()
+                .as_ref()
+                .as_slice()
+                .try_into()
+                .expect("expected 32 bytes");
+            // Returns None if the byte array does not contain
+            // a big-endian integer in the range [0, n), where n is group order.
+            let maybe_scalar = Scalar::from_bytes(bytes);
+            if bool::from(maybe_scalar.is_some()) {
+                break maybe_scalar.unwrap();
+            }
+        };
+        // we treat EC as a multiplicative group, therefore, exponentiate point is multiply.
+        let pkp = ProjectivePoint::generator() * &scalar;
+        EcPoint(pkp)
+    }
 }
+
+impl Eq for EcPoint {}
 
 impl SigmaSerializable for EcPoint {
     fn sigma_serialize<W: vlq_encode::WriteSigmaVlqExt>(&self, w: &mut W) -> Result<(), io::Error> {
-        w.write_all(&self.0.serialize_compressed())?;
+        let caff = self.0.to_affine();
+        if bool::from(caff.is_some()) {
+            let pubkey = caff.unwrap().to_compressed_pubkey();
+            w.write_all(pubkey.as_bytes())?;
+        } else {
+            // infinity point
+            let zeroes = [0u8; EcPoint::GROUP_SIZE];
+            w.write_all(&zeroes)?;
+        }
         Ok(())
     }
 
     fn sigma_parse<R: vlq_encode::ReadSigmaVlqExt>(r: &mut R) -> Result<Self, SerializationError> {
-        let mut bytes = [0; EcPoint::PUBLIC_KEY_SIZE];
-        r.read_exact(&mut bytes[..])?;
-        let pk = PublicKey::parse_compressed(&bytes)
-            .map_err(|_| SerializationError::Misc("invalid secp256k1 compressed public key"))?;
-        Ok(EcPoint(pk))
+        let mut buf = [0; EcPoint::GROUP_SIZE];
+        r.read_exact(&mut buf[..])?;
+        if buf[0] != 0 {
+            let pubkey = PublicKey::from_bytes(&buf[..])
+                .ok_or(SerializationError::Misc("failed to parse PK from bytes"))?;
+            let cp = AffinePoint::from_pubkey(&pubkey);
+            if bool::from(cp.is_none()) {
+                Err(SerializationError::Misc(
+                    "failed to get affine point from PK",
+                ))
+            } else {
+                Ok(EcPoint(ProjectivePoint::from(cp.unwrap())))
+            }
+        } else {
+            // infinity point
+            Ok(EcPoint(ProjectivePoint::identity()))
+        }
     }
 }
 
@@ -31,8 +80,6 @@ impl SigmaSerializable for EcPoint {
 mod tests {
     use super::*;
     use proptest::prelude::*;
-    use rand::thread_rng;
-    use secp256k1::SecretKey;
     use sigma_ser::test_helpers::*;
 
     impl Arbitrary for EcPoint {
@@ -40,13 +87,12 @@ mod tests {
         type Strategy = BoxedStrategy<Self>;
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            (any::<i32>())
-                .prop_map(|_| {
-                    let sk = SecretKey::random(&mut thread_rng());
-                    let pk = PublicKey::from_secret_key(&sk);
-                    EcPoint(pk)
-                })
-                .boxed()
+            prop_oneof![
+                prop::num::u8::ANY.prop_map(|_| EcPoint(ProjectivePoint::generator())),
+                prop::num::u8::ANY.prop_map(|_| EcPoint(ProjectivePoint::identity())),
+                prop::num::u8::ANY.prop_map(|_| EcPoint::random()),
+            ]
+            .boxed()
         }
     }
 


### PR DESCRIPTION
### Why RustCrypto
Bitcoin's https://github.com/rust-bitcoin/rust-secp256k1 is incompatible with
WASM since it's FFI for a C library.
Bitcoin oriented https://github.com/paritytech/libsecp256k1 is treating
infinity point as an illegal value. We can fork and built on top of it but
it seems like the project is not active anymore.

RustCrypto's secp256k1 implementation https://github.com/RustCrypto/elliptic-curves has 
all arithmetic backend and is being developed by a people who seem to know
what they are doing (from Zcash, https://github.com/iqlusioninc,
https://github.com/nucypher). 
