### PR TITLE
Explicitly handle errors in SMethod::from_ids & and PropertyCall deserialization

### DIFF
--- a/ergotree-ir/src/serialization/method_call.rs
+++ b/ergotree-ir/src/serialization/method_call.rs
@@ -26,7 +26,7 @@ impl SigmaSerializable for MethodCall {
         let obj = Expr::sigma_parse(r)?;
         let args = Vec::<Expr>::sigma_parse(r)?;
         let arg_types = args.iter().map(|arg| arg.tpe()).collect();
-        let method = SMethod::from_ids(type_id, method_id).specialize_for(obj.tpe(), arg_types)?;
+        let method = SMethod::from_ids(type_id, method_id)?.specialize_for(obj.tpe(), arg_types)?;
         Ok(MethodCall::new(obj, method, args)?)
     }
 }

--- a/ergotree-ir/src/serialization/property_call.rs
+++ b/ergotree-ir/src/serialization/property_call.rs
@@ -23,7 +23,10 @@ impl SigmaSerializable for PropertyCall {
         let type_id = TypeCode::sigma_parse(r)?;
         let method_id = MethodId::sigma_parse(r)?;
         let obj = Expr::sigma_parse(r)?;
-        Ok(PropertyCall::new(obj, SMethod::from_ids(type_id, method_id)).unwrap())
+        Ok(PropertyCall::new(
+            obj,
+            SMethod::from_ids(type_id, method_id)?,
+        )?)
     }
 }
 

--- a/ergotree-ir/src/serialization/serializable.rs
+++ b/ergotree-ir/src/serialization/serializable.rs
@@ -9,6 +9,8 @@ use super::{
     sigma_byte_reader::{SigmaByteRead, SigmaByteReader},
     sigma_byte_writer::{SigmaByteWrite, SigmaByteWriter},
 };
+use crate::serialization::types::TypeCode;
+use crate::types::smethod::MethodId;
 use io::Cursor;
 use sigma_ser::{peekable_reader::PeekableReader, vlq_encode};
 use std::io;
@@ -53,6 +55,9 @@ pub enum SerializationError {
     /// Invalid argument on node creation
     #[error("Invalid argument: {0:?}")]
     InvalidArgument(InvalidArgumentError),
+    /// Unknown method ID for given type code
+    #[error("No method id {0:?} found in type companion with type id {1:?} ")]
+    UnknownMethodId(MethodId, TypeCode),
 }
 
 impl From<vlq_encode::VlqEncodingError> for SerializationError {

--- a/ergotree-ir/src/types/sbox.rs
+++ b/ergotree-ir/src/types/sbox.rs
@@ -91,8 +91,8 @@ mod tests {
 
     #[test]
     fn test_from_ids() {
-        assert!(SMethod::from_ids(TYPE_ID, VALUE_METHOD_ID).name() == "value");
-        assert!(SMethod::from_ids(TYPE_ID, GET_REG_METHOD_ID).name() == "getReg");
-        assert!(SMethod::from_ids(TYPE_ID, TOKENS_METHOD_ID).name() == "tokens");
+        assert!(SMethod::from_ids(TYPE_ID, VALUE_METHOD_ID).map(|e| e.name()) == Ok("value"));
+        assert!(SMethod::from_ids(TYPE_ID, GET_REG_METHOD_ID).map(|e| e.name()) == Ok("getReg"));
+        assert!(SMethod::from_ids(TYPE_ID, TOKENS_METHOD_ID).map(|e| e.name()) == Ok("tokens"));
     }
 }

--- a/ergotree-ir/src/types/scoll.rs
+++ b/ergotree-ir/src/types/scoll.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_from_ids() {
-        assert!(SMethod::from_ids(TYPE_ID, INDEX_OF_METHOD_ID).name() == "indexOf");
-        assert!(SMethod::from_ids(TYPE_ID, FLATMAP_METHOD_ID).name() == "flatMap");
+        assert!(SMethod::from_ids(TYPE_ID, INDEX_OF_METHOD_ID).map(|e| e.name()) == Ok("indexOf"));
+        assert!(SMethod::from_ids(TYPE_ID, FLATMAP_METHOD_ID).map(|e| e.name()) == Ok("flatMap"));
     }
 }

--- a/ergotree-ir/src/types/scontext.rs
+++ b/ergotree-ir/src/types/scontext.rs
@@ -51,6 +51,9 @@ mod tests {
 
     #[test]
     fn test_from_ids() {
-        assert!(SMethod::from_ids(TYPE_ID, DATA_INPUTS_PROPERTY_METHOD_ID).name() == "dataInputs");
+        assert!(
+            SMethod::from_ids(TYPE_ID, DATA_INPUTS_PROPERTY_METHOD_ID).map(|e| e.name())
+                == Ok("dataInputs")
+        );
     }
 }

--- a/ergotree-ir/src/types/smethod.rs
+++ b/ergotree-ir/src/types/smethod.rs
@@ -12,6 +12,7 @@ use super::stype_companion::STypeCompanion;
 use super::stype_param::STypeVar;
 use super::type_unify::unify_many;
 use super::type_unify::TypeUnificationError;
+use crate::serialization::SerializationError::UnknownMethodId;
 
 /// Method id unique among the methods of the same object
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -45,14 +46,11 @@ impl SMethod {
     }
 
     /// Get method from type and method ids
-    pub fn from_ids(type_id: TypeCode, method_id: MethodId) -> Self {
+    pub fn from_ids(type_id: TypeCode, method_id: MethodId) -> Result<Self, SerializationError> {
         let obj_type = STypeCompanion::type_by_id(type_id);
         match obj_type.method_by_id(&method_id) {
-            Some(m) => m,
-            None => panic!(
-                "no method id {0:?} found in type companion with type id {1:?}",
-                method_id, type_id
-            ),
+            Some(m) => Ok(m),
+            None => Err(UnknownMethodId(method_id, type_id)),
         }
     }
 


### PR DESCRIPTION
I stumbled on panics when mass parsing ergo blockchain. I think parsing code should never panic no matter what is thrown at it