### PR TITLE
Optional boxid for json conversion

### DIFF
--- a/ergo-lib/src/chain/ergo_box.rs
+++ b/ergo-lib/src/chain/ergo_box.rs
@@ -279,10 +279,15 @@ impl TryFrom<json::ergo_box::ErgoBoxFromJson> for ErgoBox {
             box_id,
             ..box_with_zero_id
         };
-        if ergo_box.box_id() == box_json.box_id {
-            Ok(ergo_box)
-        } else {
-            Err(ErgoBoxFromJsonError::InvalidBoxId)
+        match box_json.box_id {
+            Some(box_id) => {
+                if ergo_box.box_id() == box_id {
+                    Ok(ergo_box)
+                } else {
+                    Err(ErgoBoxFromJsonError::InvalidBoxId)
+                }
+            }
+            None => Ok(ergo_box)
         }
     }
 }

--- a/ergo-lib/src/chain/ergo_box.rs
+++ b/ergo-lib/src/chain/ergo_box.rs
@@ -287,7 +287,7 @@ impl TryFrom<json::ergo_box::ErgoBoxFromJson> for ErgoBox {
                     Err(ErgoBoxFromJsonError::InvalidBoxId)
                 }
             }
-            None => Ok(ergo_box)
+            None => Ok(ergo_box),
         }
     }
 }

--- a/ergo-lib/src/chain/json.rs
+++ b/ergo-lib/src/chain/json.rs
@@ -66,7 +66,7 @@ pub mod ergo_box {
     #[derive(Deserialize, PartialEq, Eq, Debug, Clone)]
     pub struct ErgoBoxFromJson {
         #[serde(rename = "boxId", alias = "id")]
-        pub box_id: BoxId,
+        pub box_id: Option<BoxId>,
         /// amount of money associated with the box
         #[serde(rename = "value")]
         pub value: BoxValue,
@@ -329,6 +329,22 @@ mod tests {
         }"#;
         let b: ErgoBox = serde_json::from_str(box_json).unwrap();
         assert_eq!(b.value, 67500000000u64.try_into().unwrap());
+    }
+
+    #[test]
+    fn parse_ergo_box_without_id() {
+        let box_json = r#"{
+          "value": 67500000000,
+          "ergoTree": "100204a00b08cd021dde34603426402615658f1d970cfa7c7bd92ac81a8b16eeebff264d59ce4604ea02d192a39a8cc7a70173007301",
+          "assets": [],
+          "creationHeight": 284761,
+          "additionalRegisters": {},
+          "transactionId": "9148408c04c2e38a6402a7950d6157730fa7d49e9ab3b9cadec481d7769918e9",
+          "index": 1
+        }"#;
+        let b: ErgoBox = serde_json::from_str(box_json).unwrap();
+        let id: String = b.box_id().into();
+        assert_eq!(id, "e56847ed19b3dc6b72828fcfb992fdf7310828cf291221269b7ffc72fd66706e");
     }
 
     #[test]

--- a/ergo-lib/src/chain/json.rs
+++ b/ergo-lib/src/chain/json.rs
@@ -344,7 +344,10 @@ mod tests {
         }"#;
         let b: ErgoBox = serde_json::from_str(box_json).unwrap();
         let id: String = b.box_id().into();
-        assert_eq!(id, "e56847ed19b3dc6b72828fcfb992fdf7310828cf291221269b7ffc72fd66706e");
+        assert_eq!(
+            id,
+            "e56847ed19b3dc6b72828fcfb992fdf7310828cf291221269b7ffc72fd66706e"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Goal
Using `ErgoBox.from_json` with dummy data for testing purposes were we may not have the boxId calculated.

# Problem

Currently not passing a boxId (or passing in a dummy value) throws an error (`Box id parsed from JSON differs from calculated from box serialized bytes`)

# Solution
Use the calculated value for the field instead of throwing an error if the boxId field is missing