### PR TITLE
Implement missing IR nodes for  EIP-22 auction contract;

### DIFF
--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased] - ReleaseDate
 
 ### Added 
+- `Box.bytes` [#390](https://github.com/ergoplatform/sigma-rust/pull/390);
 - add (Coll[Byte], Coll[Byte]) and (Long, Long) support for Constant conversion in JS [#386](https://github.com/ergoplatform/sigma-rust/pull/386);
 - `Coll.slice` [#309](https://github.com/ergoplatform/sigma-rust/pull/309);
 - Byte-wise XOR for byte arrays [#310](https://github.com/ergoplatform/sigma-rust/pull/310);

--- a/ergo-lib/src/chain/ergo_box.rs
+++ b/ergo-lib/src/chain/ergo_box.rs
@@ -199,7 +199,7 @@ impl IrErgoBox for ErgoBox {
     }
 
     fn script_bytes(&self) -> Result<Vec<i8>, SigmaSerializationError> {
-        Ok(self.sigma_serialize_bytes()?.as_vec_i8())
+        Ok(self.ergo_tree.sigma_serialize_bytes()?.as_vec_i8())
     }
 
     /// Tuple of height when block got included into the blockchain and transaction identifier with
@@ -209,6 +209,10 @@ impl IrErgoBox for ErgoBox {
         bytes.extend_from_slice(self.transaction_id.0 .0.as_ref());
         bytes.extend_from_slice(&self.index.to_be_bytes());
         (self.creation_height as i32, bytes.as_vec_i8())
+    }
+
+    fn bytes(&self) -> Result<Vec<i8>, SigmaSerializationError> {
+        Ok(self.sigma_serialize_bytes()?.as_vec_i8())
     }
 }
 

--- a/ergotree-interpreter/src/contracts.rs
+++ b/ergotree-interpreter/src/contracts.rs
@@ -280,4 +280,14 @@ mod tests {
         //     .unwrap();
         // assert!(!res);
     }
+
+    #[test]
+    fn eip_22_auction() {
+        // from https://github.com/ergoplatform/eips/blob/adbe21512cadf51a2d9af8406cfd418f95335899/eip-0022.md
+        let p2s_str = "GE68RH3VEgW6b4kN3GhYigrLxoXr9jMgMpmm3KnXJaYq1PzHieYhz7Uka86idxvBWLRLmpiA3HrxHPsX1jzQZEv5yaRDueiJqks1keM7iB1eYWMEVRUUq1MLFzdA1FHQwCfSakM3Uc8uBPqk2icxhoXvw1CVbUVtFCzcPrZzf8Jjf8gS5bCFpWQscHo14HTsdBxyV3dwL6wKu8LP8FuWJE7qCEgX9ToEiztH4ZLmFwBejnUFrCQqjLVLWpdgdnAXVyewiX9DxXKJKL4wNqhPUrYjmHEVvpZAezXjzfVMr7gKupTqAgx2AJYGh4winEDeYq9MVshX8xjJweGhbAm2RXN1euQpoepFaKqfrT2mQBTmr6edbbzYg6VJ7DoSCDzmcUupFAmZMjMiaUbgtyz2VEbPEKsmAFrZ6zdB5EUxhiYZMd6KdstsJwZCgKJSSCShTgpfqNLCdpR9JbZFQpA1uhUkuLMPvGi74V5EwijTEEtjmTVcWcVhJKv4GDr1Lqe2bMPq4jfEfqvemaY8FcrCsCSi2LZoQUeJ9VrBeotGTKccq8JhwnvNGhLUUrrm32v3bhU82jbtVBVFRD3FSv5hhS6pKHtTevjwuG7JWoR3LN7279A7zQGJWmkSWDoEhHjgxseqZ2G5bLB7ZVEzKM261QhwMwmXA1eWgq8zdBH1u9kFC9bMQ812q2DPZTuhzpBWJh74UGwaEgZLhnUrDKT58cEa4R3kfWyGCMoNw78q1E3a2eKDz8Va5wnixzT2SZFHU8DfHjPSz5rm8Mr3YxgRC6GzaasPDxTrZjuMJHU2exhqsoFvur7Q";
+
+        let encoder = AddressEncoder::new(NetworkPrefix::Mainnet);
+        let addr = encoder.parse_address_from_str(p2s_str).unwrap();
+        let _script: Rc<Expr> = addr.script().unwrap().proposition().unwrap();
+    }
 }

--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -53,6 +53,7 @@ mod deserialize_register;
 pub(crate) mod exponentiate;
 pub(crate) mod expr;
 pub(crate) mod extract_amount;
+pub(crate) mod extract_bytes;
 pub(crate) mod extract_creation_info;
 pub(crate) mod extract_id;
 pub(crate) mod extract_reg_as;

--- a/ergotree-interpreter/src/eval/context/ir_ergo_box_dummy.rs
+++ b/ergotree-interpreter/src/eval/context/ir_ergo_box_dummy.rs
@@ -30,6 +30,7 @@ pub(crate) struct IrErgoBoxDummy {
     pub(crate) creation_height: i32,
     pub(crate) script_bytes: Vec<i8>,
     pub(crate) creation_info: (i32, Vec<i8>),
+    pub(crate) sigma_serialize_bytes: Vec<i8>,
 }
 
 impl IrErgoBox for IrErgoBoxDummy {
@@ -70,6 +71,10 @@ impl IrErgoBox for IrErgoBoxDummy {
     fn creation_info(&self) -> (i32, Vec<i8>) {
         self.creation_info.clone()
     }
+
+    fn bytes(&self) -> Result<Vec<i8>, SigmaSerializationError> {
+        Ok(self.sigma_serialize_bytes.clone())
+    }
 }
 
 #[cfg(feature = "arbitrary")]
@@ -93,6 +98,7 @@ pub(crate) mod arbitrary {
                 1i32..1000,
                 vec(any::<Constant>(), 0..5),
                 vec(any::<i8>(), 100..1000),
+                vec(any::<i8>(), 100..1000),
                 vec(any::<i8>(), DIGEST32_SIZE + 2..=DIGEST32_SIZE + 2),
             )
                 .prop_map(
@@ -103,6 +109,7 @@ pub(crate) mod arbitrary {
                         creation_height,
                         additional_registers,
                         script_bytes,
+                        sigma_serialize_bytes,
                         tx_id_box_index,
                     )| {
                         Self {
@@ -115,6 +122,7 @@ pub(crate) mod arbitrary {
                             additional_registers,
                             creation_height,
                             script_bytes,
+                            sigma_serialize_bytes,
                             creation_info: (creation_height, tx_id_box_index),
                         }
                     },

--- a/ergotree-interpreter/src/eval/expr.rs
+++ b/ergotree-interpreter/src/eval/expr.rs
@@ -75,6 +75,7 @@ impl Evaluable for Expr {
             Expr::MultiplyGroup(op) => op.eval(env, ctx),
             Expr::Exponentiate(op) => op.eval(env, ctx),
             Expr::XorOf(op) => op.eval(env, ctx),
+            Expr::ExtractBytes(op) => op.eval(env, ctx),
         }
     }
 }

--- a/ergotree-interpreter/src/eval/extract_bytes.rs
+++ b/ergotree-interpreter/src/eval/extract_bytes.rs
@@ -1,0 +1,49 @@
+use ergotree_ir::mir::extract_bytes::ExtractBytes;
+use ergotree_ir::mir::value::Value;
+
+use crate::eval::env::Env;
+use crate::eval::EvalContext;
+use crate::eval::EvalError;
+use crate::eval::Evaluable;
+
+impl Evaluable for ExtractBytes {
+    fn eval(&self, env: &Env, ctx: &mut EvalContext) -> Result<Value, EvalError> {
+        let input_v = self.input.eval(env, ctx)?;
+        match input_v {
+            Value::CBox(b) => Ok(ctx.ctx.box_arena.get(&b)?.bytes()?.into()),
+            _ => Err(EvalError::UnexpectedValue(format!(
+                "Expected ExtractBytes input to be Value::CBox, got {0:?}",
+                input_v
+            ))),
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::context::Context;
+    use crate::eval::tests::eval_out;
+    use ergotree_ir::mir::expr::Expr;
+    use ergotree_ir::mir::global_vars::GlobalVars;
+    use sigma_test_util::force_any_val;
+    use std::rc::Rc;
+
+    #[test]
+    fn eval() {
+        let e: Expr = ExtractBytes {
+            input: Box::new(GlobalVars::SelfBox.into()),
+        }
+        .into();
+        let ctx = Rc::new(force_any_val::<Context>());
+        assert_eq!(
+            eval_out::<Vec<i8>>(&e, ctx.clone()),
+            ctx.self_box
+                .get_box(&ctx.box_arena)
+                .unwrap()
+                .bytes()
+                .unwrap()
+        );
+    }
+}

--- a/ergotree-ir/README.md
+++ b/ergotree-ir/README.md
@@ -32,7 +32,6 @@ Descriptions for the operations can be found in [ErgoTree Specification](https:/
 
 #### Box
 
-- bytes
 - bytesWithoutRef
 
 #### AvlTree 
@@ -164,6 +163,7 @@ Descriptions for the operations can be found in [ErgoTree Specification](https:/
 - getReg
 - tokens
 - R0 .. R9
+- bytes
 
 #### Context
 

--- a/ergotree-ir/src/ir_ergo_box.rs
+++ b/ergotree-ir/src/ir_ergo_box.rs
@@ -60,4 +60,6 @@ pub trait IrErgoBox: Debug {
     /// Tuple of height when block got included into the blockchain and transaction identifier with
     /// box index in the transaction outputs serialized to the byte array.
     fn creation_info(&self) -> (i32, Vec<i8>);
+    /// Box serialized bytes
+    fn bytes(&self) -> Result<Vec<i8>, SigmaSerializationError>;
 }

--- a/ergotree-ir/src/mir.rs
+++ b/ergotree-ir/src/mir.rs
@@ -47,6 +47,8 @@ pub mod exponentiate;
 pub mod expr;
 /// Box value
 pub mod extract_amount;
+/// Box.bytes (serialized box bytes)
+pub mod extract_bytes;
 /// Box.creationInfo (height, tx id + box index)
 pub mod extract_creation_info;
 /// Box id, Blake2b256 hash of this box's content, basically equals to `blake2b256(bytes)`

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -33,6 +33,7 @@ use super::create_provedlog::CreateProveDlog;
 use super::decode_point::DecodePoint;
 use super::exponentiate::Exponentiate;
 use super::extract_amount::ExtractAmount;
+use super::extract_bytes::ExtractBytes;
 use super::extract_creation_info::ExtractCreationInfo;
 use super::extract_id::ExtractId;
 use super::extract_reg_as::ExtractRegisterAs;
@@ -149,6 +150,8 @@ pub enum Expr {
     ExtractAmount(ExtractAmount),
     /// Extract register's value (box.RX properties)
     ExtractRegisterAs(ExtractRegisterAs),
+    /// Extract serialized box bytes
+    ExtractBytes(ExtractBytes),
     /// Extract box's guarding script serialized to bytes
     ExtractScriptBytes(ExtractScriptBytes),
     /// Tuple of height when block got included into the blockchain and transaction identifier with
@@ -273,6 +276,7 @@ impl Expr {
             Expr::MultiplyGroup(v) => v.tpe(),
             Expr::Exponentiate(v) => v.tpe(),
             Expr::XorOf(v) => v.tpe(),
+            Expr::ExtractBytes(v) => v.tpe(),
         }
     }
 

--- a/ergotree-ir/src/mir/extract_bytes.rs
+++ b/ergotree-ir/src/mir/extract_bytes.rs
@@ -1,0 +1,58 @@
+use crate::serialization::op_code::OpCode;
+use crate::types::stype::SType;
+
+use super::expr::Expr;
+use super::expr::InvalidArgumentError;
+use super::unary_op::OneArgOp;
+use super::unary_op::OneArgOpTryBuild;
+use crate::has_opcode::HasStaticOpCode;
+
+/// Serialized box bytes
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct ExtractBytes {
+    /// Box, type of SBox
+    pub input: Box<Expr>,
+}
+
+impl ExtractBytes {
+    /// Type
+    pub fn tpe(&self) -> SType {
+        SType::SColl(SType::SByte.into())
+    }
+}
+
+impl HasStaticOpCode for ExtractBytes {
+    const OP_CODE: OpCode = OpCode::EXTRACT_BYTES;
+}
+
+impl OneArgOp for ExtractBytes {
+    fn input(&self) -> &Expr {
+        &self.input
+    }
+}
+
+impl OneArgOpTryBuild for ExtractBytes {
+    fn try_build(input: Expr) -> Result<Self, InvalidArgumentError> {
+        input.check_post_eval_tpe(&SType::SBox)?;
+        Ok(ExtractBytes {
+            input: input.into(),
+        })
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "arbitrary")]
+mod tests {
+    use super::*;
+    use crate::mir::global_vars::GlobalVars;
+    use crate::serialization::sigma_serialize_roundtrip;
+
+    #[test]
+    fn ser_roundtrip() {
+        let e: Expr = ExtractBytes {
+            input: Box::new(GlobalVars::SelfBox.into()),
+        }
+        .into();
+        assert_eq![sigma_serialize_roundtrip(&e), e];
+    }
+}

--- a/ergotree-ir/src/serialization/expr.rs
+++ b/ergotree-ir/src/serialization/expr.rs
@@ -39,6 +39,7 @@ use crate::mir::deserialize_register::DeserializeRegister;
 use crate::mir::exponentiate::Exponentiate;
 use crate::mir::expr::Expr;
 use crate::mir::extract_amount::ExtractAmount;
+use crate::mir::extract_bytes::ExtractBytes;
 use crate::mir::extract_creation_info::ExtractCreationInfo;
 use crate::mir::extract_id::ExtractId;
 use crate::mir::extract_reg_as::ExtractRegisterAs;
@@ -114,6 +115,7 @@ impl Expr {
                 OptionGetOrElse::OP_CODE => Ok(OptionGetOrElse::sigma_parse(r)?.into()),
                 ExtractRegisterAs::OP_CODE => Ok(ExtractRegisterAs::sigma_parse(r)?.into()),
                 ExtractScriptBytes::OP_CODE => Ok(ExtractScriptBytes::sigma_parse(r)?.into()),
+                ExtractBytes::OP_CODE => Ok(ExtractBytes::sigma_parse(r)?.into()),
                 ExtractCreationInfo::OP_CODE => Ok(ExtractCreationInfo::sigma_parse(r)?.into()),
                 ExtractId::OP_CODE => Ok(ExtractId::sigma_parse(r)?.into()),
                 OpCode::EQ => Ok(bin_op_sigma_parse(RelationOp::Eq.into(), r)?),
@@ -276,6 +278,7 @@ impl SigmaSerializable for Expr {
             Expr::MultiplyGroup(op) => op.sigma_serialize_w_opcode(w),
             Expr::Exponentiate(op) => op.sigma_serialize_w_opcode(w),
             Expr::XorOf(op) => op.sigma_serialize_w_opcode(w),
+            Expr::ExtractBytes(op) => op.sigma_serialize_w_opcode(w),
         }
     }
 


### PR DESCRIPTION
Contract - https://github.com/ergoplatform/eips/blob/adbe21512cadf51a2d9af8406cfd418f95335899/eip-0022.md

Todo:
- [x] `box.bytes` (`ExtractBytes` IR node);