### PR TITLE
Add field aliases for Explorer API

### DIFF
--- a/ergo-lib/src/chain/ergo_box.rs
+++ b/ergo-lib/src/chain/ergo_box.rs
@@ -61,7 +61,7 @@ use std::convert::TryInto;
 #[cfg_attr(feature = "json", serde(try_from = "json::ergo_box::ErgoBoxFromJson"))]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct ErgoBox {
-    #[cfg_attr(feature = "json", serde(rename = "boxId"))]
+    #[cfg_attr(feature = "json", serde(rename = "boxId", alias = "id"))]
     box_id: BoxId,
     /// amount of money associated with the box
     #[cfg_attr(feature = "json", serde(rename = "value"))]
@@ -81,7 +81,7 @@ pub struct ErgoBox {
     #[cfg_attr(feature = "json", serde(rename = "creationHeight"))]
     pub creation_height: u32,
     /// id of transaction which created the box
-    #[cfg_attr(feature = "json", serde(rename = "transactionId"))]
+    #[cfg_attr(feature = "json", serde(rename = "transactionId", alias = "txId"))]
     pub transaction_id: TxId,
     /// number of box (from 0 to total number of boxes the transaction with transactionId created - 1)
     #[cfg_attr(feature = "json", serde(rename = "index"))]

--- a/ergo-lib/src/chain/transaction/data_input.rs
+++ b/ergo-lib/src/chain/transaction/data_input.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
 pub struct DataInput {
     /// id of the box to add into context (should be in UTXO)
-    #[cfg_attr(feature = "json", serde(rename = "boxId"))]
+    #[cfg_attr(feature = "json", serde(rename = "boxId", alias = "id"))]
     pub box_id: BoxId,
 }
 

--- a/ergo-lib/src/chain/transaction/input.rs
+++ b/ergo-lib/src/chain/transaction/input.rs
@@ -72,7 +72,7 @@ impl<T: ErgoBoxId> From<T> for UnsignedInput {
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
 pub struct Input {
     /// id of the box to spent
-    #[cfg_attr(feature = "json", serde(rename = "boxId"))]
+    #[cfg_attr(feature = "json", serde(rename = "boxId", alias = "id"))]
     pub box_id: BoxId,
     /// proof of spending correctness
     #[cfg_attr(feature = "json", serde(rename = "spendingProof",))]


### PR DESCRIPTION
Note: v1 of the Explorer API is consistent with the Node API.
Differences only appear in v0 of the Explorer API.

Close #152