### PR TITLE
add type and nesting level parameters to Arbitrary impl for Expr;

### DIFF
--- a/ergo-lib/src/ast/bin_op.rs
+++ b/ergo-lib/src/ast/bin_op.rs
@@ -118,11 +118,11 @@ pub mod tests {
                     any::<LogicOp>().prop_map_into(),
                     any_with::<Expr>(ArbExprParams {
                         tpe: SType::SAny,
-                        nesting_level: args.nesting_level,
+                        depth: args.depth,
                     }),
                     any_with::<Expr>(ArbExprParams {
                         tpe: SType::SAny,
-                        nesting_level: args.nesting_level,
+                        depth: args.depth,
                     }),
                 )
                     .prop_map(|(kind, left, right)| BinOp { kind, left, right }),

--- a/ergo-lib/src/ast/expr.rs
+++ b/ergo-lib/src/ast/expr.rs
@@ -93,7 +93,7 @@ pub mod tests {
         fn default() -> Self {
             ArbExprParams {
                 tpe: SType::SBoolean,
-                nesting_level: 4,
+                nesting_level: 2,
             }
         }
     }

--- a/ergo-lib/src/ast/expr.rs
+++ b/ergo-lib/src/ast/expr.rs
@@ -86,36 +86,36 @@ pub mod tests {
     #[derive(PartialEq, Eq, Debug, Clone)]
     pub struct ArbExprParams {
         pub tpe: SType,
-        pub nesting_level: usize,
+        pub depth: usize,
     }
 
     impl Default for ArbExprParams {
         fn default() -> Self {
             ArbExprParams {
                 tpe: SType::SBoolean,
-                nesting_level: 2,
+                depth: 2,
             }
         }
     }
 
-    fn bool_nested_expr(nesting_level: usize) -> BoxedStrategy<Expr> {
+    fn bool_nested_expr(depth: usize) -> BoxedStrategy<Expr> {
         prop_oneof![any_with::<BinOp>(ArbExprParams {
             tpe: SType::SBoolean,
-            nesting_level
+            depth
         })
         .prop_map(Box::new)
         .prop_map_into()]
         .boxed()
     }
 
-    fn any_nested_expr(nesting_level: usize) -> BoxedStrategy<Expr> {
-        prop_oneof![bool_nested_expr(nesting_level)]
+    fn any_nested_expr(depth: usize) -> BoxedStrategy<Expr> {
+        prop_oneof![bool_nested_expr(depth)]
     }
 
-    fn nested_expr(tpe: SType, nesting_level: usize) -> BoxedStrategy<Expr> {
+    fn nested_expr(tpe: SType, depth: usize) -> BoxedStrategy<Expr> {
         match tpe {
-            SType::SAny => any_nested_expr(nesting_level),
-            SType::SBoolean => bool_nested_expr(nesting_level),
+            SType::SAny => any_nested_expr(depth),
+            SType::SBoolean => bool_nested_expr(depth),
             _ => todo!(),
         }
         .boxed()
@@ -142,7 +142,7 @@ pub mod tests {
         type Strategy = BoxedStrategy<Self>;
 
         fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
-            if args.nesting_level == 0 {
+            if args.depth == 0 {
                 prop_oneof![
                     any_with::<Constant>(args.tpe.clone())
                         .prop_map(Box::new)
@@ -152,7 +152,7 @@ pub mod tests {
                 ]
                 .boxed()
             } else {
-                nested_expr(args.tpe, args.nesting_level - 1)
+                nested_expr(args.tpe, args.depth - 1)
             }
         }
     }

--- a/ergo-lib/src/eval/expr.rs
+++ b/ergo-lib/src/eval/expr.rs
@@ -44,7 +44,7 @@ mod tests {
     proptest! {
 
         #[test]
-        fn eval(e in any_with::<Expr>(ArbExprParams{tpe: SType::SBoolean, nesting_level: 4})) {
+        fn eval(e in any_with::<Expr>(ArbExprParams{tpe: SType::SBoolean, depth: 4})) {
             dbg!(&e);
             let ctx = Rc::new(force_any_val::<Context>());
             let cost_accum = CostAccumulator::new(0, None);

--- a/ergo-lib/src/eval/expr.rs
+++ b/ergo-lib/src/eval/expr.rs
@@ -27,3 +27,30 @@ impl Evaluable for Expr {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+
+    use crate::ast::expr::tests::*;
+    use crate::eval::context::Context;
+    use crate::eval::cost_accum::CostAccumulator;
+    use crate::test_util::force_any_val;
+    use crate::types::stype::SType;
+
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+
+        #[test]
+        fn eval(e in any_with::<Expr>(ArbExprParams{tpe: SType::SBoolean, nesting_level: 4})) {
+            dbg!(&e);
+            let ctx = Rc::new(force_any_val::<Context>());
+            let cost_accum = CostAccumulator::new(0, None);
+            let mut ectx = EvalContext::new(ctx, cost_accum);
+            let r = e.eval(&Env::empty(), &mut ectx);
+            prop_assert!(r.is_ok());
+        }
+    }
+}

--- a/ergo-lib/src/serialization/bin_op.rs
+++ b/ergo-lib/src/serialization/bin_op.rs
@@ -49,11 +49,11 @@ mod tests {
             LogicOp::Eq.into(),
             force_any_val_with::<Expr>(ArbExprParams {
                 tpe: SType::SAny,
-                nesting_level: 1,
+                depth: 1,
             }),
             force_any_val_with::<Expr>(ArbExprParams {
                 tpe: SType::SAny,
-                nesting_level: 1,
+                depth: 1,
             }),
         )
     }
@@ -64,11 +64,11 @@ mod tests {
             LogicOp::NEq.into(),
             force_any_val_with::<Expr>(ArbExprParams {
                 tpe: SType::SAny,
-                nesting_level: 1,
+                depth: 1,
             }),
             force_any_val_with::<Expr>(ArbExprParams {
                 tpe: SType::SAny,
-                nesting_level: 1,
+                depth: 1,
             }),
         )
     }

--- a/ergo-lib/src/serialization/bin_op.rs
+++ b/ergo-lib/src/serialization/bin_op.rs
@@ -33,8 +33,10 @@ pub fn bin_op_sigma_parse<R: SigmaByteRead>(
 mod tests {
     use super::*;
     use crate::ast::bin_op::LogicOp;
+    use crate::ast::expr::tests::ArbExprParams;
     use crate::serialization::sigma_serialize_roundtrip;
-    use crate::test_util::force_any_val;
+    use crate::test_util::force_any_val_with;
+    use crate::types::stype::SType;
 
     fn test_ser_roundtrip(kind: BinOpKind, left: Expr, right: Expr) {
         let eq_op: Expr = Box::new(BinOp { kind, left, right }).into();
@@ -45,8 +47,14 @@ mod tests {
     fn ser_roundtrip_eq() {
         test_ser_roundtrip(
             LogicOp::Eq.into(),
-            force_any_val::<Expr>(),
-            force_any_val::<Expr>(),
+            force_any_val_with::<Expr>(ArbExprParams {
+                tpe: SType::SAny,
+                nesting_level: 1,
+            }),
+            force_any_val_with::<Expr>(ArbExprParams {
+                tpe: SType::SAny,
+                nesting_level: 1,
+            }),
         )
     }
 
@@ -54,8 +62,14 @@ mod tests {
     fn ser_roundtrip_neq() {
         test_ser_roundtrip(
             LogicOp::NEq.into(),
-            force_any_val::<Expr>(),
-            force_any_val::<Expr>(),
+            force_any_val_with::<Expr>(ArbExprParams {
+                tpe: SType::SAny,
+                nesting_level: 1,
+            }),
+            force_any_val_with::<Expr>(ArbExprParams {
+                tpe: SType::SAny,
+                nesting_level: 1,
+            }),
         )
     }
 }

--- a/ergo-lib/src/serialization/constant.rs
+++ b/ergo-lib/src/serialization/constant.rs
@@ -31,6 +31,7 @@ mod tests {
 
         #[test]
         fn ser_roundtrip(v in any::<Constant>()) {
+            dbg!(&v);
             prop_assert_eq![sigma_serialize_roundtrip(&v), v];
         }
     }

--- a/ergo-lib/src/serialization/expr.rs
+++ b/ergo-lib/src/serialization/expr.rs
@@ -94,3 +94,19 @@ impl SigmaSerializable for Expr {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serialization::sigma_serialize_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+
+        #[test]
+        fn ser_roundtrip(v in any::<Expr>()) {
+            dbg!(&v);
+            prop_assert_eq![sigma_serialize_roundtrip(&v), v];
+        }
+    }
+}


### PR DESCRIPTION
Close #168 

`Arbitrary` implementation for `Expr` now has type and depth parameters to generate an expression of a given type with a given depth of "nested" expression. An expression is generated recursively decreasing the depth along the way. When depth reaches zero expression with either `Constant` or parameterless expression (e.g. `HEIGHT`) is generated.

