### PR TITLE
Serialization for Ledger

### DIFF
--- a/bindings/ergo-lib-wasm/src/ast.rs
+++ b/bindings/ergo-lib-wasm/src/ast.rs
@@ -40,6 +40,13 @@ impl Constant {
         self.0.base16_str()
     }
 
+    /// Returns serialized bytes or fails with error if Constant cannot be serialized
+    pub fn sigma_serialize_bytes(&self) -> Result<Vec<u8>, JsValue> {
+        self.0
+            .sigma_serialize_bytes()
+            .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
+    }
+
     /// Create from i32 value
     pub fn from_i32(v: i32) -> Constant {
         Constant(v.into())

--- a/bindings/ergo-lib-wasm/src/context_extension.rs
+++ b/bindings/ergo-lib-wasm/src/context_extension.rs
@@ -1,6 +1,7 @@
 //! ProverResult
 
 use crate::ast::Constant;
+use ergo_lib::ergotree_ir::serialization::SigmaSerializable;
 use wasm_bindgen::prelude::*;
 
 extern crate derive_more;
@@ -33,5 +34,12 @@ impl ContextExtension {
         let wrapped: ergo_lib::ergotree_interpreter::sigma_protocol::prover::ContextExtension =
             self.0.clone();
         wrapped.values.keys().cloned().collect()
+    }
+
+    /// Returns serialized bytes or fails with error if ContextExtension cannot be serialized
+    pub fn sigma_serialize_bytes(&self) -> Result<Vec<u8>, JsValue> {
+        self.0
+            .sigma_serialize_bytes()
+            .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
     }
 }

--- a/bindings/ergo-lib-wasm/src/ergo_box.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_box.rs
@@ -224,6 +224,11 @@ impl BoxValue {
     pub fn as_i64(&self) -> I64 {
         self.0.as_i64().into()
     }
+
+    /// big-endian byte array representation
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.as_u64().to_be_bytes().to_vec()
+    }
 }
 
 impl From<BoxValue> for chain::ergo_box::BoxValue {

--- a/bindings/ergo-lib-wasm/src/ergo_box.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_box.rs
@@ -20,6 +20,7 @@ use std::convert::TryFrom;
 
 use chain::ergo_box::NonMandatoryRegisters;
 use ergo_lib::chain;
+use ergo_lib::ergotree_ir::serialization::SigmaSerializable;
 use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 
@@ -178,6 +179,15 @@ impl ErgoBox {
     /// JSON representation
     pub fn from_json(json: &str) -> Result<ErgoBox, JsValue> {
         serde_json::from_str(json).map(Self).map_err(to_js)
+    }
+
+    /// Serialized additional register as defined in ErgoBox serialization (registers count,
+    /// followed by every non-empyt register value serialized)
+    pub fn serialized_additional_registers(&self) -> Result<Vec<u8>, JsValue> {
+        self.0
+            .additional_registers
+            .sigma_serialize_bytes()
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
     }
 }
 

--- a/bindings/ergo-lib-wasm/src/ergo_box.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_box.rs
@@ -20,6 +20,7 @@ use std::convert::TryFrom;
 
 use chain::ergo_box::NonMandatoryRegisters;
 use ergo_lib::chain;
+use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 
 use crate::ast::Constant;
@@ -52,6 +53,11 @@ impl BoxId {
     /// Base16 encoded string
     pub fn to_str(&self) -> String {
         self.0.clone().into()
+    }
+
+    /// Returns byte array (32 bytes)
+    pub fn as_bytes(&self) -> Uint8Array {
+        Uint8Array::from(self.0.as_ref())
     }
 }
 

--- a/bindings/ergo-lib-wasm/src/ergo_tree.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_tree.rs
@@ -30,8 +30,8 @@ impl ErgoTree {
             .map(ErgoTree)
             .map_err(to_js)
     }
-    /// Encode Ergo tree as serialized bytes
-    pub fn to_bytes(&self) -> Result<Vec<u8>, JsValue> {
+    /// Returns serialized bytes or fails with error if ErgoTree cannot be serialized
+    pub fn sigma_serialize_bytes(&self) -> Result<Vec<u8>, JsValue> {
         self.0.sigma_serialize_bytes().map_err(to_js)
     }
 

--- a/bindings/ergo-lib-wasm/src/token.rs
+++ b/bindings/ergo-lib-wasm/src/token.rs
@@ -5,6 +5,7 @@ use std::convert::TryFrom;
 use ergo_lib::chain;
 use ergo_lib::chain::Base16DecodedBytes;
 use ergo_lib::chain::Digest32;
+use js_sys::Uint8Array;
 use wasm_bindgen::prelude::*;
 
 use crate::ergo_box::BoxId;
@@ -37,6 +38,11 @@ impl TokenId {
     /// Base16 encoded string
     pub fn to_str(&self) -> String {
         self.0.clone().into()
+    }
+
+    /// Returns byte array (32 bytes)
+    pub fn as_bytes(&self) -> Uint8Array {
+        Uint8Array::from(self.0.as_ref())
     }
 }
 

--- a/bindings/ergo-lib-wasm/src/token.rs
+++ b/bindings/ergo-lib-wasm/src/token.rs
@@ -70,6 +70,11 @@ impl TokenAmount {
     pub fn as_i64(&self) -> I64 {
         i64::from(self.0).into()
     }
+
+    /// big-endian byte array representation
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.as_u64().to_be_bytes().to_vec()
+    }
 }
 
 impl From<TokenAmount> for chain::token::TokenAmount {

--- a/bindings/ergo-lib-wasm/src/transaction.rs
+++ b/bindings/ergo-lib-wasm/src/transaction.rs
@@ -66,6 +66,23 @@ pub struct Transaction(chain::transaction::Transaction);
 
 #[wasm_bindgen]
 impl Transaction {
+    /// Create Transaction from UnsignedTransaction and an array of proofs in the same order as
+    /// UnsignedTransaction.inputs with empty proof indicated with empty byte array
+    pub fn from_unsigned_tx(
+        unsigned_tx: UnsignedTransaction,
+        proofs: Vec<Uint8Array>,
+    ) -> Result<Transaction, JsValue> {
+        chain::transaction::Transaction::from_unsigned_tx(
+            unsigned_tx.0,
+            proofs
+                .into_iter()
+                .map(|bytes| bytes.to_vec().into())
+                .collect(),
+        )
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))
+        .map(Into::into)
+    }
+
     /// Get id for transaction
     pub fn id(&self) -> TxId {
         self.0.id().into()

--- a/bindings/ergo-lib-wasm/src/transaction.rs
+++ b/bindings/ergo-lib-wasm/src/transaction.rs
@@ -6,6 +6,8 @@ use crate::data_input::DataInputs;
 use crate::error_conversion::to_js;
 use crate::input::{Inputs, UnsignedInputs};
 use ergo_lib::chain;
+use ergo_lib::chain::transaction::distinct_token_ids;
+use js_sys::Uint8Array;
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use wasm_bindgen::prelude::*;
@@ -151,6 +153,14 @@ impl UnsignedTransaction {
     /// JSON representation
     pub fn from_json(json: &str) -> Result<UnsignedTransaction, JsValue> {
         serde_json::from_str(json).map(Self).map_err(to_js)
+    }
+
+    /// Returns distinct token id from output_candidates as array of byte arrays
+    pub fn distinct_token_ids(&self) -> Vec<Uint8Array> {
+        distinct_token_ids(self.0.output_candidates.clone())
+            .iter()
+            .map(|id| Uint8Array::from(id.as_ref()))
+            .collect()
     }
 }
 

--- a/bindings/ergo-lib-wasm/tests/test_transaction.js
+++ b/bindings/ergo-lib-wasm/tests/test_transaction.js
@@ -4,32 +4,32 @@ import {
   Address, Wallet, ErgoBox, ErgoBoxCandidateBuilder, Contract,
   ErgoBoxes, ErgoBoxCandidates,
   ErgoStateContext, TxBuilder, BoxValue, BoxSelector, I64, SecretKey, SecretKeys, TxId, DataInputs,
-  SimpleBoxSelector, Tokens, Token, TokenAmount, TokenId, BlockHeaders, PreHeader,
+  SimpleBoxSelector, Tokens, Token, TokenAmount, TokenId, BlockHeaders, PreHeader, Transaction,
 } from '../pkg/ergo_lib_wasm';
 
 const block_headers = BlockHeaders.from_json([{
-      "extensionId": "d16f25b14457186df4c5f6355579cc769261ce1aebc8209949ca6feadbac5a3f",
-      "difficulty": "626412390187008",
-      "votes": "040000",
-      "timestamp": 1618929697400,
-      "size": 221,
-      "stateRoot": "8ad868627ea4f7de6e2a2fe3f98fafe57f914e0f2ef3331c006def36c697f92713",
-      "height": 471746,
-      "nBits": 117586360,
-      "version": 2,
-      "id": "4caa17e62fe66ba7bd69597afdc996ae35b1ff12e0ba90c22ff288a4de10e91b",
-      "adProofsRoot": "d882aaf42e0a95eb95fcce5c3705adf758e591532f733efe790ac3c404730c39",
-      "transactionsRoot": "63eaa9aff76a1de3d71c81e4b2d92e8d97ae572a8e9ab9e66599ed0912dd2f8b",
-      "extensionHash": "3f91f3c680beb26615fdec251aee3f81aaf5a02740806c167c0f3c929471df44",
-      "powSolutions": {
-        "pk": "02b3a06d6eaa8671431ba1db4dd427a77f75a5c2acbd71bfb725d38adc2b55f669",
-        "w": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
-        "n": "5939ecfee6b0d7f4",
-        "d": 0
-      },
-      "adProofsId": "86eaa41f328bee598e33e52c9e515952ad3b7874102f762847f17318a776a7ae",
-      "transactionsId": "ac80245714f25aa2fafe5494ad02a26d46e7955b8f5709f3659f1b9440797b3e",
-      "parentId": "6481752bace5fa5acba5d5ef7124d48826664742d46c974c98a2d60ace229a34"
+  "extensionId": "d16f25b14457186df4c5f6355579cc769261ce1aebc8209949ca6feadbac5a3f",
+  "difficulty": "626412390187008",
+  "votes": "040000",
+  "timestamp": 1618929697400,
+  "size": 221,
+  "stateRoot": "8ad868627ea4f7de6e2a2fe3f98fafe57f914e0f2ef3331c006def36c697f92713",
+  "height": 471746,
+  "nBits": 117586360,
+  "version": 2,
+  "id": "4caa17e62fe66ba7bd69597afdc996ae35b1ff12e0ba90c22ff288a4de10e91b",
+  "adProofsRoot": "d882aaf42e0a95eb95fcce5c3705adf758e591532f733efe790ac3c404730c39",
+  "transactionsRoot": "63eaa9aff76a1de3d71c81e4b2d92e8d97ae572a8e9ab9e66599ed0912dd2f8b",
+  "extensionHash": "3f91f3c680beb26615fdec251aee3f81aaf5a02740806c167c0f3c929471df44",
+  "powSolutions": {
+    "pk": "02b3a06d6eaa8671431ba1db4dd427a77f75a5c2acbd71bfb725d38adc2b55f669",
+    "w": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+    "n": "5939ecfee6b0d7f4",
+    "d": 0
+  },
+  "adProofsId": "86eaa41f328bee598e33e52c9e515952ad3b7874102f762847f17318a776a7ae",
+  "transactionsId": "ac80245714f25aa2fafe5494ad02a26d46e7955b8f5709f3659f1b9440797b3e",
+  "parentId": "6481752bace5fa5acba5d5ef7124d48826664742d46c974c98a2d60ace229a34"
 }]);
 
 it('TxBuilder test', async () => {
@@ -208,4 +208,39 @@ it('use signed tx outputs as inputs in a new tx', async () => {
   const new_tx_builder = TxBuilder.new(new_box_selection, tx_outputs, 0, fee, change_address, min_change_value);
   const new_tx = tx_builder.build();
   assert(new_tx != null);
+});
+
+it('Transaction::from_unsigned_tx test', async () => {
+  const recipient = Address.from_testnet_str('3WvsT2Gm4EpsM9Pg18PdY6XyhNNMqXDsvJTbbf6ihLvAmSb7u5RN');
+  const unspent_boxes = ErgoBoxes.from_boxes_json([
+    {
+      "boxId": "e56847ed19b3dc6b72828fcfb992fdf7310828cf291221269b7ffc72fd66706e",
+      "value": 67500000000,
+      "ergoTree": "100204a00b08cd021dde34603426402615658f1d970cfa7c7bd92ac81a8b16eeebff264d59ce4604ea02d192a39a8cc7a70173007301",
+      "assets": [],
+      "creationHeight": 284761,
+      "additionalRegisters": {},
+      "transactionId": "9148408c04c2e38a6402a7950d6157730fa7d49e9ab3b9cadec481d7769918e9",
+      "index": 1
+    }
+  ]);
+  const contract = Contract.pay_to_address(recipient);
+  const outbox_value = BoxValue.SAFE_USER_MIN();
+  const outbox = new ErgoBoxCandidateBuilder(outbox_value, contract, 0).build();
+  const tx_outputs = new ErgoBoxCandidates(outbox);
+  const fee = TxBuilder.SUGGESTED_TX_FEE();
+  const change_address = Address.from_testnet_str('3WvsT2Gm4EpsM9Pg18PdY6XyhNNMqXDsvJTbbf6ihLvAmSb7u5RN');
+  const min_change_value = BoxValue.SAFE_USER_MIN();
+  const data_inputs = new DataInputs();
+  const box_selector = new SimpleBoxSelector();
+  const target_balance = BoxValue.from_i64(outbox_value.as_i64().checked_add(fee.as_i64()));
+  const box_selection = box_selector.select(unspent_boxes, target_balance, new Tokens());
+  const tx_builder = TxBuilder.new(box_selection, tx_outputs, 0, fee, change_address, min_change_value);
+  tx_builder.set_data_inputs(data_inputs);
+  const tx = tx_builder.build();
+  assert(tx != null);
+  const proof = new Uint8Array([1, 1, 2, 255]);
+  const signed_tx = Transaction.from_unsigned_tx(tx, [proof]);
+  assert(signed_tx != null);
+  assert(signed_tx.inputs().get(0).spending_proof().proof().toString() == proof.toString());
 });

--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added 
 - `Box.bytes` [#390](https://github.com/ergoplatform/sigma-rust/pull/390);
 - add (Coll[Byte], Coll[Byte]) and (Long, Long) support for Constant conversion in JS [#386](https://github.com/ergoplatform/sigma-rust/pull/386);
+- extract distinct token ids on tx serialization and expose as `UnsignedTransaction::distinct_token_ids()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - add `to_bytes()` for `BoxValue` and `TokenAmount` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - `Constant::sigma_serialize_bytes()`, `ContextExtension::sigma_serialize_bytes()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - `TokenId::as_bytes()` and `BoxId::as_bytes()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);

--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added 
 - `Box.bytes` [#390](https://github.com/ergoplatform/sigma-rust/pull/390);
 - add (Coll[Byte], Coll[Byte]) and (Long, Long) support for Constant conversion in JS [#386](https://github.com/ergoplatform/sigma-rust/pull/386);
+- add `ErgoBox::serialized_additional_registers()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - add `Transaction::from_unsigned_tx()` to construct from unsigned tx + proofs [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - extract distinct token ids on tx serialization and expose as `UnsignedTransaction::distinct_token_ids()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - add `to_bytes()` for `BoxValue` and `TokenAmount` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);

--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added 
 - `Box.bytes` [#390](https://github.com/ergoplatform/sigma-rust/pull/390);
 - add (Coll[Byte], Coll[Byte]) and (Long, Long) support for Constant conversion in JS [#386](https://github.com/ergoplatform/sigma-rust/pull/386);
+- add `to_bytes()` for `BoxValue` and `TokenAmount` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - `Constant::sigma_serialize_bytes()`, `ContextExtension::sigma_serialize_bytes()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - `TokenId::as_bytes()` and `BoxId::as_bytes()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - `Coll.slice` [#309](https://github.com/ergoplatform/sigma-rust/pull/309);

--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added 
 - `Box.bytes` [#390](https://github.com/ergoplatform/sigma-rust/pull/390);
 - add (Coll[Byte], Coll[Byte]) and (Long, Long) support for Constant conversion in JS [#386](https://github.com/ergoplatform/sigma-rust/pull/386);
+- `Constant::sigma_serialize_bytes()`, `ContextExtension::sigma_serialize_bytes()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
+- `TokenId::as_bytes()` and `BoxId::as_bytes()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - `Coll.slice` [#309](https://github.com/ergoplatform/sigma-rust/pull/309);
 - Byte-wise XOR for byte arrays [#310](https://github.com/ergoplatform/sigma-rust/pull/310);
 - `Constant::from_i64_str_array` and `to_i64_str_array` for `Coll[Long]` encoding [#311](https://github.com/ergoplatform/sigma-rust/pull/311);
@@ -18,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `SubstConst` IR node and serialization [#318] (https://github.com/ergoplatform/sigma-rust/pull/318);
 - Better Debug print for EC point [#319](https://github.com/ergoplatform/sigma-rust/pull/319);
 - `Constant::from_ecpoint_bytes` to Wasm API [#324](https://github.com/ergoplatform/sigma-rust/pull/324);
+
+
+### Changed(BREAKING!):
+- `ErgoTree::to_bytes()` renamed to  `ErgoTree::sigma_serialize_bytes()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 
 ### Changed
 - `SigmaSerializable:sigma_serialize` errors are extended beyond `io::Error` [#328](https://github.com/ergoplatform/sigma-rust/pull/328);

--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added 
 - `Box.bytes` [#390](https://github.com/ergoplatform/sigma-rust/pull/390);
 - add (Coll[Byte], Coll[Byte]) and (Long, Long) support for Constant conversion in JS [#386](https://github.com/ergoplatform/sigma-rust/pull/386);
+- add `Transaction::from_unsigned_tx()` to construct from unsigned tx + proofs [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - extract distinct token ids on tx serialization and expose as `UnsignedTransaction::distinct_token_ids()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - add `to_bytes()` for `BoxValue` and `TokenAmount` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);
 - `Constant::sigma_serialize_bytes()`, `ContextExtension::sigma_serialize_bytes()` in Wasm [#387](https://github.com/ergoplatform/sigma-rust/pull/387);

--- a/ergo-lib/src/chain/digest32.rs
+++ b/ergo-lib/src/chain/digest32.rs
@@ -115,6 +115,12 @@ impl<const N: usize> SigmaSerializable for Digest<N> {
     }
 }
 
+impl AsRef<[u8]> for Digest32 {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
 /// Invalid byte array size
 #[derive(Error, Debug)]
 pub enum Digest32Error {

--- a/ergo-lib/src/chain/ergo_box.rs
+++ b/ergo-lib/src/chain/ergo_box.rs
@@ -482,16 +482,7 @@ pub fn serialize_box_with_indexed_digests<W: SigmaByteWrite>(
         }
         .and_then(|()| Ok(w.put_u64(t.amount.into())?))
     })?;
-
-    let regs_num = additional_registers.len();
-    w.put_u8(regs_num as u8)?;
-
-    additional_registers
-        .get_ordered_values()
-        .iter()
-        .try_for_each(|c| c.sigma_serialize(w))?;
-
-    Ok(())
+    additional_registers.sigma_serialize(w)
 }
 
 /// Box deserialization with token ids optionally parsed in transaction
@@ -526,13 +517,8 @@ pub fn parse_box_with_indexed_digests<R: SigmaByteRead>(
         })
     }
 
-    let regs_num = r.get_u8()?;
-    let mut additional_regs = Vec::with_capacity(regs_num as usize);
-    for _ in 0..regs_num {
-        let v = Constant::sigma_parse(r)?;
-        additional_regs.push(v);
-    }
-    let additional_registers = NonMandatoryRegisters::from_ordered_values(additional_regs)?;
+    let additional_registers = NonMandatoryRegisters::sigma_parse(r)?;
+
     Ok(ErgoBoxCandidate {
         value,
         ergo_tree,

--- a/ergo-lib/src/chain/ergo_box/box_id.rs
+++ b/ergo-lib/src/chain/ergo_box/box_id.rs
@@ -36,6 +36,12 @@ impl BoxId {
     }
 }
 
+impl AsRef<[u8]> for BoxId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 #[cfg(feature = "json")]
 impl From<BoxId> for String {
     fn from(v: BoxId) -> Self {

--- a/ergo-lib/src/chain/token.rs
+++ b/ergo-lib/src/chain/token.rs
@@ -39,6 +39,18 @@ impl From<TokenId> for Vec<i8> {
     }
 }
 
+impl From<TokenId> for Vec<u8> {
+    fn from(v: TokenId) -> Self {
+        v.0.into()
+    }
+}
+
+impl AsRef<[u8]> for TokenId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl From<TokenId> for String {
     fn from(v: TokenId) -> Self {
         v.0.into()

--- a/ergo-lib/src/chain/token.rs
+++ b/ergo-lib/src/chain/token.rs
@@ -102,6 +102,11 @@ impl TokenAmount {
             Ok(Self(raw))
         }
     }
+
+    /// Get the value as u64
+    pub fn as_u64(&self) -> &u64 {
+        &self.0
+    }
 }
 
 /// BoxValue errors

--- a/ergo-lib/src/chain/transaction.rs
+++ b/ergo-lib/src/chain/transaction.rs
@@ -64,6 +64,12 @@ impl From<TxId> for String {
     }
 }
 
+impl AsRef<[u8]> for TxId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 /// BouncedVec type for Tx inputs and output_candidates
 pub type TxIoVec<T> = BoundedVec<T, 1, { u16::MAX as usize }>;
 

--- a/ergo-lib/src/chain/transaction.rs
+++ b/ergo-lib/src/chain/transaction.rs
@@ -156,11 +156,12 @@ impl Transaction {
                 proofs
                     .get(index)
                     .map(|proof| Input::from_unsigned_input(unsigned_input, proof.clone()))
-                    // TODO: make new error type?
-                    .ok_or(TransactionError::InvalidArgument(format!(
-                        "no proof for input index: {}",
-                        index
-                    )))
+                    .ok_or_else(|| {
+                        TransactionError::InvalidArgument(format!(
+                            "no proof for input index: {}",
+                            index
+                        ))
+                    })
             })?;
         Ok(Transaction::new(
             inputs,

--- a/ergo-lib/src/chain/transaction/input.rs
+++ b/ergo-lib/src/chain/transaction/input.rs
@@ -88,6 +88,17 @@ impl Input {
         }
     }
 
+    /// Create Input from UnsignedInput and a proof
+    pub fn from_unsigned_input(unsigned_input: UnsignedInput, proof_bytes: ProofBytes) -> Self {
+        Self::new(
+            unsigned_input.box_id,
+            ProverResult {
+                proof: proof_bytes,
+                extension: unsigned_input.extension,
+            },
+        )
+    }
+
     /// input with an empty proof
     pub fn input_to_sign(&self) -> Input {
         Input {


### PR DESCRIPTION
Close #384

Todo:
- [x] TokenId::as_bytes()
- [x] Constant::sigma_serialize_bytes()
- [x] BoxId::as_bytes()
- [x] rename ErgoTree::to_bytes() to ErgoTree::sigma_serialize_bytes()
- [x] BoxValue and TokenAmounts to big-endian bytes
- [x] ErgoBox:: serialized_registers (count and serialized registers)
- [x] UnsignedTransaction::get_distinct_token_ids() return [TokenId]
- [x] ContextExtension::sigma_serialize_bytes
- [x] make Transaction from UnsignedTransaction + [ProofBytes]
- [x] ErgoBox::tx_id and ErgoBox::index;