### PR TITLE
Use LSB bitvector instead of MSB

### DIFF
--- a/ergotree-ir/src/mir/bin_op.rs
+++ b/ergotree-ir/src/mir/bin_op.rs
@@ -201,7 +201,11 @@ mod arbitrary {
 mod tests {
 
     use super::*;
+    use crate::mir::constant::Constant;
+    use crate::mir::expr::Expr;
+    use crate::mir::value::Value::Boolean;
     use crate::serialization::sigma_serialize_roundtrip;
+    use crate::serialization::SigmaSerializable;
     use proptest::prelude::*;
 
     proptest! {
@@ -212,5 +216,27 @@ mod tests {
             prop_assert_eq![sigma_serialize_roundtrip(&expr), expr];
         }
 
+    }
+
+    // Test that binop with boolean literals serialized correctly
+    #[test]
+    fn regression_249() {
+        let e = Expr::sigma_parse_bytes(vec![0xed, 0x85, 0x03]);
+        assert_eq!(
+            e,
+            Ok(Expr::BinOp(BinOp {
+                kind: BinOpKind::Relation(RelationOp::And,),
+                left: Expr::Const(Constant {
+                    tpe: SType::SBoolean,
+                    v: Boolean(true),
+                })
+                .into(),
+                right: Expr::Const(Constant {
+                    tpe: SType::SBoolean,
+                    v: Boolean(true),
+                })
+                .into(),
+            }))
+        );
     }
 }

--- a/sigma-ser/Cargo.toml
+++ b/sigma-ser/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # wasm-bindgen = "0.2"
 thiserror = "1"
-bit-vec = "0.6.3"
+bitvec = "0.22.3"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
sigma_ser::vlq_encode::...::{put,get}_bits should use LSB bit vectors.
Fix required switch from bit-vec to bitvec which supports LSB vectors.

Fixes #249, regression test added