### PR TITLE
Remove dbg! calls

### DIFF
--- a/ergo-lib/src/chain/json.rs
+++ b/ergo-lib/src/chain/json.rs
@@ -283,7 +283,6 @@ mod tests {
         #[test]
         fn tx_roundtrip(t in any::<Transaction>()) {
             let j = serde_json::to_string(&t)?;
-            // dbg!(j);
             eprintln!("{}", j);
             let t_parsed: Transaction = serde_json::from_str(&j)?;
             prop_assert_eq![t, t_parsed];
@@ -292,7 +291,6 @@ mod tests {
         #[test]
         fn unsigned_tx_roundtrip(t in any::<UnsignedTransaction>()) {
             let j = serde_json::to_string(&t)?;
-            // dbg!(j);
             eprintln!("{}", j);
             let t_parsed: UnsignedTransaction = serde_json::from_str(&j)?;
             prop_assert_eq![t, t_parsed];

--- a/ergoscript-compiler/src/compiler.rs
+++ b/ergoscript-compiler/src/compiler.rs
@@ -56,11 +56,9 @@ pub fn compile_expr(
     env: ScriptEnv,
 ) -> Result<ergotree_ir::mir::expr::Expr, CompileError> {
     let hir = compile_hir(source)?;
-    dbg!(&hir);
     let binder = Binder::new(env);
     let bind = binder.bind(hir)?;
     let typed = assign_type(bind)?;
-    dbg!(typed.debug_tree());
     let mir = mir::lower::lower(typed)?;
     let res = ergotree_ir::type_check::type_check(mir)?;
     Ok(res)
@@ -74,12 +72,10 @@ pub fn compile(source: &str, env: ScriptEnv) -> Result<ErgoTree, CompileError> {
 
 pub(crate) fn compile_hir(source: &str) -> Result<hir::Expr, CompileError> {
     let parse = super::parser::parse(&source);
-    dbg!(parse.debug_tree());
     if !parse.errors.is_empty() {
         return Err(CompileError::ParseError(parse.errors));
     }
     let syntax = parse.syntax();
-    dbg!(&syntax);
     let root = ast::Root::cast(syntax).unwrap();
     let hir = hir::lower(root)?;
     Ok(hir)

--- a/ergoscript-compiler/src/error.rs
+++ b/ergoscript-compiler/src/error.rs
@@ -2,10 +2,8 @@ use line_col::LineColLookup;
 use rowan::TextRange;
 
 pub fn pretty_error_desc(source: &str, span: TextRange, error_msg: &str) -> String {
-    dbg!(&span);
     let line_col_lookup = LineColLookup::new(source);
     let start_zero_based: usize = usize::from(span.start()) - 1;
-    dbg!(&start_zero_based);
     let end_zero_based: usize = usize::from(span.end()) - 1;
     let (line_start, col_start) = line_col_lookup.get(start_zero_based);
     let (line_end, col_end) = line_col_lookup.get(end_zero_based);

--- a/ergoscript-compiler/src/hir.rs
+++ b/ergoscript-compiler/src/hir.rs
@@ -93,6 +93,7 @@ impl Expr {
         }
     }
 
+    #[cfg(test)]
     pub fn debug_tree(&self) -> String {
         let tree = format!("{:#?}", self);
         tree

--- a/ergotree-ir/src/mir/block.rs
+++ b/ergotree-ir/src/mir/block.rs
@@ -45,7 +45,6 @@ impl SigmaSerializable for BlockValue {
 
     fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, SerializationError> {
         let items = Vec::<Expr>::sigma_parse(r)?;
-        dbg!(&items);
         let result = Expr::sigma_parse(r)?;
         Ok(BlockValue {
             items,

--- a/ergotree-ir/src/mir/collection.rs
+++ b/ergotree-ir/src/mir/collection.rs
@@ -150,14 +150,12 @@ mod tests {
 
         #[test]
         fn ser_roundtrip(v in any::<Collection>()) {
-            dbg!(&v);
             let expr: Expr = v.into();
             prop_assert_eq![sigma_serialize_roundtrip(&expr), expr];
         }
 
         #[test]
         fn ser_roundtrip_bool_const(v in any_with::<Collection>(ArbExprParams{tpe: SType::SBoolean, depth: 0})) {
-            dbg!(&v);
             let expr: Expr = v.into();
             prop_assert_eq![sigma_serialize_roundtrip(&expr), expr];
         }

--- a/ergotree-ir/src/mir/func_value.rs
+++ b/ergotree-ir/src/mir/func_value.rs
@@ -93,7 +93,6 @@ impl SigmaSerializable for FuncValue {
         let args = Vec::<FuncArg>::sigma_parse(r)?;
         args.iter()
             .for_each(|a| r.val_def_type_store().insert(a.idx, a.tpe.clone()));
-        dbg!(&args);
         let body = Expr::sigma_parse(r)?;
         Ok(FuncValue::new(args, body))
     }

--- a/ergotree-ir/src/mir/tuple.rs
+++ b/ergotree-ir/src/mir/tuple.rs
@@ -94,7 +94,6 @@ mod tests {
 
         #[test]
         fn ser_roundtrip(v in any::<Tuple>()) {
-            dbg!(&v);
             let expr: Expr = v.into();
             prop_assert_eq![sigma_serialize_roundtrip(&expr), expr];
         }

--- a/ergotree-ir/src/mir/val_def.rs
+++ b/ergotree-ir/src/mir/val_def.rs
@@ -66,7 +66,6 @@ impl SigmaSerializable for ValDef {
         let id = ValId::sigma_parse(r)?;
         let rhs = Expr::sigma_parse(r)?;
         r.val_def_type_store().insert(id, rhs.tpe());
-        dbg!(&id, &rhs);
         Ok(ValDef {
             id,
             rhs: Box::new(rhs),

--- a/ergotree-ir/src/serialization/constant.rs
+++ b/ergotree-ir/src/serialization/constant.rs
@@ -33,7 +33,6 @@ mod tests {
 
         #[test]
         fn ser_roundtrip(v in any_with::<Constant>(ArbConstantParams::AnyWithDepth(4))) {
-            dbg!(&v);
             prop_assert_eq![sigma_serialize_roundtrip(&v), v];
         }
     }

--- a/ergotree-ir/src/serialization/expr.rs
+++ b/ergotree-ir/src/serialization/expr.rs
@@ -149,7 +149,6 @@ impl SigmaSerializable for Expr {
             Ok(Expr::Const(constant))
         } else {
             let op_code = OpCode::sigma_parse(r)?;
-            dbg!(&op_code.shift());
             match op_code {
                 OpCode::FOLD => Ok(Fold::sigma_parse(r)?.into()),
                 ConstantPlaceholder::OP_CODE => {
@@ -237,7 +236,6 @@ impl SigmaSerializable for Expr {
                 ))),
             }
         };
-        dbg!(&res);
         res
     }
 }
@@ -257,7 +255,6 @@ mod tests {
 
         #[test]
         fn ser_roundtrip(v in any::<Expr>()) {
-            dbg!(&v);
             prop_assert_eq![sigma_serialize_roundtrip(&v), v];
         }
     }

--- a/ergotree-ir/src/serialization/types.rs
+++ b/ergotree-ir/src/serialization/types.rs
@@ -376,7 +376,6 @@ mod tests {
 
         #[test]
         fn ser_roundtrip(v in any::<SType>()) {
-            dbg!(&v);
             prop_assert_eq![sigma_serialize_roundtrip(&v), v];
         }
     }

--- a/ergotree-ir/src/serialization/val_def_type_store.rs
+++ b/ergotree-ir/src/serialization/val_def_type_store.rs
@@ -12,7 +12,6 @@ impl ValDefTypeStore {
 
     pub fn insert(&mut self, id: ValId, tpe: SType) {
         self.0.insert(id, tpe);
-        dbg!(&self.0);
     }
 
     pub fn get(&self, id: &ValId) -> Option<&SType> {


### PR DESCRIPTION
Attempt to parse blockchain data result in torrent in debug print. 

This PR simply removes all `dbg!` calls. debug_tree must be defined only for test build since otherwise it trips
dead_code lint:
    
> error: associated function is never used: `debug_tree`

Fixes #258