### PR TITLE
Better Debug print for EC point

### DIFF
--- a/ergotree-ir/src/sigma_protocol/dlog_group.rs
+++ b/ergotree-ir/src/sigma_protocol/dlog_group.rs
@@ -28,8 +28,15 @@ use std::{
 };
 
 /// Elliptic curve point
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Clone)]
 pub struct EcPoint(ProjectivePoint);
+
+impl std::fmt::Debug for EcPoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("EC:")?;
+        f.write_str(&base16::encode_lower(&self.sigma_serialize_bytes()))
+    }
+}
 
 impl EcPoint {
     /// Number of bytes to represent any group element as byte array


### PR DESCRIPTION
Make debug print for EC point much more compact: or example `EC:02bb8eb301ab3d5d14515e33760d0dfb4f7191312a640db64a3a1aeeac9703f2d3` instead of full screenful of internal details of said point. Much more useful as debug print. Compare with: 

```
EcPoint(
    ProjectivePoint {
        x: FieldElement(
            FieldElementImpl {
                value: FieldElement5x52(
                    [
                        705178180786072,
                        3855836460717471,
                        4089131105950716,
                        3301581525494108,
                        133858670344668,
                    ],
                ),
                magnitude: 1,
                normalized: true,
            },
        ),
        y: FieldElement(
            FieldElementImpl {
                value: FieldElement5x52(
                    [
                        2199641648059576,
                        1278080618437060,
                        3959378566518708,
                        3455034269351872,
                        79417610544803,
                    ],
                ),
                magnitude: 1,
                normalized: true,
            },
        ),
        z: FieldElement(
            FieldElementImpl {
                value: FieldElement5x52(
                    [
                        1,
                        0,
                        0,
                        0,
                        0,
                    ],
                ),
                magnitude: 1,
                normalized: true,
            },
        ),
    },
)
```
