### PR TITLE
XorOf IR Node implementation

### DIFF
--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -82,6 +82,7 @@ pub(crate) mod tuple;
 pub(crate) mod upcast;
 pub(crate) mod val_use;
 pub(crate) mod xor;
+pub(crate) mod xor_of;
 
 /// Interpreter errors
 #[derive(Error, PartialEq, Eq, Debug, Clone)]

--- a/ergotree-interpreter/src/eval/expr.rs
+++ b/ergotree-interpreter/src/eval/expr.rs
@@ -73,6 +73,7 @@ impl Evaluable for Expr {
             Expr::GetVar(op) => op.eval(env, ctx),
             Expr::MultiplyGroup(op) => op.eval(env, ctx),
             Expr::Exponentiate(op) => op.eval(env, ctx),
+            Expr::XorOf(op) => op.eval(env, ctx),
         }
     }
 }

--- a/ergotree-interpreter/src/eval/xor_of.rs
+++ b/ergotree-interpreter/src/eval/xor_of.rs
@@ -1,0 +1,40 @@
+use ergotree_ir::mir::constant::TryExtractInto;
+use ergotree_ir::mir::value::Value;
+
+use crate::eval::env::Env;
+use crate::eval::EvalContext;
+use crate::eval::EvalError;
+use crate::eval::Evaluable;
+use ergotree_ir::mir::xor_of::XorOf;
+
+impl Evaluable for XorOf {
+    fn eval(&self, env: &Env, ctx: &mut EvalContext) -> Result<Value, EvalError> {
+        let input_v = self.input.eval(env, ctx)?;
+        let input_v_bools = input_v.try_extract_into::<Vec<bool>>()?;
+        Ok((input_v_bools.into_iter().filter(|x| *x).count() & 1 == 1).into())
+    }
+}
+
+#[allow(clippy::panic)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::context::Context;
+    use crate::eval::tests::eval_out;
+    use ergotree_ir::mir::expr::Expr;
+    use proptest::collection;
+    use proptest::prelude::*;
+    use sigma_test_util::force_any_val;
+    use std::rc::Rc;
+
+    proptest! {
+
+        #[test]
+        fn eval(bools in collection::vec(any::<bool>(), 10..=20)) {
+            let expr: Expr = XorOf {input: Expr::Const(bools.clone().into()).into()}.into();
+            let ctx = Rc::new(force_any_val::<Context>());
+            let res = eval_out::<bool>(&expr, ctx);
+            prop_assert_eq!(res, bools.into_iter().filter(|x| *x).count() & 1 == 1);
+        }
+    }
+}

--- a/ergotree-interpreter/src/eval/xor_of.rs
+++ b/ergotree-interpreter/src/eval/xor_of.rs
@@ -30,11 +30,14 @@ mod tests {
     proptest! {
 
         #[test]
-        fn eval(bools in collection::vec(any::<bool>(), 10..=20)) {
+        fn eval(bools in collection::vec(any::<bool>(), 0..=10)) {
             let expr: Expr = XorOf {input: Expr::Const(bools.clone().into()).into()}.into();
             let ctx = Rc::new(force_any_val::<Context>());
             let res = eval_out::<bool>(&expr, ctx);
-            prop_assert_eq!(res, bools.into_iter().filter(|x| *x).count() & 1 == 1);
+
+            let mut expected = false;
+            bools.into_iter().for_each(|v| expected ^= v);
+            prop_assert_eq!(res, expected);
         }
     }
 }

--- a/ergotree-interpreter/src/eval/xor_of.rs
+++ b/ergotree-interpreter/src/eval/xor_of.rs
@@ -11,7 +11,7 @@ impl Evaluable for XorOf {
     fn eval(&self, env: &Env, ctx: &mut EvalContext) -> Result<Value, EvalError> {
         let input_v = self.input.eval(env, ctx)?;
         let input_v_bools = input_v.try_extract_into::<Vec<bool>>()?;
-        Ok((input_v_bools.into_iter().filter(|x| *x).count() & 1 == 1).into())
+        Ok(input_v_bools.into_iter().fold(false, |a, b| a ^ b).into())
     }
 }
 
@@ -34,9 +34,8 @@ mod tests {
             let expr: Expr = XorOf {input: Expr::Const(bools.clone().into()).into()}.into();
             let ctx = Rc::new(force_any_val::<Context>());
             let res = eval_out::<bool>(&expr, ctx);
-
-            let mut expected = false;
-            bools.into_iter().for_each(|v| expected ^= v);
+            // eval is true when collection has odd number of "true" values
+            let expected = bools.into_iter().filter(|x| *x).count() & 1 == 1;
             prop_assert_eq!(res, expected);
         }
     }

--- a/ergotree-ir/src/mir.rs
+++ b/ergotree-ir/src/mir.rs
@@ -98,3 +98,5 @@ pub mod val_use;
 pub mod value;
 /// Byte-wise XOR op
 pub mod xor;
+/// XOR for collection of booleans
+pub mod xor_of;

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -68,6 +68,7 @@ use crate::mir::create_prove_dh_tuple::CreateProveDhTuple;
 use crate::mir::deserialize_context::DeserializeContext;
 use crate::mir::deserialize_register::DeserializeRegister;
 use crate::mir::get_var::GetVar;
+use crate::mir::xor_of::XorOf;
 use bounded_vec::BoundedVecOutOfBounds;
 use derive_more::From;
 use derive_more::TryInto;
@@ -200,6 +201,8 @@ pub enum Expr {
     MultiplyGroup(MultiplyGroup),
     /// Exponentiate op for GroupElement
     Exponentiate(Exponentiate),
+    /// XOR for collection of booleans
+    XorOf(XorOf),
 }
 
 impl Expr {
@@ -265,6 +268,7 @@ impl Expr {
             Expr::GetVar(v) => v.tpe(),
             Expr::MultiplyGroup(v) => v.tpe(),
             Expr::Exponentiate(v) => v.tpe(),
+            Expr::XorOf(v) => v.tpe(),
         }
     }
 

--- a/ergotree-ir/src/mir/xor_of.rs
+++ b/ergotree-ir/src/mir/xor_of.rs
@@ -1,0 +1,84 @@
+//! XOR for collection of booleans
+
+use crate::serialization::op_code::OpCode;
+use crate::serialization::sigma_byte_reader::SigmaByteRead;
+use crate::serialization::sigma_byte_writer::SigmaByteWrite;
+use crate::serialization::SigmaParsingError;
+use crate::serialization::SigmaSerializable;
+use crate::serialization::SigmaSerializeResult;
+use crate::types::stype::SType;
+
+use super::expr::Expr;
+use crate::has_opcode::HasStaticOpCode;
+
+/// XOR Of
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct XorOf {
+    /// Collection of SBoolean
+    pub input: Box<Expr>,
+}
+
+impl XorOf {
+    /// Type
+    pub fn tpe(&self) -> SType {
+        SType::SBoolean
+    }
+}
+
+impl HasStaticOpCode for XorOf {
+    const OP_CODE: OpCode = OpCode::XOR_OF;
+}
+
+impl SigmaSerializable for XorOf {
+    fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> SigmaSerializeResult {
+        self.input.sigma_serialize(w)
+    }
+
+    fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, SigmaParsingError> {
+        Ok(Self {
+            input: Expr::sigma_parse(r)?.into(),
+        })
+    }
+}
+
+/// Arbitrary impl
+#[cfg(feature = "arbitrary")]
+mod arbitrary {
+    use super::*;
+    use crate::mir::expr::arbitrary::ArbExprParams;
+    use proptest::prelude::*;
+
+    impl Arbitrary for XorOf {
+        type Strategy = BoxedStrategy<Self>;
+        type Parameters = usize;
+
+        fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+            any_with::<Expr>(ArbExprParams {
+                tpe: SType::SColl(SType::SBoolean.into()),
+                depth: args,
+            })
+            .prop_map(|input| Self {
+                input: input.into(),
+            })
+            .boxed()
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::mir::expr::Expr;
+    use crate::serialization::sigma_serialize_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+
+        #[test]
+        fn ser_roundtrip(v in any_with::<XorOf>(1)) {
+            let expr: Expr = v.into();
+            prop_assert_eq![sigma_serialize_roundtrip(&expr), expr];
+        }
+    }
+}

--- a/ergotree-ir/src/serialization/expr.rs
+++ b/ergotree-ir/src/serialization/expr.rs
@@ -70,6 +70,7 @@ use crate::serialization::{
     sigma_byte_reader::SigmaByteRead, SigmaParsingError, SigmaSerializable,
 };
 
+use crate::mir::xor_of::XorOf;
 use crate::serialization::types::TypeCode;
 
 impl Expr {
@@ -174,6 +175,7 @@ impl Expr {
                 DeserializeContext::OP_CODE => Ok(DeserializeContext::sigma_parse(r)?.into()),
                 MultiplyGroup::OP_CODE => Ok(MultiplyGroup::sigma_parse(r)?.into()),
                 Exponentiate::OP_CODE => Ok(Exponentiate::sigma_parse(r)?.into()),
+                XorOf::OP_CODE => Ok(XorOf::sigma_parse(r)?.into()),
                 o => Err(SigmaParsingError::NotImplementedOpCode(format!(
                     "{0}(shift {1})",
                     o.value(),
@@ -269,6 +271,7 @@ impl SigmaSerializable for Expr {
             Expr::DeserializeContext(op) => op.sigma_serialize_w_opcode(w),
             Expr::MultiplyGroup(op) => op.sigma_serialize_w_opcode(w),
             Expr::Exponentiate(op) => op.sigma_serialize_w_opcode(w),
+            Expr::XorOf(op) => op.sigma_serialize_w_opcode(w),
         }
     }
 


### PR DESCRIPTION
PR for https://github.com/ergoplatform/sigma-rust/issues/356

Since `Xor` is associative, I went with a slightly different approach than the Scala implementation based on https://github.com/ScorexFoundation/sigmastate-interpreter/issues/640 by checking for an odd number of `true` values.

Let me know if you see any issues with this; instead I can rework this to use `^` bitwise XOR, perhaps in a `fold` or `reduce` operation.

In the scala version, there is also a check for `E.context.activatedScriptVersion >= 2`, do I need to take this into account?