### PR TITLE
Fix issues #288 and #289: Make bigint operations check for 256-bit overflow and Change numeric negation on all types to give an error on overflow.

### DIFF
--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -22,6 +22,7 @@ pub mod env;
 
 pub(crate) mod and;
 pub(crate) mod apply;
+pub(crate) mod bigint;
 pub(crate) mod bin_op;
 pub(crate) mod block;
 pub(crate) mod bool_to_sigma;

--- a/ergotree-interpreter/src/eval/bigint.rs
+++ b/ergotree-interpreter/src/eval/bigint.rs
@@ -1,0 +1,12 @@
+use lazy_static::lazy_static;
+use num_bigint::BigInt;
+use num_traits::pow::Pow;
+
+lazy_static! {
+    pub static ref MAX_BOUND: BigInt = Pow::pow(BigInt::from(2), 255u32) - 1;
+    pub static ref MIN_BOUND: BigInt = -Pow::pow(BigInt::from(2), 255u32);
+}
+
+pub fn fits_in_256_bits(b: &BigInt) -> bool {
+    *b >= *MIN_BOUND && *b <= *MAX_BOUND
+}

--- a/ergotree-interpreter/src/eval/bin_op.rs
+++ b/ergotree-interpreter/src/eval/bin_op.rs
@@ -34,8 +34,8 @@ fn arithmetic_err<T: std::fmt::Display>(
     ))
 }
 
-fn check_bigint_overflow(res: Result<Value, EvalError>) -> Result<Value, EvalError> {
-    let bigint = res?.try_extract_into::<BigInt>()?;
+fn check_bigint_overflow(val: Value) -> Result<Value, EvalError> {
+    let bigint = val.try_extract_into::<BigInt>()?;
     if fits_in_256_bits(&bigint) {
         Ok(bigint.into())
     } else {
@@ -201,7 +201,7 @@ impl Evaluable for BinOp {
                     Value::Short(lv_raw) => eval_plus(lv_raw, rv()?),
                     Value::Int(lv_raw) => eval_plus(lv_raw, rv()?),
                     Value::Long(lv_raw) => eval_plus(lv_raw, rv()?),
-                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_plus(lv_raw, rv()?)),
+                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_plus(lv_raw, rv()?)?),
                     _ => Err(EvalError::UnexpectedValue(format!(
                         "expected BinOp::left to be numeric value, got {0:?}",
                         lv
@@ -212,7 +212,7 @@ impl Evaluable for BinOp {
                     Value::Short(lv_raw) => eval_minus(lv_raw, rv()?),
                     Value::Int(lv_raw) => eval_minus(lv_raw, rv()?),
                     Value::Long(lv_raw) => eval_minus(lv_raw, rv()?),
-                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_minus(lv_raw, rv()?)),
+                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_minus(lv_raw, rv()?)?),
                     _ => Err(EvalError::UnexpectedValue(format!(
                         "expected BinOp::left to be numeric value, got {0:?}",
                         lv
@@ -223,7 +223,7 @@ impl Evaluable for BinOp {
                     Value::Short(lv_raw) => eval_mul(lv_raw, rv()?),
                     Value::Int(lv_raw) => eval_mul(lv_raw, rv()?),
                     Value::Long(lv_raw) => eval_mul(lv_raw, rv()?),
-                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_mul(lv_raw, rv()?)),
+                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_mul(lv_raw, rv()?)?),
                     _ => Err(EvalError::UnexpectedValue(format!(
                         "expected BinOp::left to be numeric value, got {0:?}",
                         lv
@@ -235,7 +235,7 @@ impl Evaluable for BinOp {
                     Value::Int(lv_raw) => eval_div(lv_raw, rv()?),
                     Value::Long(lv_raw) => eval_div(lv_raw, rv()?),
                     // MIN / -1  can actually overflow
-                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_div(lv_raw, rv()?)),
+                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_div(lv_raw, rv()?)?),
                     _ => Err(EvalError::UnexpectedValue(format!(
                         "expected BinOp::left to be numeric value, got {0:?}",
                         lv

--- a/ergotree-interpreter/src/eval/bin_op.rs
+++ b/ergotree-interpreter/src/eval/bin_op.rs
@@ -16,23 +16,44 @@ use num_traits::CheckedSub;
 use num_traits::Num;
 
 use crate::eval;
+use crate::eval::bigint::fits_in_256_bits;
 use crate::eval::env::Env;
 use crate::eval::EvalContext;
 use crate::eval::EvalError;
 use crate::eval::Evaluable;
+
+fn arithmetic_err<T: std::fmt::Display>(
+    op: &str,
+    lv_raw: T,
+    rv_raw: T,
+    err_str: &str,
+) -> EvalError {
+    EvalError::ArithmeticException(format!(
+        "({0}) {1} ({2}) resulted in {3}",
+        lv_raw, op, rv_raw, err_str
+    ))
+}
+
+fn check_bigint_overflow(res: Result<Value, EvalError>) -> Result<Value, EvalError> {
+    let bigint = res?.try_extract_into::<BigInt>()?;
+    if fits_in_256_bits(&bigint) {
+        Ok(bigint.into())
+    } else {
+        Err(EvalError::ArithmeticException(
+            "Arithmetic Overflow on BigInt operation".to_string(),
+        ))
+    }
+}
 
 fn eval_plus<T>(lv_raw: T, rv: Value) -> Result<Value, EvalError>
 where
     T: Num + CheckedAdd + TryExtractFrom<Value> + Into<Value> + std::fmt::Display,
 {
     let rv_raw = rv.try_extract_into::<T>()?;
-    Ok((lv_raw.checked_add(&rv_raw).ok_or_else(|| {
-        EvalError::ArithmeticException(format!(
-            "({0}) + ({1}) resulted in overflow",
-            lv_raw, rv_raw
-        ))
-    })?)
-    .into())
+    lv_raw
+        .checked_add(&rv_raw)
+        .ok_or_else(|| arithmetic_err("+", lv_raw, rv_raw, "overflow"))
+        .map(|t| t.into()) // convert T to Value
 }
 
 fn eval_minus<T>(lv_raw: T, rv: Value) -> Result<Value, EvalError>
@@ -40,13 +61,10 @@ where
     T: Num + CheckedSub + TryExtractFrom<Value> + Into<Value> + std::fmt::Display,
 {
     let rv_raw = rv.try_extract_into::<T>()?;
-    Ok((lv_raw.checked_sub(&rv_raw).ok_or_else(|| {
-        EvalError::ArithmeticException(format!(
-            "({0}) - ({1}) resulted in overflow",
-            lv_raw, rv_raw
-        ))
-    })?)
-    .into())
+    lv_raw
+        .checked_sub(&rv_raw)
+        .ok_or_else(|| arithmetic_err("-", lv_raw, rv_raw, "overflow"))
+        .map(|t| t.into()) // convert T to Value
 }
 
 fn eval_mul<T>(lv_raw: T, rv: Value) -> Result<Value, EvalError>
@@ -54,13 +72,10 @@ where
     T: Num + CheckedMul + TryExtractFrom<Value> + Into<Value> + std::fmt::Display,
 {
     let rv_raw = rv.try_extract_into::<T>()?;
-    Ok((lv_raw.checked_mul(&rv_raw).ok_or_else(|| {
-        EvalError::ArithmeticException(format!(
-            "({0}) * ({1}) resulted in overflow",
-            lv_raw, rv_raw
-        ))
-    })?)
-    .into())
+    lv_raw
+        .checked_mul(&rv_raw)
+        .ok_or_else(|| arithmetic_err("*", lv_raw, rv_raw, "overflow"))
+        .map(|t| t.into()) // convert T to Value
 }
 
 fn eval_div<T>(lv_raw: T, rv: Value) -> Result<Value, EvalError>
@@ -68,13 +83,10 @@ where
     T: Num + CheckedDiv + TryExtractFrom<Value> + Into<Value> + std::fmt::Display,
 {
     let rv_raw = rv.try_extract_into::<T>()?;
-    Ok((lv_raw.checked_div(&rv_raw).ok_or_else(|| {
-        EvalError::ArithmeticException(format!(
-            "({0}) / ({1}) resulted in exception",
-            lv_raw, rv_raw
-        ))
-    })?)
-    .into())
+    lv_raw
+        .checked_div(&rv_raw)
+        .ok_or_else(|| arithmetic_err("/", lv_raw, rv_raw, "exception"))
+        .map(|t| t.into()) // convert T to Value
 }
 
 fn eval_bit_op<T, F>(lv_raw: T, rv: Value, op: F) -> Result<Value, EvalError>
@@ -189,7 +201,7 @@ impl Evaluable for BinOp {
                     Value::Short(lv_raw) => eval_plus(lv_raw, rv()?),
                     Value::Int(lv_raw) => eval_plus(lv_raw, rv()?),
                     Value::Long(lv_raw) => eval_plus(lv_raw, rv()?),
-                    Value::BigInt(lv_raw) => eval_plus(lv_raw, rv()?),
+                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_plus(lv_raw, rv()?)),
                     _ => Err(EvalError::UnexpectedValue(format!(
                         "expected BinOp::left to be numeric value, got {0:?}",
                         lv
@@ -200,7 +212,7 @@ impl Evaluable for BinOp {
                     Value::Short(lv_raw) => eval_minus(lv_raw, rv()?),
                     Value::Int(lv_raw) => eval_minus(lv_raw, rv()?),
                     Value::Long(lv_raw) => eval_minus(lv_raw, rv()?),
-                    Value::BigInt(lv_raw) => eval_minus(lv_raw, rv()?),
+                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_minus(lv_raw, rv()?)),
                     _ => Err(EvalError::UnexpectedValue(format!(
                         "expected BinOp::left to be numeric value, got {0:?}",
                         lv
@@ -211,7 +223,7 @@ impl Evaluable for BinOp {
                     Value::Short(lv_raw) => eval_mul(lv_raw, rv()?),
                     Value::Int(lv_raw) => eval_mul(lv_raw, rv()?),
                     Value::Long(lv_raw) => eval_mul(lv_raw, rv()?),
-                    Value::BigInt(lv_raw) => eval_mul(lv_raw, rv()?),
+                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_mul(lv_raw, rv()?)),
                     _ => Err(EvalError::UnexpectedValue(format!(
                         "expected BinOp::left to be numeric value, got {0:?}",
                         lv
@@ -222,7 +234,8 @@ impl Evaluable for BinOp {
                     Value::Short(lv_raw) => eval_div(lv_raw, rv()?),
                     Value::Int(lv_raw) => eval_div(lv_raw, rv()?),
                     Value::Long(lv_raw) => eval_div(lv_raw, rv()?),
-                    Value::BigInt(lv_raw) => eval_div(lv_raw, rv()?),
+                    // MIN / -1  can actually overflow
+                    Value::BigInt(lv_raw) => check_bigint_overflow(eval_div(lv_raw, rv()?)),
                     _ => Err(EvalError::UnexpectedValue(format!(
                         "expected BinOp::left to be numeric value, got {0:?}",
                         lv
@@ -445,19 +458,23 @@ mod tests {
 
         // The commented tests below are currently failing due to issue #288.
 
-        // assert!(   eval_num_op(ArithOp::Multiply, max(), b(2)).is_err());
+        assert!(eval_num_op(ArithOp::Multiply, max(), b(2)).is_err());
         assert_eq!(eval_num_op(ArithOp::Multiply, max(), b(1)), Ok(max()));
-        // assert!(   eval_num_op(ArithOp::Multiply, min(), b(2)).is_err());
+        assert!(eval_num_op(ArithOp::Multiply, min(), b(2)).is_err());
         assert_eq!(eval_num_op(ArithOp::Multiply, min(), b(1)), Ok(min()));
 
-        // assert!(   eval_num_op(ArithOp::Plus, max(), b(1)).is_err());
+        assert!(eval_num_op(ArithOp::Divide, min(), b(-1)).is_err());
+        assert_eq!(eval_num_op(ArithOp::Divide, min() + 1, b(-1)), Ok(max()));
+        assert!(eval_num_op(ArithOp::Divide, b(20), b(0)).is_err());
+
+        assert!(eval_num_op(ArithOp::Plus, max(), b(1)).is_err());
         assert_eq!(eval_num_op(ArithOp::Plus, max(), b(0)), Ok(max()));
-        // assert!(   eval_num_op(ArithOp::Plus, min(), b(-1)).is_err());
+        assert!(eval_num_op(ArithOp::Plus, min(), b(-1)).is_err());
         assert_eq!(eval_num_op(ArithOp::Plus, min(), b(0)), Ok(min()));
 
-        // assert!(   eval_num_op(ArithOp::Minus, max(), b(-1)).is_err());
+        assert!(eval_num_op(ArithOp::Minus, max(), b(-1)).is_err());
         assert_eq!(eval_num_op(ArithOp::Minus, max(), b(0)), Ok(max()));
-        // assert!(   eval_num_op(ArithOp::Minus, min(), b(1)).is_err());
+        assert!(eval_num_op(ArithOp::Minus, min(), b(1)).is_err());
         assert_eq!(eval_num_op(ArithOp::Minus, min(), b(0)), Ok(min()));
 
         assert_eq!(eval_num_op(ArithOp::BitAnd, max(), min()), Ok(b(0)));

--- a/ergotree-interpreter/src/eval/byte_array_to_bigint.rs
+++ b/ergotree-interpreter/src/eval/byte_array_to_bigint.rs
@@ -2,8 +2,8 @@
 use ergotree_ir::mir::byte_array_to_bigint::ByteArrayToBigInt;
 use ergotree_ir::mir::value::Value;
 
+use crate::eval::bigint::{MAX_BOUND, MIN_BOUND};
 use crate::eval::env::Env;
-use crate::eval::bigint::{MIN_BOUND, MAX_BOUND};
 use crate::eval::EvalContext;
 use crate::eval::EvalError;
 use crate::eval::EvalError::UnexpectedValue;

--- a/ergotree-interpreter/src/eval/byte_array_to_bigint.rs
+++ b/ergotree-interpreter/src/eval/byte_array_to_bigint.rs
@@ -3,15 +3,13 @@ use ergotree_ir::mir::byte_array_to_bigint::ByteArrayToBigInt;
 use ergotree_ir::mir::value::Value;
 
 use crate::eval::env::Env;
+use crate::eval::bigint::{MIN_BOUND, MAX_BOUND};
 use crate::eval::EvalContext;
 use crate::eval::EvalError;
 use crate::eval::EvalError::UnexpectedValue;
 use crate::eval::Evaluable;
 use ergotree_ir::mir::constant::TryExtractInto;
 use ergotree_ir::mir::value::Value::BigInt;
-use lazy_static::lazy_static;
-use num_bigint::ToBigInt;
-use num_traits::pow::Pow;
 
 impl Evaluable for ByteArrayToBigInt {
     fn eval(&self, env: &Env, ctx: &mut EvalContext) -> Result<Value, EvalError> {
@@ -34,15 +32,6 @@ impl Evaluable for ByteArrayToBigInt {
         }
         Ok(BigInt(n))
     }
-}
-
-lazy_static! {
-    static ref MAX_BOUND: num_bigint::BigInt =
-        Pow::pow(2.to_bigint().unwrap(), 255_u32) - 1.to_bigint().unwrap();
-}
-
-lazy_static! {
-    static ref MIN_BOUND: num_bigint::BigInt = -Pow::pow(2.to_bigint().unwrap(), 255_u32);
 }
 
 #[allow(clippy::unwrap_used)]

--- a/ergotree-interpreter/src/eval/negation.rs
+++ b/ergotree-interpreter/src/eval/negation.rs
@@ -1,20 +1,38 @@
 use ergotree_ir::mir::negation::Negation;
 use ergotree_ir::mir::value::Value;
 
+use crate::eval::bigint::fits_in_256_bits;
 use crate::eval::env::Env;
 use crate::eval::EvalContext;
 use crate::eval::EvalError;
 use crate::eval::Evaluable;
+use num_traits::CheckedNeg;
 
 impl Evaluable for Negation {
     fn eval(&self, env: &Env, ctx: &mut EvalContext) -> Result<Value, EvalError> {
         let input_v = self.input.eval(env, ctx)?;
+
+        fn overflow_err<T: std::fmt::Display>(v: &T) -> EvalError {
+            EvalError::ArithmeticException(format!("Overflow on Negation of value {}", *v))
+        }
+        fn neg<T: CheckedNeg + Into<Value> + std::fmt::Display>(v: &T) -> Result<Value, EvalError> {
+            v.checked_neg()
+                .map(|v| v.into())
+                .ok_or_else(|| overflow_err(v))
+        }
         match input_v {
-            Value::Byte(v) => Ok((-v).into()),
-            Value::Short(v) => Ok((-v).into()),
-            Value::Int(v) => Ok((-v).into()),
-            Value::Long(v) => Ok((-v).into()),
-            Value::BigInt(v) => Ok((-v).into()),
+            Value::Byte(v) => neg(&v),
+            Value::Short(v) => neg(&v),
+            Value::Int(v) => neg(&v),
+            Value::Long(v) => neg(&v),
+            Value::BigInt(v) => {
+                let neg_v = -v;
+                if fits_in_256_bits(&neg_v) {
+                    Ok((neg_v).into())
+                } else {
+                    Err(overflow_err(&-neg_v))
+                }
+            }
             _ => Err(EvalError::UnexpectedValue(format!(
                 "Expected Negation input to be numeric value, got {:?}",
                 input_v
@@ -28,7 +46,7 @@ impl Evaluable for Negation {
 mod tests {
 
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::tests::try_eval_out_wo_ctx;
     use ergotree_ir::mir::constant::Constant;
     use ergotree_ir::mir::constant::TryExtractFrom;
     use ergotree_ir::mir::expr::Expr;
@@ -36,22 +54,32 @@ mod tests {
     use num_bigint::ToBigInt;
     use num_traits::Num;
 
-    fn run_eval<T: Num + Into<Constant> + TryExtractFrom<Value>>(input: T) -> T {
+    fn try_run_eval<T: Num + Into<Constant> + TryExtractFrom<Value>>(
+        input: T,
+    ) -> Result<T, EvalError> {
         let expr: Expr = Negation::try_build(Expr::Const(input.into()))
             .unwrap()
             .into();
-        eval_out_wo_ctx::<T>(&expr)
+        try_eval_out_wo_ctx::<T>(&expr)
+    }
+    fn run_eval<T: Num + Into<Constant> + TryExtractFrom<Value>>(input: T) -> T {
+        try_run_eval(input).unwrap()
     }
 
     #[test]
     fn eval() {
         assert_eq!(run_eval(1i8), -1i8);
+        assert!(try_run_eval(i8::MIN).is_err());
         assert_eq!(run_eval(1i16), -1i16);
+        assert!(try_run_eval(i16::MIN).is_err());
         assert_eq!(run_eval(1i32), -1i32);
+        assert!(try_run_eval(i32::MIN).is_err());
         assert_eq!(run_eval(1i64), -1i64);
+        assert!(try_run_eval(i64::MIN).is_err());
         assert_eq!(
             run_eval(1i64.to_bigint().unwrap()),
             (-1i64).to_bigint().unwrap()
         );
+        assert!(try_run_eval(crate::eval::bigint::MIN_BOUND.clone()).is_err());
     }
 }


### PR DESCRIPTION
Make negation return an error on overflow for all integral types (including BigInt). This happens when negating the minimum value.

Separately, (but included in this PR because it depends on the previous change), check for overflow on the arithmetic operations on BigInt (+-*/) and error in that case. I considered a more involved change of adding a 256-bit integer type (implemented using bigint, and implementing the required numeric traits) which would check on all ops, but this would require replacing use of BigInt everywhere, and seemed a bit invasive.