### PR TITLE
Base16-based implementation of Debug for Digest32

### DIFF
--- a/ergo-lib/src/chain/block_header.rs
+++ b/ergo-lib/src/chain/block_header.rs
@@ -25,7 +25,7 @@ pub struct BlockId(Digest32);
     serde(into = "Base16EncodedBytes", try_from = "Base16DecodedBytes")
 )]
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub struct Votes(pub Box<[u8; 3]>);
+pub struct Votes(pub [u8; 3]);
 
 /// Votes errors
 #[derive(Error, Debug)]
@@ -40,7 +40,7 @@ impl TryFrom<Base16DecodedBytes> for Votes {
 
     fn try_from(bytes: Base16DecodedBytes) -> Result<Self, Self::Error> {
         let arr: [u8; 3] = bytes.0.as_slice().try_into()?;
-        Ok(Self(Box::new(arr)))
+        Ok(Self(arr))
     }
 }
 

--- a/ergo-lib/src/chain/digest32.rs
+++ b/ergo-lib/src/chain/digest32.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use sigma_ser::vlq_encode;
 use std::convert::TryFrom;
 use std::convert::TryInto;
+use std::fmt::Formatter;
 use std::io;
 use thiserror::Error;
 
@@ -19,7 +20,7 @@ use thiserror::Error;
     feature = "json",
     serde(into = "Base16EncodedBytes", try_from = "Base16DecodedBytes")
 )]
-#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct Digest32(pub Box<[u8; Digest32::SIZE]>);
 
@@ -30,6 +31,12 @@ impl Digest32 {
     /// All zeros
     pub fn zero() -> Digest32 {
         Digest32(Box::new([0u8; Digest32::SIZE]))
+    }
+}
+
+impl std::fmt::Debug for Digest32 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        base16::encode_lower(&(*self.0)).fmt(f)
     }
 }
 

--- a/ergo-lib/src/chain/token.rs
+++ b/ergo-lib/src/chain/token.rs
@@ -47,8 +47,7 @@ impl From<TokenId> for String {
 
 impl SigmaSerializable for TokenId {
     fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> Result<(), io::Error> {
-        self.0.sigma_serialize(w)?;
-        Ok(())
+        self.0.sigma_serialize(w)
     }
     fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, SerializationError> {
         Ok(Self(Digest32::sigma_parse(r)?))

--- a/ergotree-ir/src/serialization/serializable.rs
+++ b/ergotree-ir/src/serialization/serializable.rs
@@ -30,7 +30,7 @@ pub enum SerializationError {
     InvalidTypePrefix,
     /// Failed to decode VLQ
     #[error("vlq encode error: {0}")]
-    VlqEncode(vlq_encode::VlqEncodingError),
+    VlqEncode(#[from] vlq_encode::VlqEncodingError),
     /// IO fail (EOF, etc.)
     #[error("io error")]
     Io(String),
@@ -58,12 +58,6 @@ pub enum SerializationError {
     /// Unknown method ID for given type code
     #[error("No method id {0:?} found in type companion with type id {1:?} ")]
     UnknownMethodId(MethodId, TypeCode),
-}
-
-impl From<vlq_encode::VlqEncodingError> for SerializationError {
-    fn from(error: vlq_encode::VlqEncodingError) -> Self {
-        SerializationError::VlqEncode(error)
-    }
 }
 
 impl From<io::Error> for SerializationError {

--- a/ergotree-ir/src/serialization/serializable.rs
+++ b/ergotree-ir/src/serialization/serializable.rs
@@ -32,7 +32,7 @@ pub enum SerializationError {
     #[error("vlq encode error: {0}")]
     VlqEncode(#[from] vlq_encode::VlqEncodingError),
     /// IO fail (EOF, etc.)
-    #[error("io error")]
+    #[error("IO error: {0}")]
     Io(String),
     /// Misc fail
     #[error("misc error")]


### PR DESCRIPTION
This PR adds base-16 Debug instance for Digest2. It's way more useful this way since it much more compact and allows to compare it directly with block explorer data, search, etc.

It also contain few other unrelated changes

1. Use from `#from` annotation to derive From instance
2. Show error text for IO error
3. Use plain `[u8;3]` array for `Votes`. No reason to add pointer for 3-bytes array.