### PR TITLE
export ergo box value, id, registers types from ergo_box module;

### DIFF
--- a/bindings/ergo-lib-wasm/src/ergo_box.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_box.rs
@@ -18,7 +18,7 @@
 
 use std::convert::TryFrom;
 
-use chain::ergo_box::register::NonMandatoryRegisters;
+use chain::ergo_box::NonMandatoryRegisters;
 use ergo_lib::chain;
 use wasm_bindgen::prelude::*;
 
@@ -31,7 +31,7 @@ pub mod box_builder;
 /// Box id (32-byte digest)
 #[wasm_bindgen]
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub struct BoxId(chain::ergo_box::box_id::BoxId);
+pub struct BoxId(chain::ergo_box::BoxId);
 
 #[wasm_bindgen]
 impl BoxId {
@@ -41,13 +41,13 @@ impl BoxId {
     }
 }
 
-impl From<chain::ergo_box::box_id::BoxId> for BoxId {
-    fn from(b: chain::ergo_box::box_id::BoxId) -> Self {
+impl From<chain::ergo_box::BoxId> for BoxId {
+    fn from(b: chain::ergo_box::BoxId) -> Self {
         BoxId(b)
     }
 }
 
-impl From<BoxId> for chain::ergo_box::box_id::BoxId {
+impl From<BoxId> for chain::ergo_box::BoxId {
     fn from(b: BoxId) -> Self {
         b.0
     }
@@ -152,7 +152,7 @@ impl From<chain::ergo_box::ErgoBox> for ErgoBox {
 /// Box value in nanoERGs with bound checks
 #[wasm_bindgen]
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub struct BoxValue(pub(crate) chain::ergo_box::box_value::BoxValue);
+pub struct BoxValue(pub(crate) chain::ergo_box::BoxValue);
 
 #[wasm_bindgen]
 impl BoxValue {
@@ -160,13 +160,13 @@ impl BoxValue {
     /// Allows box size upto 2777 bytes with current min box value per byte of 360 nanoERGs
     #[allow(non_snake_case)]
     pub fn SAFE_USER_MIN() -> BoxValue {
-        BoxValue(chain::ergo_box::box_value::BoxValue::SAFE_USER_MIN)
+        BoxValue(chain::ergo_box::BoxValue::SAFE_USER_MIN)
     }
 
     /// Create from u32 with bounds check
     pub fn from_u32(v: u32) -> Result<BoxValue, JsValue> {
         Ok(BoxValue(
-            chain::ergo_box::box_value::BoxValue::try_from(v as u64)
+            chain::ergo_box::BoxValue::try_from(v as u64)
                 .map_err(|e| JsValue::from_str(&format!("{}", e)))?,
         ))
     }
@@ -177,14 +177,14 @@ impl BoxValue {
     }
 }
 
-impl From<BoxValue> for chain::ergo_box::box_value::BoxValue {
+impl From<BoxValue> for chain::ergo_box::BoxValue {
     fn from(v: BoxValue) -> Self {
         v.0
     }
 }
 
-impl From<chain::ergo_box::box_value::BoxValue> for BoxValue {
-    fn from(v: chain::ergo_box::box_value::BoxValue) -> Self {
+impl From<chain::ergo_box::BoxValue> for BoxValue {
+    fn from(v: chain::ergo_box::BoxValue) -> Self {
         BoxValue(v)
     }
 }
@@ -210,9 +210,9 @@ pub enum NonMandatoryRegisterId {
 
 impl NonMandatoryRegisterId {}
 
-impl From<NonMandatoryRegisterId> for chain::ergo_box::register::NonMandatoryRegisterId {
+impl From<NonMandatoryRegisterId> for chain::ergo_box::NonMandatoryRegisterId {
     fn from(v: NonMandatoryRegisterId) -> Self {
-        use chain::ergo_box::register::NonMandatoryRegisterId::*;
+        use chain::ergo_box::NonMandatoryRegisterId::*;
         match v {
             NonMandatoryRegisterId::R4 => R4,
             NonMandatoryRegisterId::R5 => R5,
@@ -224,16 +224,16 @@ impl From<NonMandatoryRegisterId> for chain::ergo_box::register::NonMandatoryReg
     }
 }
 
-impl From<chain::ergo_box::register::NonMandatoryRegisterId> for NonMandatoryRegisterId {
-    fn from(v: chain::ergo_box::register::NonMandatoryRegisterId) -> Self {
+impl From<chain::ergo_box::NonMandatoryRegisterId> for NonMandatoryRegisterId {
+    fn from(v: chain::ergo_box::NonMandatoryRegisterId) -> Self {
         use NonMandatoryRegisterId::*;
         match v {
-            chain::ergo_box::register::NonMandatoryRegisterId::R4 => R4,
-            chain::ergo_box::register::NonMandatoryRegisterId::R5 => R5,
-            chain::ergo_box::register::NonMandatoryRegisterId::R6 => R6,
-            chain::ergo_box::register::NonMandatoryRegisterId::R7 => R7,
-            chain::ergo_box::register::NonMandatoryRegisterId::R8 => R8,
-            chain::ergo_box::register::NonMandatoryRegisterId::R9 => R9,
+            chain::ergo_box::NonMandatoryRegisterId::R4 => R4,
+            chain::ergo_box::NonMandatoryRegisterId::R5 => R5,
+            chain::ergo_box::NonMandatoryRegisterId::R6 => R6,
+            chain::ergo_box::NonMandatoryRegisterId::R7 => R7,
+            chain::ergo_box::NonMandatoryRegisterId::R8 => R8,
+            chain::ergo_box::NonMandatoryRegisterId::R9 => R9,
         }
     }
 }

--- a/bindings/ergo-lib-wasm/src/token.rs
+++ b/bindings/ergo-lib-wasm/src/token.rs
@@ -19,7 +19,7 @@ pub struct TokenId(chain::token::TokenId);
 impl TokenId {
     /// Create token id from erbo box id (32 byte digest)
     pub fn from_box_id(box_id: &BoxId) -> TokenId {
-        let box_id: chain::ergo_box::box_id::BoxId = box_id.clone().into();
+        let box_id: chain::ergo_box::BoxId = box_id.clone().into();
         TokenId(chain::token::TokenId::from(box_id))
     }
 

--- a/ergo-lib/src/chain/data_input.rs
+++ b/ergo-lib/src/chain/data_input.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use super::ergo_box::box_id::BoxId;
+use super::ergo_box::BoxId;
 use crate::serialization::{
     sigma_byte_reader::SigmaByteRead, sigma_byte_writer::SigmaByteWrite, SerializationError,
     SigmaSerializable,

--- a/ergo-lib/src/chain/ergo_box.rs
+++ b/ergo-lib/src/chain/ergo_box.rs
@@ -1,9 +1,13 @@
 //! Ergo box
 
 pub mod box_builder;
-pub mod box_id;
-pub mod box_value;
-pub mod register;
+mod box_id;
+mod box_value;
+mod register;
+
+pub use box_id::*;
+pub use box_value::*;
+pub use register::*;
 
 #[cfg(feature = "json")]
 use super::json;
@@ -23,10 +27,7 @@ use crate::{
         SerializationError, SigmaSerializable,
     },
 };
-use box_id::BoxId;
-use box_value::BoxValue;
 use indexmap::IndexSet;
-use register::NonMandatoryRegisters;
 #[cfg(feature = "json")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/ergo-lib/src/chain/input.rs
+++ b/ergo-lib/src/chain/input.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use super::{
     context_extension::ContextExtension,
-    ergo_box::box_id::BoxId,
+    ergo_box::BoxId,
     ergo_box::ErgoBoxId,
     prover_result::{ProofBytes, ProverResult},
 };

--- a/ergo-lib/src/chain/json.rs
+++ b/ergo-lib/src/chain/json.rs
@@ -38,12 +38,11 @@ pub mod ergo_tree {
 }
 
 pub mod ergo_box {
+    use crate::chain::ergo_box::BoxId;
+    use crate::chain::ergo_box::BoxValue;
+    use crate::chain::ergo_box::NonMandatoryRegisters;
     use crate::{
-        chain::{
-            ergo_box::{box_id::BoxId, box_value::BoxValue, register::NonMandatoryRegisters},
-            token::Token,
-            transaction::TxId,
-        },
+        chain::{token::Token, transaction::TxId},
         ErgoTree,
     };
     use serde::Deserialize;
@@ -128,7 +127,6 @@ mod tests {
     use super::*;
     use crate::chain::context_extension::ContextExtension;
     use proptest::prelude::*;
-    use register::NonMandatoryRegisters;
 
     proptest! {
 

--- a/ergo-lib/src/chain/token.rs
+++ b/ergo-lib/src/chain/token.rs
@@ -8,7 +8,7 @@ use std::convert::TryFrom;
 use std::io;
 
 use super::digest32::Digest32;
-use super::ergo_box::box_id::BoxId;
+use super::ergo_box::BoxId;
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 #[cfg(feature = "json")]

--- a/ergo-lib/src/serialization/ergo_box.rs
+++ b/ergo-lib/src/serialization/ergo_box.rs
@@ -5,7 +5,7 @@ use crate::serialization::{
 use crate::{
     ast::Constant,
     chain::{
-        ergo_box::{box_value::BoxValue, register::NonMandatoryRegisters, ErgoBoxCandidate},
+        ergo_box::{BoxValue, ErgoBoxCandidate, NonMandatoryRegisters},
         token::{Token, TokenId},
     },
     ErgoTree,

--- a/ergo-lib/src/wallet/box_selector.rs
+++ b/ergo-lib/src/wallet/box_selector.rs
@@ -3,10 +3,10 @@
 mod simple;
 pub use simple::*;
 
-use crate::chain::ergo_box::box_value::BoxValueError;
+use crate::chain::ergo_box::BoxValueError;
 use crate::chain::ergo_box::ErgoBoxAssetsData;
 use crate::chain::{
-    ergo_box::{box_value::BoxValue, ErgoBoxAssets},
+    ergo_box::{BoxValue, ErgoBoxAssets},
     token::Token,
 };
 use thiserror::Error;

--- a/ergo-lib/src/wallet/box_selector/simple.rs
+++ b/ergo-lib/src/wallet/box_selector/simple.rs
@@ -4,9 +4,9 @@ use std::cmp::min;
 use std::collections::HashMap;
 use std::convert::TryInto;
 
-use crate::chain::ergo_box::box_value::BoxValue;
 use crate::chain::ergo_box::sum_tokens;
 use crate::chain::ergo_box::sum_tokens_from_boxes;
+use crate::chain::ergo_box::BoxValue;
 use crate::chain::ergo_box::ErgoBoxAssets;
 use crate::chain::ergo_box::ErgoBoxAssetsData;
 use crate::chain::token::Token;
@@ -146,7 +146,7 @@ impl Default for SimpleBoxSelector {
 mod tests {
     use std::convert::TryFrom;
 
-    use crate::chain::ergo_box::box_value;
+    use crate::chain::ergo_box::checked_sum;
     use crate::chain::ergo_box::sum_value;
     use crate::chain::ergo_box::ErgoBox;
     use crate::chain::ergo_box::ErgoBoxAssetsData;
@@ -169,7 +169,7 @@ mod tests {
                                         vec(any_with::<ErgoBoxAssetsData>(
                                             (BoxValue::MIN_RAW * 1000 .. BoxValue::MIN_RAW * 10000).into()), 1..10)) {
             let s = SimpleBoxSelector::new();
-            let all_inputs_val = box_value::checked_sum(inputs.iter().map(|b| b.value)).unwrap();
+            let all_inputs_val = checked_sum(inputs.iter().map(|b| b.value)).unwrap();
 
             let balance_too_much = all_inputs_val.checked_add(&BoxValue::SAFE_USER_MIN).unwrap();
             prop_assert!(s.select(inputs, balance_too_much, vec![].as_slice()).is_err());
@@ -241,7 +241,7 @@ mod tests {
                                   vec(any_with::<ErgoBoxAssetsData>(
                                       (BoxValue::MIN_RAW * 1000 .. BoxValue::MIN_RAW * 10000).into()), 1..10)) {
             let s = SimpleBoxSelector::new();
-            let all_inputs_val = box_value::checked_sum(inputs.iter().map(|b| b.value)).unwrap();
+            let all_inputs_val = checked_sum(inputs.iter().map(|b| b.value)).unwrap();
             let balance_less = all_inputs_val.checked_sub(&BoxValue::SAFE_USER_MIN).unwrap();
             let selection_less = s.select(inputs.clone(), balance_less, vec![].as_slice()).unwrap();
             prop_assert!(selection_less.boxes == inputs);

--- a/ergo-lib/src/wallet/signing.rs
+++ b/ergo-lib/src/wallet/signing.rs
@@ -71,12 +71,10 @@ mod tests {
     use proptest::prelude::*;
 
     use crate::chain::ergo_box::box_builder::ErgoBoxCandidateBuilder;
-    use crate::chain::ergo_box::box_value::BoxValue;
+    use crate::chain::ergo_box::BoxValue;
     use crate::{
         ast::{Constant, Expr},
-        chain::{
-            ergo_box::register::NonMandatoryRegisters, input::UnsignedInput, transaction::TxId,
-        },
+        chain::{ergo_box::NonMandatoryRegisters, input::UnsignedInput, transaction::TxId},
         sigma_protocol::{
             prover::TestProver,
             verifier::{TestVerifier, Verifier, VerifierError},


### PR DESCRIPTION
Close #119 

### Changes:
- `box_id`, `box_value` and `register` modules made private in `ergo_box` module and all types are re-exported from `ergo_box` module itself;