### PR TITLE
Fix flatmap method & GET_VAR opcode

### DIFF
--- a/ergotree-ir/src/mir/value.rs
+++ b/ergotree-ir/src/mir/value.rs
@@ -63,7 +63,7 @@ impl CollKind {
             SType::SByte => items
                 .into_iter()
                 .map(|v| v.try_extract_into::<i8>())
-                .collect::<Result<Vec<i8>, TryExtractFromError>>()
+                .collect::<Result<Vec<_>, _>>()
                 .map(|bytes| CollKind::NativeColl(NativeColl::CollByte(bytes))),
             _ => Ok(CollKind::WrappedColl { elem_tpe, items }),
         }
@@ -78,12 +78,12 @@ impl CollKind {
             SType::SByte => items
                 .into_iter()
                 .map(|v| v.try_extract_into::<Vec<i8>>())
-                .collect::<Result<Vec<Vec<i8>>, TryExtractFromError>>()
+                .collect::<Result<Vec<_>, _>>()
                 .map(|bytes| CollKind::NativeColl(NativeColl::CollByte(bytes.concat()))),
             _ => items
                 .into_iter()
                 .map(|v| v.try_extract_into::<Vec<Value>>())
-                .collect::<Result<Vec<Vec<Value>>, TryExtractFromError>>()
+                .collect::<Result<Vec<_>, _>>()
                 .map(|v| CollKind::WrappedColl {
                     elem_tpe,
                     items: v.concat(),

--- a/ergotree-ir/src/serialization/op_code.rs
+++ b/ergotree-ir/src/serialization/op_code.rs
@@ -126,7 +126,7 @@ impl OpCode {
     pub const SOME_VALUE: OpCode = Self::new_op_code(110);
     pub const NONE_VALUE: OpCode = Self::new_op_code(111);
 
-    pub const GET_VAR: OpCode = Self::new_op_code(114);
+    pub const GET_VAR: OpCode = Self::new_op_code(115);
     pub const OPTION_GET: OpCode = Self::new_op_code(116);
     pub const OPTION_GET_OR_ELSE: OpCode = Self::new_op_code(117);
     pub const OPTION_IS_DEFINED: OpCode = Self::new_op_code(118);

--- a/ergotree-ir/src/types/scoll.rs
+++ b/ergotree-ir/src/types/scoll.rs
@@ -15,7 +15,7 @@ pub const TYPE_ID: TypeCode = TypeCode::COLLECTION;
 /// Coll.indexOf
 pub const INDEX_OF_METHOD_ID: MethodId = MethodId(26);
 /// Coll.flatmap
-pub const FLATMAP_METHOD_ID: MethodId = MethodId(1);
+pub const FLATMAP_METHOD_ID: MethodId = MethodId(15);
 
 static S_COLL_TYPE_COMPANION_HEAD: STypeCompanionHead = STypeCompanionHead {
     type_id: TYPE_ID,
@@ -54,7 +54,10 @@ lazy_static! {
         tpe: SFunc::new(
             vec![
                 SType::SColl(SType::STypeVar(STypeVar::iv()).into()),
-                SFunc::new(vec![STypeVar::iv().into()], STypeVar::ov().into()).into()
+                SFunc::new(
+                    vec![STypeVar::iv().into()],
+                    SType::SColl(Box::new(STypeVar::ov().into())),
+                ).into()
                 ],
             SType::SColl(SType::STypeVar(STypeVar::ov()).into()),
         ),


### PR DESCRIPTION
GET_VAR should be 115 not 114 [See](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/25251c1313b0131835f92099f02cef8a5d932b5e/sigmastate/src/main/scala/sigmastate/serialization/OpCodes.scala#L181)

Same with method ID of flatmap [See](https://github.com/ScorexFoundation/sigmastate-interpreter/blob/25251c1313b0131835f92099f02cef8a5d932b5e/sigmastate/src/main/scala/sigmastate/types.scala#L1129-L1142). Also it looks like type is wrong. It should be `([i], i->[o]) -> [o]` instead of `([i], i->o) -> [o]`