### PR TITLE
Added from_json to wasm bindigns for ErgoBox / UnsignedTransaction

### DIFF
--- a/bindings/ergo-lib-wasm/src/ergo_box.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_box.rs
@@ -170,6 +170,13 @@ impl ErgoBox {
     pub fn to_json(&self) -> Result<JsValue, JsValue> {
         JsValue::from_serde(&self.0.clone()).map_err(|e| JsValue::from_str(&format!("{}", e)))
     }
+
+    /// JSON representation
+    pub fn from_json(json: &str) -> Result<ErgoBox, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
 }
 
 impl From<ErgoBox> for chain::ergo_box::ErgoBox {

--- a/bindings/ergo-lib-wasm/src/transaction.rs
+++ b/bindings/ergo-lib-wasm/src/transaction.rs
@@ -126,6 +126,13 @@ impl UnsignedTransaction {
     pub fn to_json(&self) -> Result<JsValue, JsValue> {
         JsValue::from_serde(&self.0.clone()).map_err(|e| JsValue::from_str(&format!("{}", e)))
     }
+
+    /// JSON representation
+    pub fn from_json(json: &str) -> Result<UnsignedTransaction, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
 }
 
 impl From<chain::transaction::unsigned::UnsignedTransaction> for UnsignedTransaction {


### PR DESCRIPTION
We needed this for the ergo dapp<->wallet connector when users send entire unsigned txs over to the wallet which must then be re-parsed. JSON is the easiest way and is what the EIP-0012 (dapp connector) spec requires.