### PR TITLE
Alter SimpleBoxSelector algo to sort inputs by target tokens;

### DIFF
--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added 
 - `BlockValue`, `ValDef`, `ValUse`, `FuncValue`, `Apply` IR nodes evaluation and serialization [#171](https://github.com/ergoplatform/sigma-rust/pull/171);
+- `SimpleBoxSelector`: sort inputs by target tokens and skip inputs that does not have target tokens [#175](https://github.com/ergoplatform/sigma-rust/pull/175);
 
 ## [0.4.3] - 2021-01-15
 


### PR DESCRIPTION
Close #174 

### Summary
- Sort inputs by target tokens amount, putting inputs with largets target tokens first. 
- While going through sorted inputs having only target tokens missing skip the input if it does not have any of the target tokens.