### PR TITLE
Implement SubstConst node

### DIFF
--- a/ergotree-interpreter/src/eval/expr.rs
+++ b/ergotree-interpreter/src/eval/expr.rs
@@ -11,6 +11,7 @@ impl Evaluable for Expr {
         ctx.cost_accum.add_cost_of(self)?;
         match self {
             Expr::Const(c) => Ok(c.v.clone()),
+            Expr::SubstConstants(_) => todo!(),
             Expr::ByteArrayToLong(op) => op.eval(env, ctx),
             Expr::ByteArrayToBigInt(op) => op.eval(env, ctx),
             Expr::LongToByteArray(op) => op.eval(env, ctx),

--- a/ergotree-ir/src/mir.rs
+++ b/ergotree-ir/src/mir.rs
@@ -84,6 +84,7 @@ pub mod sigma_and;
 pub mod sigma_or;
 /// Extract serialized bytes of a SigmaProp value
 pub mod sigma_prop_bytes;
+pub mod subst_const;
 /// Tuple of elements
 pub mod tuple;
 pub mod unary_op;

--- a/ergotree-ir/src/mir/constant.rs
+++ b/ergotree-ir/src/mir/constant.rs
@@ -275,8 +275,11 @@ pub(crate) mod arbitrary {
             // SType::SAvlTree => {}
             // SType::SOption(tpe) =>
             SType::SColl(elem_tpe) => match *elem_tpe {
-                SType::SByte => vec(any::<u8>(), 0..400).prop_map_into().boxed(),
                 SType::SBoolean => vec(any::<bool>(), 0..400).prop_map_into().boxed(),
+                SType::SByte => vec(any::<u8>(), 0..400).prop_map_into().boxed(),
+                SType::SShort => vec(any::<i16>(), 0..400).prop_map_into().boxed(),
+                SType::SInt => vec(any::<i32>(), 0..400).prop_map_into().boxed(),
+                SType::SLong => vec(any::<i64>(), 0..400).prop_map_into().boxed(),
                 _ => todo!(),
             },
             // SType::STuple(_) => {}

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -544,10 +544,19 @@ pub(crate) mod arbitrary {
 
     fn coll_non_nested_expr(elem_tpe: &SType) -> BoxedStrategy<Expr> {
         match elem_tpe {
+            SType::SBoolean => any_with::<Constant>(SType::SColl(Box::new(SType::SBoolean)).into())
+                .prop_map(Expr::Const)
+                .boxed(),
             SType::SByte => any_with::<Constant>(SType::SColl(Box::new(SType::SByte)).into())
                 .prop_map(Expr::Const)
                 .boxed(),
-            SType::SBoolean => any_with::<Constant>(SType::SColl(Box::new(SType::SBoolean)).into())
+            SType::SShort => any_with::<Constant>(SType::SColl(Box::new(SType::SShort)).into())
+                .prop_map(Expr::Const)
+                .boxed(),
+            SType::SInt => any_with::<Constant>(SType::SColl(Box::new(SType::SInt)).into())
+                .prop_map(Expr::Const)
+                .boxed(),
+            SType::SLong => any_with::<Constant>(SType::SColl(Box::new(SType::SLong)).into())
                 .prop_map(Expr::Const)
                 .boxed(),
             _ => todo!("Collection of {0:?} is not yet implemented", elem_tpe),

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -54,6 +54,7 @@ use super::select_field::SelectField;
 use super::sigma_and::SigmaAnd;
 use super::sigma_or::SigmaOr;
 use super::sigma_prop_bytes::SigmaPropBytes;
+use super::subst_const::SubstConstants;
 use super::tuple::Tuple;
 use super::upcast::Upcast;
 use super::val_def::ValDef;
@@ -81,6 +82,8 @@ pub enum Expr {
     Const(Constant),
     /// Placeholder for a constant
     ConstPlaceholder(ConstantPlaceholder),
+    /// FIXME: Doc
+    SubstConstants(SubstConstants),
     /// Convert byte array to SLong
     ByteArrayToLong(ByteArrayToLong),
     /// Convert byte array to SLong
@@ -204,6 +207,7 @@ impl Expr {
             Expr::Append(op) => op.op_code(),
             Expr::Const(_) => panic!("constant does not have op code assigned"),
             Expr::ConstPlaceholder(op) => op.op_code(),
+            Expr::SubstConstants(op) => op.op_code(),
             Expr::ByteArrayToLong(op) => op.op_code(),
             Expr::ByteArrayToBigInt(op) => op.op_code(),
             Expr::LongToByteArray(op) => op.op_code(),
@@ -267,6 +271,7 @@ impl Expr {
             Expr::Append(ap) => ap.tpe(),
             Expr::Const(v) => v.tpe.clone(),
             Expr::Collection(v) => v.tpe(),
+            Expr::SubstConstants(_v) => todo!(),
             Expr::ByteArrayToLong(v) => v.tpe(),
             Expr::ByteArrayToBigInt(v) => v.tpe(),
             Expr::LongToByteArray(v) => v.tpe(),

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -82,7 +82,7 @@ pub enum Expr {
     Const(Constant),
     /// Placeholder for a constant
     ConstPlaceholder(ConstantPlaceholder),
-    /// FIXME: Doc
+    /// Substitute constants in serialized ergo tree
     SubstConstants(SubstConstants),
     /// Convert byte array to SLong
     ByteArrayToLong(ByteArrayToLong),
@@ -271,7 +271,7 @@ impl Expr {
             Expr::Append(ap) => ap.tpe(),
             Expr::Const(v) => v.tpe.clone(),
             Expr::Collection(v) => v.tpe(),
-            Expr::SubstConstants(_v) => todo!(),
+            Expr::SubstConstants(v) => v.tpe(),
             Expr::ByteArrayToLong(v) => v.tpe(),
             Expr::ByteArrayToBigInt(v) => v.tpe(),
             Expr::LongToByteArray(v) => v.tpe(),

--- a/ergotree-ir/src/mir/subst_const.rs
+++ b/ergotree-ir/src/mir/subst_const.rs
@@ -1,27 +1,35 @@
-//! FIXME
-
+//! Substitution of constants in serialized sigma expression
+use super::expr::Expr;
+use crate::mir::expr::InvalidArgumentError;
 use crate::serialization::op_code::OpCode;
 use crate::serialization::sigma_byte_reader::SigmaByteRead;
 use crate::serialization::sigma_byte_writer::SigmaByteWrite;
 use crate::serialization::SerializationError;
 use crate::serialization::SigmaSerializable;
-//use crate::types::stype::SType;
-
-use super::expr::Expr;
+use crate::types::stype::SType;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
-/// FIXME: DOC
+/// Substitute constants in the serialized representation of sigma script. Returns
+/// original scriptBytes array where only specified constants are replaced and all
+/// other bytes remain exactly the same.
 pub struct SubstConstants {
-    /// FIXME: DOC
+    /// Serialized ergo tree with ConstantSegregationFlag set to 1.
     pub script_bytes: Box<Expr>,
-    /// FIXME: DOC
+    /// Zero based indexes in ErgoTree.constants array which should be
+    /// replaced with new values.
     pub positions: Box<Expr>,
-    /// FIXME: DOC
+    /// New values to be injected into the corresponding positions in ErgoTree.constants
+    /// array.
     pub new_values: Box<Expr>,
 }
 
 impl SubstConstants {
     pub(crate) const OP_CODE: OpCode = OpCode::SUBST_CONSTANTS;
+
+    /// Type of returned value
+    pub fn tpe(&self) -> SType {
+        SType::SColl(SType::SByte.into())
+    }
 
     pub(crate) fn op_code(&self) -> OpCode {
         Self::OP_CODE
@@ -36,8 +44,14 @@ impl SigmaSerializable for SubstConstants {
     }
 
     fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, SerializationError> {
-        let script_bytes = Expr::sigma_parse(r)?.into();
-        let positions = Expr::sigma_parse(r)?.into();
+        let script_bytes = Box::new(Expr::sigma_parse(r)?);
+        script_bytes
+            .check_post_eval_tpe(SType::SColl(SType::SByte.into()))
+            .map_err(InvalidArgumentError::from)?;
+        let positions = Box::new(Expr::sigma_parse(r)?);
+        positions
+            .check_post_eval_tpe(SType::SColl(SType::SInt.into()))
+            .map_err(InvalidArgumentError::from)?;
         let new_values = Expr::sigma_parse(r)?.into();
         Ok(Self {
             script_bytes,
@@ -51,6 +65,7 @@ impl SigmaSerializable for SubstConstants {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
+    use crate::mir::expr::arbitrary::ArbExprParams;
     use crate::mir::expr::Expr;
     use crate::serialization::sigma_serialize_roundtrip;
     use proptest::prelude::*;
@@ -60,10 +75,20 @@ mod tests {
         type Parameters = ();
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-            (any::<Box<Expr>>(), any::<Box<Expr>>(), any::<Box<Expr>>())
+            (
+                any_with::<Expr>(ArbExprParams {
+                    tpe: SType::SColl(SType::SByte.into()),
+                    depth: 0,
+                }),
+                any_with::<Expr>(ArbExprParams {
+                    tpe: SType::SColl(SType::SInt.into()),
+                    depth: 0,
+                }),
+                any::<Box<Expr>>(),
+            )
                 .prop_map(|(script_bytes, positions, new_values)| Self {
-                    script_bytes,
-                    positions,
+                    script_bytes: script_bytes.into(),
+                    positions: positions.into(),
                     new_values,
                 })
                 .boxed()

--- a/ergotree-ir/src/mir/subst_const.rs
+++ b/ergotree-ir/src/mir/subst_const.rs
@@ -1,0 +1,83 @@
+//! FIXME
+
+use crate::serialization::op_code::OpCode;
+use crate::serialization::sigma_byte_reader::SigmaByteRead;
+use crate::serialization::sigma_byte_writer::SigmaByteWrite;
+use crate::serialization::SerializationError;
+use crate::serialization::SigmaSerializable;
+//use crate::types::stype::SType;
+
+use super::expr::Expr;
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+/// FIXME: DOC
+pub struct SubstConstants {
+    /// FIXME: DOC
+    pub script_bytes: Box<Expr>,
+    /// FIXME: DOC
+    pub positions: Box<Expr>,
+    /// FIXME: DOC
+    pub new_values: Box<Expr>,
+}
+
+impl SubstConstants {
+    pub(crate) const OP_CODE: OpCode = OpCode::SUBST_CONSTANTS;
+
+    pub(crate) fn op_code(&self) -> OpCode {
+        Self::OP_CODE
+    }
+}
+
+impl SigmaSerializable for SubstConstants {
+    fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> Result<(), std::io::Error> {
+        self.script_bytes.sigma_serialize(w)?;
+        self.positions.sigma_serialize(w)?;
+        self.new_values.sigma_serialize(w)
+    }
+
+    fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, SerializationError> {
+        let script_bytes = Expr::sigma_parse(r)?.into();
+        let positions = Expr::sigma_parse(r)?.into();
+        let new_values = Expr::sigma_parse(r)?.into();
+        Ok(Self {
+            script_bytes,
+            positions,
+            new_values,
+        })
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "arbitrary")]
+mod tests {
+    use super::*;
+    use crate::mir::expr::Expr;
+    use crate::serialization::sigma_serialize_roundtrip;
+    use proptest::prelude::*;
+
+    impl Arbitrary for SubstConstants {
+        type Strategy = BoxedStrategy<Self>;
+        type Parameters = ();
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            (any::<Box<Expr>>(), any::<Box<Expr>>(), any::<Box<Expr>>())
+                .prop_map(|(script_bytes, positions, new_values)| Self {
+                    script_bytes,
+                    positions,
+                    new_values,
+                })
+                .boxed()
+        }
+    }
+
+    proptest! {
+
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        #[test]
+        fn ser_roundtrip(v in any::<SubstConstants>()) {
+            let expr: Expr = v.into();
+            prop_assert_eq![sigma_serialize_roundtrip(&expr), expr];
+        }
+    }
+}

--- a/ergotree-ir/src/serialization/expr.rs
+++ b/ergotree-ir/src/serialization/expr.rs
@@ -57,6 +57,7 @@ use crate::mir::select_field::SelectField;
 use crate::mir::sigma_and::SigmaAnd;
 use crate::mir::sigma_or::SigmaOr;
 use crate::mir::sigma_prop_bytes::SigmaPropBytes;
+use crate::mir::subst_const::SubstConstants;
 use crate::mir::tuple::Tuple;
 use crate::mir::upcast::Upcast;
 use crate::mir::val_def::ValDef;
@@ -161,6 +162,7 @@ impl Expr {
                 SigmaPropBytes::OP_CODE => Ok(SigmaPropBytes::sigma_parse(r)?.into()),
                 Tuple::OP_CODE => Ok(Tuple::sigma_parse(r)?.into()),
                 DecodePoint::OP_CODE => Ok(DecodePoint::sigma_parse(r)?.into()),
+                SubstConstants::OP_CODE => Ok(SubstConstants::sigma_parse(r)?.into()),
                 ByteArrayToLong::OP_CODE => Ok(ByteArrayToLong::sigma_parse(r)?.into()),
                 ByteArrayToBigInt::OP_CODE => Ok(ByteArrayToBigInt::sigma_parse(r)?.into()),
                 LongToByteArray::OP_CODE => Ok(LongToByteArray::sigma_parse(r)?.into()),
@@ -200,6 +202,7 @@ impl SigmaSerializable for Expr {
                     Expr::Append(ap) => ap.sigma_serialize(w),
                     Expr::Fold(op) => op.sigma_serialize(w),
                     Expr::ConstPlaceholder(cp) => cp.sigma_serialize(w),
+                    Expr::SubstConstants(s) => s.sigma_serialize(w),
                     Expr::ByteArrayToLong(s) => s.sigma_serialize(w),
                     Expr::ByteArrayToBigInt(s) => s.sigma_serialize(w),
                     Expr::LongToByteArray(s) => s.sigma_serialize(w),


### PR DESCRIPTION
I'm not quite sure what does it do. So there's no meaningful comment. 

1. What should `tpe` return for `SubstConstants`? To infer type one must decode script and to type check it. 
2. Should parsing check that types of arguments are correct?