### PR TITLE
Remove Peekable constraint from ReadSigmaVlqExt

### DIFF
--- a/ergotree-ir/src/serialization/sigma_byte_reader.rs
+++ b/ergotree-ir/src/serialization/sigma_byte_reader.rs
@@ -39,7 +39,7 @@ impl<R: Peekable> SigmaByteReader<R> {
 }
 
 /// Sigma byte reader trait with a constant store to resolve segregated constants
-pub trait SigmaByteRead: ReadSigmaVlqExt {
+pub trait SigmaByteRead: ReadSigmaVlqExt + Peekable {
     /// Constant store with constants to resolve constant placeholder types
     fn constant_store(&mut self) -> &mut ConstantStore;
 
@@ -65,7 +65,7 @@ impl<R: Peekable> Peekable for SigmaByteReader<R> {
     }
 }
 
-impl<R: ReadSigmaVlqExt> SigmaByteRead for SigmaByteReader<R> {
+impl<R: ReadSigmaVlqExt + Peekable> SigmaByteRead for SigmaByteReader<R> {
     fn constant_store(&mut self) -> &mut ConstantStore {
         &mut self.constant_store
     }

--- a/ergotree-ir/src/serialization/sigma_byte_reader.rs
+++ b/ergotree-ir/src/serialization/sigma_byte_reader.rs
@@ -53,7 +53,7 @@ pub trait SigmaByteRead: ReadSigmaVlqExt {
     fn val_def_type_store(&mut self) -> &mut ValDefTypeStore;
 }
 
-impl<R: Peekable> Read for SigmaByteReader<R> {
+impl<R: Read> Read for SigmaByteReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         self.inner.read(buf)
     }


### PR DESCRIPTION
    ReadSigmaVlqExt does not use Peekable anywhere
    
    So here we downgrade constraint from Peekable to mere Read and move Peekable to
    SigmaByteRead. It doesn't strictly need SigmaByteRead either but it's used in
    SigmaSerializable which requires it.
    
    Main motivation is parsing of network messages which use VLQ encoding quite a
    bit but does not require ability to peek. In fact only parsing of ergo script
    requires it.