### PR TITLE
Fix for UnsignedTransaction's from-JSON conversion

### DIFF
--- a/bindings/ergo-lib-wasm/src/transaction.rs
+++ b/bindings/ergo-lib-wasm/src/transaction.rs
@@ -74,6 +74,13 @@ impl Transaction {
         JsValue::from_serde(&self.0.clone()).map_err(|e| JsValue::from_str(&format!("{}", e)))
     }
 
+    /// JSON representation
+    pub fn from_json(json: &str) -> Result<Transaction, JsValue> {
+        serde_json::from_str(json)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+    }
+
     /// Inputs for transaction
     pub fn inputs(&self) -> Inputs {
         self.0.inputs.clone().into()

--- a/ergo-lib/src/chain/json/transaction.rs
+++ b/ergo-lib/src/chain/json/transaction.rs
@@ -1,5 +1,5 @@
-use crate::chain::transaction::{DataInput, Input};
-use crate::chain::{ergo_box::ErgoBox, transaction::TxId};
+use crate::chain::transaction::{DataInput, Input, UnsignedInput};
+use crate::chain::{ergo_box::{ErgoBox, ErgoBoxCandidate}, transaction::TxId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -16,6 +16,21 @@ pub struct TransactionJson {
     pub data_inputs: Vec<DataInput>,
     #[cfg_attr(feature = "json", serde(rename = "outputs"))]
     pub outputs: Vec<ErgoBox>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct UnsignedTransactionJson {
+    /// unsigned inputs, that will be spent by this transaction.
+    #[cfg_attr(feature = "json", serde(rename = "inputs"))]
+    pub inputs: Vec<UnsignedInput>,
+    /// inputs, that are not going to be spent by transaction, but will be reachable from inputs
+    /// scripts. `dataInputs` scripts will not be executed, thus their scripts costs are not
+    /// included in transaction cost and they do not contain spending proofs.
+    #[cfg_attr(feature = "json", serde(rename = "dataInputs"))]
+    pub data_inputs: Vec<DataInput>,
+    /// box candidates to be created by this transaction
+    #[cfg_attr(feature = "json", serde(rename = "outputs"))]
+    pub outputs: Vec<ErgoBoxCandidate>,
 }
 
 #[cfg(test)]

--- a/ergo-lib/src/chain/json/transaction.rs
+++ b/ergo-lib/src/chain/json/transaction.rs
@@ -1,5 +1,8 @@
 use crate::chain::transaction::{DataInput, Input, UnsignedInput};
-use crate::chain::{ergo_box::{ErgoBox, ErgoBoxCandidate}, transaction::TxId};
+use crate::chain::{
+    ergo_box::{ErgoBox, ErgoBoxCandidate},
+    transaction::TxId,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]

--- a/ergo-lib/src/chain/transaction/unsigned.rs
+++ b/ergo-lib/src/chain/transaction/unsigned.rs
@@ -5,7 +5,7 @@ use super::prover_result::ProverResult;
 use super::DataInput;
 use super::{
     super::{digest32::blake2b256_hash, ergo_box::ErgoBoxCandidate},
-    Transaction, TxId, json
+    json, Transaction, TxId,
 };
 use ergotree_interpreter::sigma_protocol::prover::ProofBytes;
 #[cfg(feature = "json")]

--- a/ergo-lib/src/chain/transaction/unsigned.rs
+++ b/ergo-lib/src/chain/transaction/unsigned.rs
@@ -1,15 +1,18 @@
 //! Unsigned (without proofs) transaction
 
 use super::input::{Input, UnsignedInput};
+#[cfg(feature = "json")]
+use super::json;
 use super::prover_result::ProverResult;
 use super::DataInput;
 use super::{
     super::{digest32::blake2b256_hash, ergo_box::ErgoBoxCandidate},
-    json, Transaction, TxId,
+    Transaction, TxId,
 };
 use ergotree_interpreter::sigma_protocol::prover::ProofBytes;
 #[cfg(feature = "json")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "json")]
 use std::convert::TryFrom;
 
 /// Unsigned (inputs without proofs) transaction

--- a/ergo-lib/src/chain/transaction/unsigned.rs
+++ b/ergo-lib/src/chain/transaction/unsigned.rs
@@ -92,9 +92,9 @@ impl UnsignedTransaction {
 impl From<UnsignedTransaction> for json::transaction::UnsignedTransactionJson {
     fn from(v: UnsignedTransaction) -> Self {
         json::transaction::UnsignedTransactionJson {
-            inputs: v.inputs.clone(),
-            data_inputs: v.data_inputs.clone(),
-            outputs: v.output_candidates.clone(),
+            inputs: v.inputs,
+            data_inputs: v.data_inputs,
+            outputs: v.output_candidates,
         }
     }
 }


### PR DESCRIPTION
After tx ids were removed from UnsignedTransaction, the automatic serde
deserialization no longer worked as there was no way for it to know how
to construct the tx_id field. This just does an approach similar to how
Transaction does its JSON conversions.

We could have alternatively just removed the tx_id field entirely and
computed it whenever we needed it, but I wasn't sure how this would
impact other users efficiency-wise so I went with this approach instead.