### PR TITLE
Add AST node and evaluation for DecodePoint

### DIFF
--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -37,6 +37,7 @@ pub(crate) mod collection;
 pub(crate) mod cost_accum;
 pub(crate) mod costs;
 pub(crate) mod create_provedlog;
+pub(crate) mod decode_point;
 pub(crate) mod expr;
 pub(crate) mod extract_amount;
 pub(crate) mod extract_creation_info;

--- a/ergotree-interpreter/src/eval/decode_point.rs
+++ b/ergotree-interpreter/src/eval/decode_point.rs
@@ -1,0 +1,45 @@
+use ergotree_ir::mir::decode_point::DecodePoint;
+use ergotree_ir::mir::value::Value;
+
+use crate::eval::env::Env;
+use crate::eval::EvalContext;
+use crate::eval::EvalError;
+use crate::eval::EvalError::Misc;
+use crate::eval::Evaluable;
+use ergotree_ir::mir::constant::TryExtractInto;
+use ergotree_ir::serialization::SigmaSerializable;
+use ergotree_ir::sigma_protocol::dlog_group::EcPoint;
+
+impl Evaluable for DecodePoint {
+    fn eval(&self, env: &Env, ctx: &mut EvalContext) -> Result<Value, EvalError> {
+        let point_bytes = self.input.eval(env, ctx)?.try_extract_into::<Vec<u8>>()?;
+        let point: EcPoint = SigmaSerializable::sigma_parse_bytes(point_bytes).map_err(|_| {
+            Misc(String::from(
+                "DecodePoint: Failed to parse EC point from bytes",
+            ))
+        })?;
+        Ok(point.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::eval::tests::eval_out_wo_ctx;
+
+    use super::*;
+
+    use ergotree_ir::mir::expr::Expr;
+    use ergotree_ir::serialization::SigmaSerializable;
+    use proptest::prelude::*;
+
+    proptest! {
+
+        #[test]
+        fn eval(ecp in any::<EcPoint>()) {
+            let bytes = ecp.sigma_serialize_bytes();
+            let expr: Expr = DecodePoint {input: Expr::Const(bytes.clone().into()).into()}.into();
+            let res = eval_out_wo_ctx::<EcPoint>(&expr);
+            prop_assert_eq!(res, ecp);
+        }
+    }
+}

--- a/ergotree-interpreter/src/eval/expr.rs
+++ b/ergotree-interpreter/src/eval/expr.rs
@@ -50,6 +50,7 @@ impl Evaluable for Expr {
             Expr::Negation(op) => op.eval(env, ctx),
             Expr::ForAll(op) => op.eval(env, ctx),
             Expr::Tuple(op) => op.eval(env, ctx),
+            Expr::DecodePoint(op) => op.eval(env, ctx),
             Expr::SigmaAnd(_) => todo!(),
             Expr::SigmaOr(_) => todo!(),
         }

--- a/ergotree-ir/src/mir.rs
+++ b/ergotree-ir/src/mir.rs
@@ -26,6 +26,7 @@ pub mod collection;
 pub mod constant;
 /// Create proveDlog from GroupElement(PK)
 pub mod create_provedlog;
+pub mod decode_point;
 pub mod expr;
 /// Box value
 pub mod extract_amount;

--- a/ergotree-ir/src/mir/bin_op.rs
+++ b/ergotree-ir/src/mir/bin_op.rs
@@ -136,6 +136,20 @@ mod arbitrary {
         type Strategy = BoxedStrategy<Self>;
 
         fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+            let numeric_binop = || -> BoxedStrategy<BinOp> {
+                (
+                    any::<ArithOp>().prop_map_into(),
+                    any_with::<Expr>(args.clone()),
+                    any_with::<Expr>(args.clone()),
+                )
+                    .prop_map(|(kind, left, right)| BinOp {
+                        kind,
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    })
+                    .boxed()
+            };
+
             match args.tpe {
                 SType::SBoolean => (
                     any::<RelationOp>().prop_map_into(),
@@ -155,41 +169,11 @@ mod arbitrary {
                     })
                     .boxed(),
 
-                SType::SInt => (
-                    any::<ArithOp>().prop_map_into(),
-                    any_with::<Expr>(ArbExprParams {
-                        tpe: SType::SInt,
-                        depth: args.depth,
-                    }),
-                    any_with::<Expr>(ArbExprParams {
-                        tpe: SType::SInt,
-                        depth: args.depth,
-                    }),
-                )
-                    .prop_map(|(kind, left, right)| BinOp {
-                        kind,
-                        left: Box::new(left),
-                        right: Box::new(right),
-                    })
-                    .boxed(),
-
-                SType::SByte => (
-                    any::<ArithOp>().prop_map_into(),
-                    any_with::<Expr>(ArbExprParams {
-                        tpe: SType::SByte,
-                        depth: args.depth,
-                    }),
-                    any_with::<Expr>(ArbExprParams {
-                        tpe: SType::SByte,
-                        depth: args.depth,
-                    }),
-                )
-                    .prop_map(|(kind, left, right)| BinOp {
-                        kind,
-                        left: Box::new(left),
-                        right: Box::new(right),
-                    })
-                    .boxed(),
+                SType::SByte => numeric_binop(),
+                SType::SShort => numeric_binop(),
+                SType::SInt => numeric_binop(),
+                SType::SLong => numeric_binop(),
+                SType::SBigInt => numeric_binop(),
 
                 _ => (
                     any::<BinOpKind>(),
@@ -208,11 +192,6 @@ mod arbitrary {
                         right: Box::new(right),
                     })
                     .boxed(),
-                // SType::SByte => {}
-                // SType::SShort => {}
-                // SType::SInt => {}
-                // SType::SLong => {}
-                // SType::SBigInt => {}
             }
         }
     }

--- a/ergotree-ir/src/mir/bin_op.rs
+++ b/ergotree-ir/src/mir/bin_op.rs
@@ -173,6 +173,24 @@ mod arbitrary {
                     })
                     .boxed(),
 
+                SType::SByte => (
+                    any::<ArithOp>().prop_map_into(),
+                    any_with::<Expr>(ArbExprParams {
+                        tpe: SType::SByte,
+                        depth: args.depth,
+                    }),
+                    any_with::<Expr>(ArbExprParams {
+                        tpe: SType::SByte,
+                        depth: args.depth,
+                    }),
+                )
+                    .prop_map(|(kind, left, right)| BinOp {
+                        kind,
+                        left: Box::new(left),
+                        right: Box::new(right),
+                    })
+                    .boxed(),
+
                 _ => (
                     any::<BinOpKind>(),
                     any_with::<Expr>(ArbExprParams {

--- a/ergotree-ir/src/mir/decode_point.rs
+++ b/ergotree-ir/src/mir/decode_point.rs
@@ -1,0 +1,84 @@
+//! Decode byte array to EC point
+
+use crate::serialization::op_code::OpCode;
+use crate::serialization::sigma_byte_reader::SigmaByteRead;
+use crate::serialization::sigma_byte_writer::SigmaByteWrite;
+use crate::serialization::SerializationError;
+use crate::serialization::SigmaSerializable;
+use crate::types::stype::SType;
+
+use super::expr::Expr;
+
+/// Decode byte array to EC point
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct DecodePoint {
+    /// Byte array to be decoded
+    pub input: Box<Expr>,
+}
+
+impl DecodePoint {
+    pub(crate) const OP_CODE: OpCode = OpCode::DECODE_POINT;
+
+    /// Type
+    pub fn tpe(&self) -> SType {
+        SType::SGroupElement
+    }
+
+    pub(crate) fn op_code(&self) -> OpCode {
+        Self::OP_CODE
+    }
+}
+
+impl SigmaSerializable for DecodePoint {
+    fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> Result<(), std::io::Error> {
+        self.input.sigma_serialize(w)
+    }
+
+    fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, SerializationError> {
+        Ok(Self {
+            input: Expr::sigma_parse(r)?.into(),
+        })
+    }
+}
+
+/// Arbitrary impl
+#[cfg(feature = "arbitrary")]
+mod arbitrary {
+    use super::*;
+    use crate::mir::expr::arbitrary::ArbExprParams;
+    use proptest::prelude::*;
+
+    impl Arbitrary for DecodePoint {
+        type Strategy = BoxedStrategy<Self>;
+        type Parameters = usize;
+
+        fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+            any_with::<Expr>(ArbExprParams {
+                tpe: SType::SColl(SType::SByte.into()),
+                depth: args,
+            })
+            .prop_map(|input| Self {
+                input: input.into(),
+            })
+            .boxed()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mir::expr::Expr;
+    use crate::serialization::sigma_serialize_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+
+        #[test]
+        fn ser_roundtrip(v in any_with::<DecodePoint>(1)) {
+            let expr: Expr = v.into();
+            prop_assert_eq![sigma_serialize_roundtrip(&expr), expr];
+        }
+
+    }
+}

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -27,6 +27,7 @@ use super::constant::ConstantPlaceholder;
 use super::constant::TryExtractFrom;
 use super::constant::TryExtractFromError;
 use super::create_provedlog::CreateProveDlog;
+use super::decode_point::DecodePoint;
 use super::extract_amount::ExtractAmount;
 use super::extract_creation_info::ExtractCreationInfo;
 use super::extract_id::ExtractId;
@@ -143,6 +144,8 @@ pub enum Expr {
     CreateProveDlog(CreateProveDlog),
     /// Extract serialized bytes of a SigmaProp value
     SigmaPropBytes(SigmaPropBytes),
+    /// Decode byte array to EC point
+    DecodePoint(DecodePoint),
     /// AND conjunction for sigma propositions
     SigmaAnd(SigmaAnd),
     /// OR conjunction for sigma propositions
@@ -193,6 +196,7 @@ impl Expr {
             Expr::Negation(op) => op.op_code(),
             Expr::ForAll(op) => op.op_code(),
             Expr::Tuple(op) => op.op_code(),
+            Expr::DecodePoint(op) => op.op_code(),
             Expr::SigmaAnd(op) => op.op_code(),
             Expr::SigmaOr(op) => op.op_code(),
         }
@@ -241,6 +245,7 @@ impl Expr {
             Expr::Negation(v) => v.tpe(),
             Expr::ForAll(v) => v.tpe(),
             Expr::Tuple(v) => v.tpe(),
+            Expr::DecodePoint(v) => v.tpe(),
             Expr::SigmaAnd(v) => v.tpe(),
             Expr::SigmaOr(v) => v.tpe(),
         }

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -352,6 +352,15 @@ pub(crate) mod arbitrary {
         .boxed()
     }
 
+    fn byte_nested_expr(depth: usize) -> BoxedStrategy<Expr> {
+        prop_oneof![any_with::<BinOp>(ArbExprParams {
+            tpe: SType::SByte,
+            depth
+        })
+        .prop_map_into(),]
+            .boxed()
+    }
+
     fn bool_nested_expr(depth: usize) -> BoxedStrategy<Expr> {
         prop_oneof![
             any_with::<BinOp>(ArbExprParams {
@@ -370,6 +379,10 @@ pub(crate) mod arbitrary {
         match elem_tpe {
             SType::SBoolean => vec(bool_nested_expr(depth), 0..10)
                 .prop_map(|items| Collection::new(SType::SBoolean, items).unwrap())
+                .prop_map_into()
+                .boxed(),
+            SType::SByte => vec(byte_nested_expr(depth), 0..10)
+                .prop_map(|items| Collection::new(SType::SByte, items).unwrap())
                 .prop_map_into()
                 .boxed(),
 

--- a/ergotree-ir/src/serialization/expr.rs
+++ b/ergotree-ir/src/serialization/expr.rs
@@ -21,6 +21,7 @@ use crate::mir::collection::coll_sigma_serialize;
 use crate::mir::constant::Constant;
 use crate::mir::constant::ConstantPlaceholder;
 use crate::mir::create_provedlog::CreateProveDlog;
+use crate::mir::decode_point::DecodePoint;
 use crate::mir::expr::Expr;
 use crate::mir::extract_amount::ExtractAmount;
 use crate::mir::extract_creation_info::ExtractCreationInfo;
@@ -107,6 +108,7 @@ impl SigmaSerializable for Expr {
                     Expr::Negation(op) => op.sigma_serialize(w),
                     Expr::ForAll(op) => op.sigma_serialize(w),
                     Expr::Tuple(op) => op.sigma_serialize(w),
+                    Expr::DecodePoint(op) => op.sigma_serialize(w),
                     Expr::SigmaAnd(op) => op.sigma_serialize(w),
                     Expr::SigmaOr(op) => op.sigma_serialize(w),
                 }
@@ -196,6 +198,7 @@ impl SigmaSerializable for Expr {
                 CreateProveDlog::OP_CODE => Ok(CreateProveDlog::sigma_parse(r)?.into()),
                 SigmaPropBytes::OP_CODE => Ok(SigmaPropBytes::sigma_parse(r)?.into()),
                 Tuple::OP_CODE => Ok(Tuple::sigma_parse(r)?.into()),
+                DecodePoint::OP_CODE => Ok(DecodePoint::sigma_parse(r)?.into()),
                 SigmaAnd::OP_CODE => Ok(SigmaAnd::sigma_parse(r)?.into()),
                 SigmaOr::OP_CODE => Ok(SigmaOr::sigma_parse(r)?.into()),
                 o => Err(SerializationError::NotImplementedOpCode(format!(


### PR DESCRIPTION
This is first PR for parsing ergo script. In the end we'll need to be able to parse all of ergoscript for ergvein wallet and DecodePoint is as good starting point as any

I wasn't able to find where DecodePoint is evaluated in scala code so this is only my best guess on how it should be evaluated.

P.S. I noticed that there're quite a few of AST nodes that are just wrappers over `Box<Expr>`. At least `And`, `Or`, `DecodePoint` and probably others. Wouldn't it be better to implement them using single struct parametrized by phantom type parameter to distinguish different nodes? Something along the lines of:

```rust
struct UnaryNode<T> {
    input: Box<Expr>
}
```

