### PR TITLE
sigma_parse_bytes does not need mutable vector as parameter

### DIFF
--- a/bindings/ergo-lib-wasm/src/address.rs
+++ b/bindings/ergo-lib-wasm/src/address.rs
@@ -200,7 +200,7 @@ impl Address {
 
     /// Create an address from a public key
     pub fn from_public_key(bytes: &[u8]) -> Result<Address, JsValue> {
-        EcPoint::sigma_parse_bytes(bytes.to_vec())
+        EcPoint::sigma_parse_bytes(bytes)
             .map(|point| ergo_lib::ergotree_ir::address::Address::P2Pk(ProveDlog::new(point)))
             .map(Address)
             .map_err(|e| JsValue::from_str(&format!("{}", e)))

--- a/bindings/ergo-lib-wasm/src/ergo_tree.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_tree.rs
@@ -25,7 +25,7 @@ impl ErgoTree {
 
     /// Decode from encoded serialized ErgoTree
     pub fn from_bytes(data: Vec<u8>) -> Result<ErgoTree, JsValue> {
-        ergo_lib::ergotree_ir::ergo_tree::ErgoTree::sigma_parse_bytes(data)
+        ergo_lib::ergotree_ir::ergo_tree::ErgoTree::sigma_parse_bytes(&data)
             .map(ErgoTree)
             .map_err(|e| JsValue::from_str(&format!("{}", e)))
     }

--- a/ergo-lib/src/chain/base16_bytes.rs
+++ b/ergo-lib/src/chain/base16_bytes.rs
@@ -64,7 +64,7 @@ impl TryFrom<Base16DecodedBytes> for Constant {
     type Error = SerializationError;
 
     fn try_from(value: Base16DecodedBytes) -> Result<Self, Self::Error> {
-        Constant::sigma_parse_bytes(value.0)
+        Constant::sigma_parse_bytes(&value.0)
     }
 }
 

--- a/ergo-lib/src/chain/json.rs
+++ b/ergo-lib/src/chain/json.rs
@@ -39,7 +39,8 @@ pub mod ergo_tree {
         String::deserialize(deserializer)
             .and_then(|str| base16::decode(&str).map_err(|err| Error::custom(err.to_string())))
             .and_then(|bytes| {
-                ErgoTree::sigma_parse_bytes(bytes).map_err(|error| Error::custom(error.to_string()))
+                ErgoTree::sigma_parse_bytes(&bytes)
+                    .map_err(|error| Error::custom(error.to_string()))
             })
     }
 }
@@ -129,8 +130,8 @@ pub mod ergo_box {
     impl TryFrom<Base16DecodedBytes> for ConstantWrapper {
         type Error = ConstantParsingError;
 
-        fn try_from(bytes: Base16DecodedBytes) -> Result<Self, Self::Error> {
-            let c = Constant::sigma_parse_bytes(bytes.into())?;
+        fn try_from(Base16DecodedBytes(bytes): Base16DecodedBytes) -> Result<Self, Self::Error> {
+            let c = Constant::sigma_parse_bytes(&bytes)?;
             Ok(ConstantWrapper(c))
         }
     }
@@ -138,8 +139,8 @@ pub mod ergo_box {
     impl FromStr for RichConstant {
         type Err = ConstantParsingError;
         fn from_str(s: &str) -> Result<Self, Self::Err> {
-            let bytes = Base16DecodedBytes::try_from(s)?;
-            let c = Constant::sigma_parse_bytes(bytes.into())?;
+            let Base16DecodedBytes(bytes) = Base16DecodedBytes::try_from(s)?;
+            let c = Constant::sigma_parse_bytes(&bytes)?;
             Ok(RichConstant {
                 raw_value: ConstantWrapper(c),
             })

--- a/ergotree-interpreter/src/eval/decode_point.rs
+++ b/ergotree-interpreter/src/eval/decode_point.rs
@@ -13,7 +13,7 @@ use ergotree_ir::sigma_protocol::dlog_group::EcPoint;
 impl Evaluable for DecodePoint {
     fn eval(&self, env: &Env, ctx: &mut EvalContext) -> Result<Value, EvalError> {
         let point_bytes = self.input.eval(env, ctx)?.try_extract_into::<Vec<u8>>()?;
-        let point: EcPoint = SigmaSerializable::sigma_parse_bytes(point_bytes).map_err(|_| {
+        let point: EcPoint = SigmaSerializable::sigma_parse_bytes(&point_bytes).map_err(|_| {
             Misc(String::from(
                 "DecodePoint: Failed to parse EC point from bytes",
             ))

--- a/ergotree-interpreter/src/sigma_protocol/prover/context_extension.rs
+++ b/ergotree-interpreter/src/sigma_protocol/prover/context_extension.rs
@@ -90,7 +90,7 @@ impl TryFrom<HashMap<String, String>> for ContextExtension {
                 })?;
                 acc.insert(
                     idx,
-                    Constant::sigma_parse_bytes(constant_bytes).map_err(|_| {
+                    Constant::sigma_parse_bytes(&constant_bytes).map_err(|_| {
                         ConstantParsingError(format!(
                             "cannot deserialize constant bytes from {0:?}",
                             pair.1

--- a/ergotree-ir/src/address.rs
+++ b/ergotree-ir/src/address.rs
@@ -71,7 +71,7 @@ pub enum Address {
 impl Address {
     /// Create a P2PK address from serialized PK bytes(EcPoint/GroupElement)
     pub fn p2pk_from_pk_bytes(bytes: &[u8]) -> Result<Address, SerializationError> {
-        EcPoint::sigma_parse_bytes(bytes.to_vec())
+        EcPoint::sigma_parse_bytes(bytes)
             .map(ProveDlog::from)
             .map(Address::P2Pk)
     }
@@ -122,7 +122,7 @@ impl Address {
                 ))
                 .into(),
             ))),
-            Address::P2S(bytes) => ErgoTree::sigma_parse_bytes(bytes.to_vec()),
+            Address::P2S(bytes) => ErgoTree::sigma_parse_bytes(bytes),
         }
     }
 }
@@ -362,7 +362,7 @@ impl AddressEncoder {
         let address_type = AddressTypePrefix::try_from(bytes[0] & 0xF_u8)?;
         Ok(match address_type {
             AddressTypePrefix::P2Pk => {
-                Address::P2Pk(ProveDlog::new(EcPoint::sigma_parse_bytes(content_bytes)?))
+                Address::P2Pk(ProveDlog::new(EcPoint::sigma_parse_bytes(&content_bytes)?))
             }
             AddressTypePrefix::Pay2S => Address::P2S(content_bytes),
             AddressTypePrefix::Pay2Sh => todo!(),

--- a/ergotree-ir/src/ergo_tree.rs
+++ b/ergotree-ir/src/ergo_tree.rs
@@ -228,8 +228,8 @@ impl SigmaSerializable for ErgoTree {
         })
     }
 
-    fn sigma_parse_bytes(mut bytes: Vec<u8>) -> Result<Self, SerializationError> {
-        let cursor = Cursor::new(&mut bytes[..]);
+    fn sigma_parse_bytes(bytes: &[u8]) -> Result<Self, SerializationError> {
+        let cursor = Cursor::new(bytes);
         let mut r = SigmaByteReader::new(PeekableReader::new(cursor), ConstantStore::empty());
         let header = ErgoTreeHeader::sigma_parse(&mut r)?;
         let constants = if header.is_constant_segregation() {
@@ -350,7 +350,7 @@ mod tests {
     #[test]
     fn deserialization_non_parseable_tree_ok() {
         // constants length is set, invalid constant
-        assert!(ErgoTree::sigma_parse_bytes(vec![
+        assert!(ErgoTree::sigma_parse_bytes(&vec![
             ErgoTreeHeader::CONSTANT_SEGREGATION_FLAG,
             1,
             0,
@@ -363,7 +363,7 @@ mod tests {
     #[test]
     fn deserialization_non_parseable_root_ok() {
         // no constant segregation, Expr is invalid
-        assert!(ErgoTree::sigma_parse_bytes(vec![0, 0, 1]).is_ok());
+        assert!(ErgoTree::sigma_parse_bytes(&vec![0, 0, 1]).is_ok());
     }
 
     #[test]
@@ -384,7 +384,7 @@ mod tests {
         });
         let ergo_tree = ErgoTree::with_segregation(&expr);
         let bytes = ergo_tree.sigma_serialize_bytes();
-        let parsed_expr = ErgoTree::sigma_parse_bytes(bytes)
+        let parsed_expr = ErgoTree::sigma_parse_bytes(&bytes)
             .unwrap()
             .proposition()
             .unwrap();

--- a/ergotree-ir/src/mir/bin_op.rs
+++ b/ergotree-ir/src/mir/bin_op.rs
@@ -223,7 +223,7 @@ mod tests {
     // Test that binop with boolean literals serialized correctly
     #[test]
     fn regression_249() {
-        let e = Expr::sigma_parse_bytes(vec![0xed, 0x85, 0x03]);
+        let e = Expr::sigma_parse_bytes(&vec![0xed, 0x85, 0x03]);
         assert_eq!(
             e,
             Ok(Expr::BinOp(BinOp {

--- a/ergotree-ir/src/serialization/serializable.rs
+++ b/ergotree-ir/src/serialization/serializable.rs
@@ -124,8 +124,8 @@ pub trait SigmaSerializable: Sized {
     }
 
     /// Parse `self` from the bytes
-    fn sigma_parse_bytes(mut bytes: Vec<u8>) -> Result<Self, SerializationError> {
-        let cursor = Cursor::new(&mut bytes[..]);
+    fn sigma_parse_bytes(bytes: &[u8]) -> Result<Self, SerializationError> {
+        let cursor = Cursor::new(bytes);
         let pr = PeekableReader::new(cursor);
         let mut sr = SigmaByteReader::new(pr, ConstantStore::empty());
         Self::sigma_parse(&mut sr)


### PR DESCRIPTION
And could work quite happily with just &[u8]. This allowed to remove few
conversions but mostly amounted to just slapping & everywhere.