### PR TITLE
Add DataInput ctor, PreHeader in WASM bindings

### DIFF
--- a/bindings/ergo-lib-wasm/src/block_header.rs
+++ b/bindings/ergo-lib-wasm/src/block_header.rs
@@ -1,0 +1,90 @@
+//! Block header
+use ergo_lib::chain;
+use wasm_bindgen::prelude::*;
+
+extern crate derive_more;
+use derive_more::{From, Into};
+
+/// Block header
+#[wasm_bindgen]
+#[derive(PartialEq, Eq, Debug, Clone, From, Into)]
+pub struct BlockHeader(ergo_lib::chain::block_header::BlockHeader);
+
+#[wasm_bindgen]
+impl BlockHeader {
+    /// Parse from JSON (Node API)
+    pub fn from_json(json: &str) -> Result<BlockHeader, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
+}
+
+/// Collection of BlockHeaders
+#[wasm_bindgen]
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct BlockHeaders(Vec<BlockHeader>);
+
+#[wasm_bindgen]
+impl BlockHeaders {
+    /// parse BlockHeader array from json
+    #[allow(clippy::boxed_local, clippy::or_fun_call)]
+    pub fn from_boxes_json(boxes: Box<[JsValue]>) -> Result<BlockHeaders, JsValue> {
+        boxes
+            .iter()
+            .try_fold(vec![], |mut acc, jb| {
+                let b: chain::block_header::BlockHeader = if jb.is_string() {
+                    let jb_str = jb
+                        .as_string()
+                        .ok_or(JsValue::from_str("Expected BlockHeader JSON as string"))?;
+                    serde_json::from_str(jb_str.as_str())
+                } else {
+                    jb.into_serde::<chain::block_header::BlockHeader>()
+                }
+                .map_err(|e| {
+                    JsValue::from_str(&format!(
+                        "Failed to parse BlockHeader from JSON string: {:?} \n with error: {}",
+                        jb, e
+                    ))
+                })?;
+                acc.push(b);
+                Ok(acc)
+            })
+            .map(BlockHeaders::from)
+    }
+
+    /// Create new collection with one element
+    #[wasm_bindgen(constructor)]
+    pub fn new(b: &BlockHeader) -> BlockHeaders {
+        BlockHeaders(vec![b.clone()])
+    }
+
+    /// Returns the number of elements in the collection
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Add an element to the collection
+    pub fn add(&mut self, b: &BlockHeader) {
+        self.0.push(b.clone());
+    }
+
+    /// Returns the element of the collection with a given index
+    pub fn get(&self, index: usize) -> BlockHeader {
+        self.0[index].clone()
+    }
+}
+
+impl From<Vec<chain::block_header::BlockHeader>> for BlockHeaders {
+    fn from(bs: Vec<chain::block_header::BlockHeader>) -> Self {
+        BlockHeaders(bs.into_iter().map(BlockHeader::from).collect())
+    }
+}
+
+impl From<BlockHeaders> for Vec<chain::block_header::BlockHeader> {
+    fn from(bs: BlockHeaders) -> Self {
+        bs.0.into_iter()
+            .map(chain::block_header::BlockHeader::from)
+            .collect()
+    }
+}

--- a/bindings/ergo-lib-wasm/src/block_header.rs
+++ b/bindings/ergo-lib-wasm/src/block_header.rs
@@ -29,7 +29,7 @@ pub struct BlockHeaders(Vec<BlockHeader>);
 impl BlockHeaders {
     /// parse BlockHeader array from json
     #[allow(clippy::boxed_local, clippy::or_fun_call)]
-    pub fn from_boxes_json(boxes: Box<[JsValue]>) -> Result<BlockHeaders, JsValue> {
+    pub fn from_json(boxes: Box<[JsValue]>) -> Result<BlockHeaders, JsValue> {
         boxes
             .iter()
             .try_fold(vec![], |mut acc, jb| {

--- a/bindings/ergo-lib-wasm/src/block_header.rs
+++ b/bindings/ergo-lib-wasm/src/block_header.rs
@@ -27,7 +27,7 @@ pub struct BlockHeaders(Vec<BlockHeader>);
 
 #[wasm_bindgen]
 impl BlockHeaders {
-    /// parse BlockHeader array from json
+    /// parse BlockHeader array from JSON (Node API)
     #[allow(clippy::boxed_local, clippy::or_fun_call)]
     pub fn from_json(boxes: Box<[JsValue]>) -> Result<BlockHeaders, JsValue> {
         boxes

--- a/bindings/ergo-lib-wasm/src/data_input.rs
+++ b/bindings/ergo-lib-wasm/src/data_input.rs
@@ -14,6 +14,15 @@ pub struct DataInput(chain::transaction::DataInput);
 
 #[wasm_bindgen]
 impl DataInput {
+    /// Parse box id (32 byte digest) from base16-encoded string
+    #[wasm_bindgen(constructor)]
+    pub fn new(box_id: BoxId) -> Self {
+        chain::transaction::DataInput {
+            box_id: box_id.into(),
+        }
+        .into()
+    }
+
     /// Get box id
     pub fn box_id(&self) -> BoxId {
         self.0.box_id.clone().into()

--- a/bindings/ergo-lib-wasm/src/ergo_box.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_box.rs
@@ -35,26 +35,22 @@ pub mod box_builder;
 
 /// Box id (32-byte digest)
 #[wasm_bindgen]
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, From, Into)]
 pub struct BoxId(chain::ergo_box::BoxId);
 
 #[wasm_bindgen]
 impl BoxId {
+    /// Parse box id (32 byte digest) from base16-encoded string
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(box_id_str: String) -> Result<BoxId, JsValue> {
+        chain::ergo_box::BoxId::try_from(box_id_str)
+            .map(BoxId)
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
+
     /// Base16 encoded string
     pub fn to_str(&self) -> String {
         self.0.clone().into()
-    }
-}
-
-impl From<chain::ergo_box::BoxId> for BoxId {
-    fn from(b: chain::ergo_box::BoxId) -> Self {
-        BoxId(b)
-    }
-}
-
-impl From<BoxId> for chain::ergo_box::BoxId {
-    fn from(b: BoxId) -> Self {
-        b.0
     }
 }
 

--- a/bindings/ergo-lib-wasm/src/ergo_state_ctx.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_state_ctx.rs
@@ -17,3 +17,6 @@ impl ErgoStateContext {
         ErgoStateContext(chain::ergo_state_context::ErgoStateContext::dummy())
     }
 }
+
+// TODO: add PreHeader, and build it from BlockHeader
+// TODO: add BlockHeader and parse them from JSON (REST API lastHeaders)

--- a/bindings/ergo-lib-wasm/src/ergo_state_ctx.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_state_ctx.rs
@@ -5,18 +5,26 @@ use wasm_bindgen::prelude::*;
 extern crate derive_more;
 use derive_more::{From, Into};
 
-/// TBD
+use crate::header::PreHeader;
+
+/// Blockchain state (last headers, etc.)
 #[wasm_bindgen]
 #[derive(PartialEq, Eq, Debug, Clone, From, Into)]
 pub struct ErgoStateContext(chain::ergo_state_context::ErgoStateContext);
 
 #[wasm_bindgen]
 impl ErgoStateContext {
+    /// Create new context from pre-header
+    #[wasm_bindgen(constructor)]
+    pub fn new(pre_header: PreHeader) -> Self {
+        chain::ergo_state_context::ErgoStateContext {
+            pre_header: pre_header.into(),
+        }
+        .into()
+    }
+
     /// empty (dummy) context (for signing P2PK tx only)
     pub fn dummy() -> ErgoStateContext {
         ErgoStateContext(chain::ergo_state_context::ErgoStateContext::dummy())
     }
 }
-
-// TODO: add PreHeader, and build it from BlockHeader
-// TODO: add BlockHeader and parse them from JSON (REST API lastHeaders)

--- a/bindings/ergo-lib-wasm/src/header.rs
+++ b/bindings/ergo-lib-wasm/src/header.rs
@@ -1,0 +1,23 @@
+//! Block header with the current `spendingTransaction`, that can be predicted by a miner before it's formation
+use wasm_bindgen::prelude::*;
+
+extern crate derive_more;
+use derive_more::{From, Into};
+
+use crate::block_header::BlockHeader;
+
+/// Block header with the current `spendingTransaction`, that can be predicted
+/// by a miner before it's formation
+#[wasm_bindgen]
+#[derive(PartialEq, Eq, Debug, Clone, From, Into)]
+pub struct PreHeader(ergo_lib::ergotree_ir::mir::header::PreHeader);
+
+#[wasm_bindgen]
+impl PreHeader {
+    /// Create using data from block header
+    pub fn from_block_header(block_header: BlockHeader) -> Self {
+        let bh: ergo_lib::chain::block_header::BlockHeader = block_header.into();
+        let ph: ergo_lib::ergotree_ir::mir::header::PreHeader = bh.into();
+        ph.into()
+    }
+}

--- a/bindings/ergo-lib-wasm/src/lib.rs
+++ b/bindings/ergo-lib-wasm/src/lib.rs
@@ -16,6 +16,7 @@
 
 pub mod address;
 pub mod ast;
+pub mod block_header;
 pub mod box_coll;
 pub mod box_selector;
 pub mod context_extension;
@@ -24,6 +25,7 @@ pub mod data_input;
 pub mod ergo_box;
 pub mod ergo_state_ctx;
 pub mod ergo_tree;
+pub mod header;
 pub mod input;
 pub mod prover_result;
 pub mod secret_key;

--- a/bindings/ergo-lib-wasm/src/token.rs
+++ b/bindings/ergo-lib-wasm/src/token.rs
@@ -23,7 +23,7 @@ impl TokenId {
         TokenId(chain::token::TokenId::from(box_id))
     }
 
-    /// Parse token id (32 byte digets) from base16-encoded string
+    /// Parse token id (32 byte digest) from base16-encoded string
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(str: &str) -> Result<TokenId, JsValue> {
         Base16DecodedBytes::try_from(str.to_string())
@@ -31,13 +31,13 @@ impl TokenId {
             .and_then(|bytes| {
                 Digest32::try_from(bytes).map_err(|e| JsValue::from_str(&format!("{}", e)))
             })
-            .map(chain::token::TokenId)
+            .map(|dig| dig.into())
             .map(TokenId)
     }
 
     /// Base16 encoded string
     pub fn to_str(&self) -> String {
-        self.0 .0.clone().into()
+        self.0.clone().into()
     }
 }
 

--- a/bindings/ergo-lib-wasm/tests/index.js
+++ b/bindings/ergo-lib-wasm/tests/index.js
@@ -1,2 +1,0 @@
-// eslint-disable-next-line no-unused-vars
-import test_transaction from './test_transaction';

--- a/bindings/ergo-lib-wasm/tests/test_data_input.js
+++ b/bindings/ergo-lib-wasm/tests/test_data_input.js
@@ -1,0 +1,14 @@
+import { expect, assert } from 'chai';
+
+import {
+  DataInput,
+  BoxId,
+} from '../pkg/ergo_lib_wasm';
+
+it('from str', async () => {
+  const box_id = BoxId.from_str('e56847ed19b3dc6b72828fcfb992fdf7310828cf291221269b7ffc72fd66706e');
+  assert(box_id != null);
+  const di = new DataInput(box_id);
+  assert(di != null);
+});
+

--- a/bindings/ergo-lib-wasm/tests/test_transaction.js
+++ b/bindings/ergo-lib-wasm/tests/test_transaction.js
@@ -3,8 +3,34 @@ import { expect, assert } from 'chai';
 import {
   Address, Wallet, ErgoBox, ErgoBoxCandidateBuilder, Contract,
   ErgoBoxes, ErgoBoxCandidates,
-  ErgoStateContext, TxBuilder, BoxValue, BoxSelector, I64, SecretKey, SecretKeys, TxId, DataInputs, SimpleBoxSelector, Tokens, Token, TokenAmount, TokenId
+  ErgoStateContext, TxBuilder, BoxValue, BoxSelector, I64, SecretKey, SecretKeys, TxId, DataInputs,
+  SimpleBoxSelector, Tokens, Token, TokenAmount, TokenId, BlockHeaders, PreHeader,
 } from '../pkg/ergo_lib_wasm';
+
+const block_headers = BlockHeaders.from_json([{
+      "extensionId": "d16f25b14457186df4c5f6355579cc769261ce1aebc8209949ca6feadbac5a3f",
+      "difficulty": "626412390187008",
+      "votes": "040000",
+      "timestamp": 1618929697400,
+      "size": 221,
+      "stateRoot": "8ad868627ea4f7de6e2a2fe3f98fafe57f914e0f2ef3331c006def36c697f92713",
+      "height": 471746,
+      "nBits": 117586360,
+      "version": 2,
+      "id": "4caa17e62fe66ba7bd69597afdc996ae35b1ff12e0ba90c22ff288a4de10e91b",
+      "adProofsRoot": "d882aaf42e0a95eb95fcce5c3705adf758e591532f733efe790ac3c404730c39",
+      "transactionsRoot": "63eaa9aff76a1de3d71c81e4b2d92e8d97ae572a8e9ab9e66599ed0912dd2f8b",
+      "extensionHash": "3f91f3c680beb26615fdec251aee3f81aaf5a02740806c167c0f3c929471df44",
+      "powSolutions": {
+        "pk": "02b3a06d6eaa8671431ba1db4dd427a77f75a5c2acbd71bfb725d38adc2b55f669",
+        "w": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "n": "5939ecfee6b0d7f4",
+        "d": 0
+      },
+      "adProofsId": "86eaa41f328bee598e33e52c9e515952ad3b7874102f762847f17318a776a7ae",
+      "transactionsId": "ac80245714f25aa2fafe5494ad02a26d46e7955b8f5709f3659f1b9440797b3e",
+      "parentId": "6481752bace5fa5acba5d5ef7124d48826664742d46c974c98a2d60ace229a34"
+}]);
 
 it('TxBuilder test', async () => {
   const recipient = Address.from_testnet_str('3WvsT2Gm4EpsM9Pg18PdY6XyhNNMqXDsvJTbbf6ihLvAmSb7u5RN');
@@ -58,13 +84,12 @@ it('sign transaction', async () => {
   const tx_builder = TxBuilder.new(box_selection, tx_outputs, 0, fee, change_address, min_change_value);
   const tx = tx_builder.build();
   const tx_data_inputs = ErgoBoxes.from_boxes_json([]);
-  const dummy_ctx = ErgoStateContext.dummy();
-  
+  const pre_header = PreHeader.from_block_header(block_headers.get(0));
+  const ctx = new ErgoStateContext(pre_header);
   const sks = new SecretKeys();
   sks.add(sk);
-
   const wallet = Wallet.from_secrets(sks);
-  const signed_tx = wallet.sign_transaction(dummy_ctx, tx, unspent_boxes, tx_data_inputs);
+  const signed_tx = wallet.sign_transaction(ctx, tx, unspent_boxes, tx_data_inputs);
   assert(signed_tx != null);
 });
 

--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Implement GetVar [#236](https://github.com/ergoplatform/sigma-rust/pull/236)
 - Implement Atleast IR node (serialization) [#237](https://github.com/ergoplatform/sigma-rust/pull/237)
 - Implementation of Deserialize{Context,Register} (serialization) [#239](https://github.com/ergoplatform/sigma-rust/pull/239)
+- WASM: fix DataInput construction, ErgoStateContext construction from parsed JSON block headers [#238](https://github.com/ergoplatform/sigma-rust/pull/238) 
 
 ### Changed 
 - Explicitly handle errors in SMethod::from_ids & and PropertyCall deserialization [#231](https://github.com/ergoplatform/sigma-rust/pull/231);

--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+### Added 
+- Add MinerPubKey and Global as global variables [#232](https://github.com/ergoplatform/sigma-rust/pull/232);
+- Implement parser and evaluator for DH tuple [#233](https://github.com/ergoplatform/sigma-rust/pull/233);
+- Add method descriptions for SContext (serialization) [#235](https://github.com/ergoplatform/sigma-rust/pull/235)
+- Implement GetVar [#236](https://github.com/ergoplatform/sigma-rust/pull/236)
+- Implement Atleast IR node (serialization) [#237](https://github.com/ergoplatform/sigma-rust/pull/237)
+- Implementation of Deserialize{Context,Register} (serialization) [#239](https://github.com/ergoplatform/sigma-rust/pull/239)
+
+### Changed 
+- Explicitly handle errors in SMethod::from_ids & and PropertyCall deserialization [#231](https://github.com/ergoplatform/sigma-rust/pull/231);
+- Fix flatmap method & GET_VAR opcode [#234](https://github.com/ergoplatform/sigma-rust/pull/234);
+
 ## [0.9.0] - 2021-04-09
 
 ### Added 

--- a/ergo-lib/src/chain.rs
+++ b/ergo-lib/src/chain.rs
@@ -9,6 +9,7 @@ mod digest32;
 pub use base16_bytes::*;
 pub use digest32::*;
 
+pub mod block_header;
 pub mod contract;
 pub mod ergo_box;
 pub mod ergo_state_context;

--- a/ergo-lib/src/chain/base16_bytes.rs
+++ b/ergo-lib/src/chain/base16_bytes.rs
@@ -24,7 +24,7 @@ impl Base16EncodedBytes {
 
 /// Transitioning type for Base16 decoded bytes
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "json", serde(try_from = "String"))]
+#[cfg_attr(feature = "json", serde(try_from = "String", into = "String"))]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Base16DecodedBytes(pub Vec<u8>);
 
@@ -32,6 +32,12 @@ impl TryFrom<String> for Base16DecodedBytes {
     type Error = base16::DecodeError;
     fn try_from(str: String) -> Result<Self, Self::Error> {
         Ok(Base16DecodedBytes(base16::decode(&str)?))
+    }
+}
+
+impl From<Base16DecodedBytes> for String {
+    fn from(b: Base16DecodedBytes) -> Self {
+        base16::encode_lower(&b.0)
     }
 }
 

--- a/ergo-lib/src/chain/block_header.rs
+++ b/ergo-lib/src/chain/block_header.rs
@@ -1,0 +1,91 @@
+//! Block header
+
+use std::convert::TryFrom;
+use std::convert::TryInto;
+
+use ergotree_ir::mir::header::PreHeader;
+use ergotree_ir::sigma_protocol::dlog_group;
+#[cfg(feature = "json")]
+use serde::{Deserialize, Serialize};
+
+use super::Base16DecodedBytes;
+use super::Base16EncodedBytes;
+use super::Digest32;
+use thiserror::Error;
+
+/// Block id
+#[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct BlockId(Digest32);
+
+/// Votes for changing system parameters
+#[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "json",
+    serde(into = "Base16EncodedBytes", try_from = "Base16DecodedBytes")
+)]
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct Votes(pub Box<[u8; 3]>);
+
+/// Votes errors
+#[derive(Error, Debug)]
+pub enum VotesError {
+    /// Invalid byte array size
+    #[error("Votes: Invalid byte array size ({0})")]
+    InvalidSize(#[from] std::array::TryFromSliceError),
+}
+
+impl TryFrom<Base16DecodedBytes> for Votes {
+    type Error = VotesError;
+
+    fn try_from(bytes: Base16DecodedBytes) -> Result<Self, Self::Error> {
+        let arr: [u8; 3] = bytes.0.as_slice().try_into()?;
+        Ok(Self(Box::new(arr)))
+    }
+}
+
+impl From<Votes> for Base16EncodedBytes {
+    fn from(v: Votes) -> Self {
+        Base16EncodedBytes::new(v.0.as_ref())
+    }
+}
+
+impl From<Votes> for Vec<u8> {
+    fn from(v: Votes) -> Self {
+        v.0.to_vec()
+    }
+}
+
+/// Block header
+#[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct BlockHeader {
+    /// Block version, to be increased on every soft and hardfork
+    pub version: u8,
+    /// Id of a parent block
+    #[cfg_attr(feature = "json", serde(rename = "parentId"))]
+    pub parent_id: BlockId,
+    /// Timestamp of a block in ms from UNIX epoch
+    pub timestamp: u64,
+    /// Current difficulty in a compressed view.
+    #[cfg_attr(feature = "json", serde(rename = "nBits"))]
+    pub n_bits: u64,
+    /// Block height
+    pub height: i32,
+    /// Votes
+    pub votes: Votes,
+}
+
+impl From<BlockHeader> for PreHeader {
+    fn from(bh: BlockHeader) -> Self {
+        PreHeader {
+            version: bh.version,
+            parent_id: bh.parent_id.0.into(),
+            timestamp: bh.timestamp,
+            n_bits: bh.n_bits,
+            height: bh.height,
+            miner_pk: dlog_group::identity().into(), // TODO: get from bh.powSolution when its implemented
+            votes: bh.votes.into(),
+        }
+    }
+}

--- a/ergo-lib/src/chain/block_header.rs
+++ b/ergo-lib/src/chain/block_header.rs
@@ -71,7 +71,7 @@ pub struct BlockHeader {
     #[cfg_attr(feature = "json", serde(rename = "nBits"))]
     pub n_bits: u64,
     /// Block height
-    pub height: i32,
+    pub height: u32,
     /// Votes
     pub votes: Votes,
 }

--- a/ergo-lib/src/chain/digest32.rs
+++ b/ergo-lib/src/chain/digest32.rs
@@ -56,6 +56,12 @@ impl From<Digest32> for Vec<i8> {
     }
 }
 
+impl From<Digest32> for Vec<u8> {
+    fn from(v: Digest32) -> Self {
+        v.0.to_vec()
+    }
+}
+
 impl From<Digest32> for [u8; Digest32::SIZE] {
     fn from(v: Digest32) -> Self {
         *v.0

--- a/ergo-lib/src/chain/ergo_box.rs
+++ b/ergo-lib/src/chain/ergo_box.rs
@@ -149,7 +149,7 @@ impl ErgoBox {
 
     fn calc_box_id(&self) -> BoxId {
         let bytes = self.sigma_serialize_bytes();
-        BoxId(blake2b256_hash(&bytes))
+        blake2b256_hash(&bytes).into()
     }
 
     /// Get register value

--- a/ergo-lib/src/chain/json.rs
+++ b/ergo-lib/src/chain/json.rs
@@ -260,6 +260,7 @@ pub enum ProofBytesSerde {
 
 #[cfg(test)]
 mod tests {
+    use crate::chain::block_header::BlockHeader;
     use crate::chain::transaction::unsigned::UnsignedTransaction;
     use std::convert::TryInto;
 
@@ -477,5 +478,35 @@ mod tests {
                                                                                                                                            "#;
         let regs: NonMandatoryRegisters = serde_json::from_str(json).unwrap();
         assert!(regs.get(NonMandatoryRegisterId::R4).is_some());
+    }
+
+    #[test]
+    fn parse_block_header() {
+        let json = r#"{
+            "extensionId": "d16f25b14457186df4c5f6355579cc769261ce1aebc8209949ca6feadbac5a3f",
+            "difficulty": "626412390187008",
+            "votes": "040000",
+            "timestamp": 1618929697400,
+            "size": 221,
+            "stateRoot": "8ad868627ea4f7de6e2a2fe3f98fafe57f914e0f2ef3331c006def36c697f92713",
+            "height": 471746,
+            "nBits": 117586360,
+            "version": 2,
+            "id": "4caa17e62fe66ba7bd69597afdc996ae35b1ff12e0ba90c22ff288a4de10e91b",
+            "adProofsRoot": "d882aaf42e0a95eb95fcce5c3705adf758e591532f733efe790ac3c404730c39",
+            "transactionsRoot": "63eaa9aff76a1de3d71c81e4b2d92e8d97ae572a8e9ab9e66599ed0912dd2f8b",
+            "extensionHash": "3f91f3c680beb26615fdec251aee3f81aaf5a02740806c167c0f3c929471df44",
+            "powSolutions": {
+              "pk": "02b3a06d6eaa8671431ba1db4dd427a77f75a5c2acbd71bfb725d38adc2b55f669",
+              "w": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+              "n": "5939ecfee6b0d7f4",
+              "d": 0
+            },
+            "adProofsId": "86eaa41f328bee598e33e52c9e515952ad3b7874102f762847f17318a776a7ae",
+            "transactionsId": "ac80245714f25aa2fafe5494ad02a26d46e7955b8f5709f3659f1b9440797b3e",
+            "parentId": "6481752bace5fa5acba5d5ef7124d48826664742d46c974c98a2d60ace229a34"
+        }"#;
+        let b: BlockHeader = serde_json::from_str(json).unwrap();
+        assert_eq!(b.height, 471746);
     }
 }

--- a/ergo-lib/src/chain/token.rs
+++ b/ergo-lib/src/chain/token.rs
@@ -9,6 +9,8 @@ use std::io;
 
 use super::digest32::Digest32;
 use super::ergo_box::BoxId;
+use derive_more::From;
+use derive_more::Into;
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 #[cfg(feature = "json")]
@@ -16,28 +18,28 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// newtype for token id
-#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone, From, Into)]
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
-pub struct TokenId(pub Digest32);
+pub struct TokenId(Digest32);
 
 impl TokenId {
     /// token id size in bytes
     pub const SIZE: usize = Digest32::SIZE;
 }
 
-impl From<Digest32> for TokenId {
-    fn from(d: Digest32) -> Self {
-        TokenId(d)
-    }
-}
-
 impl From<BoxId> for TokenId {
     fn from(i: BoxId) -> Self {
-        TokenId(i.0)
+        TokenId(i.into())
     }
 }
 
 impl From<TokenId> for Vec<i8> {
+    fn from(v: TokenId) -> Self {
+        v.0.into()
+    }
+}
+
+impl From<TokenId> for String {
     fn from(v: TokenId) -> Self {
         v.0.into()
     }

--- a/ergotree-interpreter/src/eval/context.rs
+++ b/ergotree-interpreter/src/eval/context.rs
@@ -12,7 +12,7 @@ pub struct Context {
     /// Arena with all boxes (from self, inputs, outputs, data_inputs)
     pub box_arena: Rc<dyn IrErgoBoxArena>,
     /// Current height
-    pub height: i32,
+    pub height: u32,
     /// Box that contains the script we're evaluating (from spending transaction inputs)
     pub self_box: IrBoxId,
     /// Spending transaction outputs
@@ -40,7 +40,7 @@ mod arbitrary {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             (
-                0..i32::MAX,
+                0..i32::MAX as u32,
                 any::<IrErgoBoxDummy>(),
                 vec(any::<IrErgoBoxDummy>(), 1..3),
                 vec(any::<IrErgoBoxDummy>(), 1..3),

--- a/ergotree-interpreter/src/eval/global_vars.rs
+++ b/ergotree-interpreter/src/eval/global_vars.rs
@@ -9,7 +9,7 @@ use super::Evaluable;
 impl Evaluable for GlobalVars {
     fn eval(&self, _env: &Env, ectx: &mut EvalContext) -> Result<Value, EvalError> {
         match self {
-            GlobalVars::Height => Ok(ectx.ctx.height.clone().into()),
+            GlobalVars::Height => Ok((ectx.ctx.height as i32).into()),
             GlobalVars::SelfBox => Ok(ectx.ctx.self_box.clone().into()),
             GlobalVars::Outputs => Ok(ectx.ctx.outputs.clone().into()),
             GlobalVars::Inputs => Ok(ectx.ctx.inputs.clone().into()),
@@ -35,7 +35,7 @@ mod tests {
     fn eval_height() {
         let ctx = Rc::new(force_any_val::<Context>());
         let expr = compile_expr("HEIGHT", ScriptEnv::new()).unwrap();
-        assert_eq!(eval_out::<i32>(&expr, ctx.clone()), ctx.height);
+        assert_eq!(eval_out::<i32>(&expr, ctx.clone()), ctx.height as i32);
     }
 
     #[test]

--- a/ergotree-ir/README.md
+++ b/ergotree-ir/README.md
@@ -56,7 +56,7 @@ Descriptions for the operations can be found in [ErgoTree Specification](https:/
 - :heavy_check_mark: blake2b256
 - sha256
 - :heavy_check_mark: proveDlog
-- proveDHTuple
+- :heavy_check_mark: proveDHTuple
 - :heavy_check_mark: sigmaProp
 - executeFromVar
 - executeFromSelfReg
@@ -151,8 +151,8 @@ Descriptions for the operations can be found in [ErgoTree Specification](https:/
 - :heavy_check_mark: SELF
 - selfBoxIndex
 - LastBlockUtxoRootHash
-- minerPubKey
-- getVar
+- :heavy_check_mark: minerPubKey
+- :heavy_check_mark: getVar
 
 #### Collection
 

--- a/ergotree-ir/src/mir/header.rs
+++ b/ergotree-ir/src/mir/header.rs
@@ -13,7 +13,7 @@ pub struct PreHeader {
     /// Current difficulty in a compressed view.
     pub n_bits: u64,
     /// Block height
-    pub height: i32,
+    pub height: u32,
     /// Public key of miner
     pub miner_pk: Box<dlog_group::EcPoint>,
     /// Votes
@@ -52,7 +52,7 @@ mod arbitrary {
                 // Timestamps between 2000-2050
                 946_674_000_000..2_500_400_300_000u64,
                 any::<u64>(),
-                0..1_000_000,
+                0..1_000_000u32,
                 any::<Box<EcPoint>>(),
             )
                 .prop_map(|(parent_id, timestamp, n_bits, height, miner_pk)| Self {


### PR DESCRIPTION
`DataInput` can be created from `BoxId` which is parsed from Base16-encoded string. See example - https://github.com/ergoplatform/sigma-rust/blob/3129c628ad8fc98276d47a55ca26279ce1a0512d/bindings/ergo-lib-wasm/tests/test_data_input.js#L8-L13

`ErgoStateContext` can be created from `PreHeader` which is created from `BlockHeader` which in turn can be parsed from JSON (multiple headers can be parsed with `BlockHeaders.from_json()`). See example - 

https://github.com/ergoplatform/sigma-rust/blob/3129c628ad8fc98276d47a55ca26279ce1a0512d/bindings/ergo-lib-wasm/tests/test_transaction.js#L10-L33

https://github.com/ergoplatform/sigma-rust/blob/3129c628ad8fc98276d47a55ca26279ce1a0512d/bindings/ergo-lib-wasm/tests/test_transaction.js#L87-L88
