### PR TITLE
First draft of extended wasm addresses

### DIFF
--- a/bindings/ergo-lib-wasm/src/address.rs
+++ b/bindings/ergo-lib-wasm/src/address.rs
@@ -166,15 +166,6 @@ impl Address {
             .map(Address)
             .map_err(|e| JsValue::from_str(&format!("{}", e)))
     }
-
-    /// Create an address from an ergo tree
-    pub fn to_ergo_tree(&self) -> ErgoTree {
-        if (this.getType() === AddressKind.P2PK) {
-            return Buffer.concat([Buffer.from([0x00, 0x08, 0xcd]), this.publicKey]).toString('hex');
-        } else {
-            return this.addrBytes.slice(1, this.addrBytes.length - 4).toString('hex');
-        }
-    }
 }
 
 impl Into<chain::address::Address> for Address {

--- a/bindings/ergo-lib-wasm/src/address.rs
+++ b/bindings/ergo-lib-wasm/src/address.rs
@@ -2,6 +2,80 @@
 
 use ergo_lib::chain;
 use wasm_bindgen::prelude::*;
+use ergo_lib::{
+    serialization::{SigmaSerializable},
+    sigma_protocol::{
+        dlog_group::EcPoint,
+        sigma_boolean::{ProveDlog},
+    },
+};
+
+/// Network type
+#[wasm_bindgen]
+#[repr(u8)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum NetworkPrefix {
+    /// Mainnet
+    Mainnet = 0,
+    /// Testnet
+    Testnet = 16,
+}
+
+impl From<NetworkPrefix> for chain::address::NetworkPrefix {
+    fn from(v: NetworkPrefix) -> Self {
+        use chain::address::NetworkPrefix::*;
+        match v {
+            NetworkPrefix::Mainnet => Mainnet,
+            NetworkPrefix::Testnet => Testnet,
+        }
+    }
+}
+
+impl From<chain::address::NetworkPrefix> for NetworkPrefix {
+    fn from(v: chain::address::NetworkPrefix) -> Self {
+        use NetworkPrefix::*;
+        match v {
+            chain::address::NetworkPrefix::Mainnet => Mainnet,
+            chain::address::NetworkPrefix::Testnet => Testnet,
+        }
+    }
+}
+
+
+/// Address types
+#[wasm_bindgen]
+#[repr(u8)]
+pub enum AddressTypePrefix {
+    /// 0x01 - Pay-to-PublicKey(P2PK) address
+    P2PK = 1,
+    /// 0x02 - Pay-to-Script-Hash(P2SH)
+    Pay2SH = 2,
+    /// 0x03 - Pay-to-Script(P2S)
+    Pay2S = 3,
+}
+
+impl From<AddressTypePrefix> for chain::address::AddressTypePrefix {
+    fn from(v: AddressTypePrefix) -> Self {
+        use chain::address::AddressTypePrefix::*;
+        match v {
+            AddressTypePrefix::P2PK => P2PK,
+            AddressTypePrefix::Pay2SH => Pay2SH,
+            AddressTypePrefix::Pay2S => Pay2S,
+        }
+    }
+}
+
+impl From<chain::address::AddressTypePrefix> for AddressTypePrefix {
+    fn from(v: chain::address::AddressTypePrefix) -> Self {
+        use AddressTypePrefix::*;
+        match v {
+            chain::address::AddressTypePrefix::P2PK => P2PK,
+            chain::address::AddressTypePrefix::Pay2SH => Pay2SH,
+            chain::address::AddressTypePrefix::Pay2S => Pay2S,
+        }
+    }
+}
+
 
 /**
  * An address is a short string corresponding to some script used to protect a box. Unlike (string-encoded) binary
@@ -58,6 +132,48 @@ impl Address {
             .parse_address_from_str(s)
             .map(Address)
             .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
+
+    /// Decode (base58) mainnet address from string
+    pub fn from_mainnet_str(s: &str) -> Result<Address, JsValue> {
+        chain::address::AddressEncoder::new(chain::address::NetworkPrefix::Mainnet)
+            .parse_address_from_str(s)
+            .map(Address)
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
+
+    /// Decode (base58) address from string
+    pub fn from_base58(s: &str) -> Result<Address, JsValue> {
+        chain::address::AddressEncoder::unchecked_parse_address_from_str(s)
+            .map(Address)
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
+
+    /// Encode (base58) address
+    pub fn to_base58(&self, network_prefix: NetworkPrefix) -> String {
+        chain::address::AddressEncoder::encode_address(network_prefix.into(), &self.0)
+    }
+
+    /// Get the type of the address
+    pub fn address_type_prefix(&self) -> AddressTypePrefix {
+        self.0.address_type_prefix().into()
+    }
+
+    /// Create an address from a public key
+    pub fn from_public_key(bytes: &[u8]) -> Result<Address, JsValue> {
+        EcPoint::sigma_parse_bytes(bytes.to_vec())
+            .map(|point| chain::address::Address::P2PK(ProveDlog::new(point)))
+            .map(Address)
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
+
+    /// Create an address from an ergo tree
+    pub fn to_ergo_tree(&self) -> ErgoTree {
+        if (this.getType() === AddressKind.P2PK) {
+            return Buffer.concat([Buffer.from([0x00, 0x08, 0xcd]), this.publicKey]).toString('hex');
+        } else {
+            return this.addrBytes.slice(1, this.addrBytes.length - 4).toString('hex');
+        }
     }
 }
 

--- a/ergo-lib/src/ergo_tree.rs
+++ b/ergo-lib/src/ergo_tree.rs
@@ -45,7 +45,7 @@ impl ErgoTreeHeader {
 /// Whole ErgoTree parsing (deserialization) error
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ErgoTreeConstantsParsingError {
-    /// Ergo tree bytes (faild to deserialize)
+    /// Ergo tree bytes (failed to deserialize)
     pub bytes: Vec<u8>,
     /// Deserialization error
     pub error: SerializationError,
@@ -54,7 +54,7 @@ pub struct ErgoTreeConstantsParsingError {
 /// ErgoTree root expr parsing (deserialization) error
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ErgoTreeRootParsingError {
-    /// Ergo tree root expr bytes (faild to deserialize)
+    /// Ergo tree root expr bytes (failed to deserialize)
     pub bytes: Vec<u8>,
     /// Deserialization error
     pub error: SerializationError,

--- a/ergo-lib/src/sigma_protocol/sigma_boolean.rs
+++ b/ergo-lib/src/sigma_protocol/sigma_boolean.rs
@@ -94,7 +94,7 @@ impl TryInto<ProveDlog> for SigmaBoolean {
 pub struct SigmaProp(SigmaBoolean);
 
 impl SigmaProp {
-    /// create new sigma propostion from [`SigmaBoolean`] value
+    /// create new sigma proposition from [`SigmaBoolean`] value
     pub fn new(sbool: SigmaBoolean) -> Self {
         SigmaProp { 0: sbool }
     }


### PR DESCRIPTION
For Yoroi, we use the following ergo-ts functions

```
fromBytes
fromBase58
getType
fromPk
fromErgoTree
addr
```

Currently the only thing exposed by sigma-rust is

```
declare export class Address {
    static from_testnet_str(s: string): Address;
}
```

This PR is meant to add bindings to expose the missing functionality