### PR TITLE
Start making definition of block header complete

### DIFF
--- a/ergo-lib/src/chain.rs
+++ b/ergo-lib/src/chain.rs
@@ -9,6 +9,8 @@ mod digest32;
 pub use base16_bytes::*;
 pub use digest32::*;
 
+///
+pub mod addigest;
 pub mod block_header;
 pub mod contract;
 pub mod ergo_box;

--- a/ergo-lib/src/chain/addigest.rs
+++ b/ergo-lib/src/chain/addigest.rs
@@ -1,0 +1,105 @@
+use crate::chain::{Base16DecodedBytes, Base16EncodedBytes};
+use ergotree_ir::util::AsVecI8;
+#[cfg(feature = "json")]
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+use std::convert::TryInto;
+use thiserror::Error;
+
+///
+#[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "json",
+    serde(into = "Base16EncodedBytes", try_from = "Base16DecodedBytes")
+)]
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+pub struct ADDigest(pub Box<[u8; Self::SIZE]>);
+
+impl ADDigest {
+    /// Digest size 33 bytes
+    pub const SIZE: usize = 33;
+}
+
+impl From<[u8; ADDigest::SIZE]> for ADDigest {
+    fn from(bytes: [u8; ADDigest::SIZE]) -> Self {
+        ADDigest(Box::new(bytes))
+    }
+}
+
+impl From<ADDigest> for Base16EncodedBytes {
+    fn from(v: ADDigest) -> Self {
+        Base16EncodedBytes::new(v.0.as_ref())
+    }
+}
+
+impl From<ADDigest> for Vec<i8> {
+    fn from(v: ADDigest) -> Self {
+        v.0.to_vec().as_vec_i8()
+    }
+}
+
+impl From<ADDigest> for Vec<u8> {
+    fn from(v: ADDigest) -> Self {
+        v.0.to_vec()
+    }
+}
+
+impl From<ADDigest> for [u8; ADDigest::SIZE] {
+    fn from(v: ADDigest) -> Self {
+        *(v.0)
+    }
+}
+
+impl From<ADDigest> for String {
+    fn from(v: ADDigest) -> Self {
+        let bytes: Base16EncodedBytes = v.into();
+        bytes.into()
+    }
+}
+
+impl TryFrom<Base16DecodedBytes> for ADDigest {
+    type Error = ADDigestError;
+    fn try_from(bytes: Base16DecodedBytes) -> Result<Self, Self::Error> {
+        let arr: [u8; ADDigest::SIZE] = bytes.0.as_slice().try_into()?;
+        Ok(ADDigest(Box::new(arr)))
+    }
+}
+
+impl TryFrom<String> for ADDigest {
+    type Error = ADDigestError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let bytes = Base16DecodedBytes::try_from(value)?;
+        ADDigest::try_from(bytes)
+    }
+}
+
+/// Invalid byte array size
+#[derive(Error, Debug)]
+pub enum ADDigestError {
+    /// error decoding from Base16
+    #[error("error decoding from Base16: {0}")]
+    Base16DecodingError(#[from] base16::DecodeError),
+    /// Invalid byte array size
+    #[error("Invalid byte array size ({0})")]
+    InvalidSize(#[from] std::array::TryFromSliceError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ADDigest;
+    use proptest::prelude::{Arbitrary, BoxedStrategy};
+    use proptest::{collection::vec, prelude::*};
+    use std::convert::TryInto;
+
+    impl Arbitrary for ADDigest {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            vec(any::<u8>(), Self::SIZE)
+                .prop_map(|v| ADDigest(Box::new(v.try_into().unwrap())))
+                .boxed()
+        }
+    }
+}

--- a/ergo-lib/src/chain/block_header.rs
+++ b/ergo-lib/src/chain/block_header.rs
@@ -80,7 +80,7 @@ pub struct BlockHeader {
     pub timestamp: u64,
     /// Current difficulty in a compressed view.
     #[cfg_attr(feature = "json", serde(rename = "nBits"))]
-    pub n_bits: u64,
+    pub n_bits: u32,
     /// Block height
     pub height: u32,
     /// Votes

--- a/ergo-lib/src/chain/block_header.rs
+++ b/ergo-lib/src/chain/block_header.rs
@@ -8,6 +8,7 @@ use ergotree_ir::sigma_protocol::dlog_group;
 #[cfg(feature = "json")]
 use serde::{Deserialize, Serialize};
 
+use super::addigest::ADDigest;
 use super::Base16DecodedBytes;
 use super::Base16EncodedBytes;
 use super::Digest32;
@@ -76,6 +77,15 @@ pub struct BlockHeader {
     /// Id of a parent block
     #[cfg_attr(feature = "json", serde(rename = "parentId"))]
     pub parent_id: BlockId,
+    ///
+    #[cfg_attr(feature = "json", serde(rename = "adProofsRoot"))]
+    pub ad_proofs_root: Digest32,
+    ///
+    #[cfg_attr(feature = "json", serde(rename = "transactionsRoot"))]
+    pub transactions_root: Digest32,
+    ///
+    #[cfg_attr(feature = "json", serde(rename = "stateRoot"))]
+    pub state_root: ADDigest,
     /// Timestamp of a block in ms from UNIX epoch
     pub timestamp: u64,
     /// Current difficulty in a compressed view.

--- a/ergotree-ir/src/mir/header.rs
+++ b/ergotree-ir/src/mir/header.rs
@@ -11,7 +11,7 @@ pub struct PreHeader {
     /// Timestamp of a block in ms from UNIX epoch
     pub timestamp: u64,
     /// Current difficulty in a compressed view.
-    pub n_bits: u64,
+    pub n_bits: u32,
     /// Block height
     pub height: u32,
     /// Public key of miner
@@ -51,7 +51,7 @@ mod arbitrary {
                 vec(any::<u8>(), 32),
                 // Timestamps between 2000-2050
                 946_674_000_000..2_500_400_300_000u64,
-                any::<u64>(),
+                any::<u32>(),
                 0..1_000_000u32,
                 any::<Box<EcPoint>>(),
             )


### PR DESCRIPTION
This draft PR adds all fields for block header except for the proof of PoW. Few outstanding questions:

1. `ADDigest` looks almost same as `Digest32`. Only difference is length. One way to unify them is to use const generics and make digest length parameter and then make `type Digest32 = Digest<32>`

2. Autolykos proof contain EC point which require serde traint implementations. Machinery for deriving base16-based serde instances is located in ergo lib and not accessible for `EcPoint`. Maybe it should be moved to `sigma-ser` to be accessible everywhere.