### PR TITLE
Add SigmaSerializable for Box<T>

### DIFF
--- a/ergotree-ir/src/serialization/serializable.rs
+++ b/ergotree-ir/src/serialization/serializable.rs
@@ -148,7 +148,17 @@ impl<T: SigmaSerializable> SigmaSerializable for Vec<T> {
     }
 }
 
-impl<T: SigmaSerializable> SigmaSerializable for Option<Box<T>> {
+impl<T: SigmaSerializable> SigmaSerializable for Box<T> {
+    fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> Result<(), io::Error> {
+        let x: &T = self;
+        x.sigma_serialize(w)
+    }
+    fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, SerializationError> {
+        Ok(Box::new(T::sigma_parse(r)? ))
+    }
+}
+
+impl<T: SigmaSerializable> SigmaSerializable for Option<T> {
     fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> Result<(), io::Error> {
         match self {
             Some(v) => {


### PR DESCRIPTION
Reasoning is simple: `Box` is just wrapper type which changes its memory layout, so in serialization code it could be just ignored. This allows to write more generic implementation for `Option<T>` instead if `Option<Box<T>>`. As small bonus this allows write parsing code in style:

```rust
   let field = <_>::sigma_parse(r)?;
```
And let type inference to do its work