### PR TITLE
Downcast IR node implementation

### DIFF
--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -50,6 +50,7 @@ pub(crate) mod create_provedlog;
 pub(crate) mod decode_point;
 mod deserialize_context;
 mod deserialize_register;
+pub(crate) mod downcast;
 pub(crate) mod exponentiate;
 pub(crate) mod expr;
 pub(crate) mod extract_amount;

--- a/ergotree-interpreter/src/eval/downcast.rs
+++ b/ergotree-interpreter/src/eval/downcast.rs
@@ -1,0 +1,425 @@
+use ergotree_ir::bigint256::BigInt256;
+use ergotree_ir::mir::downcast::Downcast;
+use ergotree_ir::mir::value::Value;
+use ergotree_ir::types::stype::SType;
+
+use crate::eval::env::Env;
+use crate::eval::EvalContext;
+use crate::eval::EvalError;
+use crate::eval::Evaluable;
+use std::convert::TryFrom;
+
+fn downcast_to_bigint(in_v: Value) -> Result<Value, EvalError> {
+    match in_v {
+        Value::Byte(v) => Ok(BigInt256::from(v).into()),
+        Value::Short(v) => Ok(BigInt256::from(v).into()),
+        Value::Int(v) => Ok(BigInt256::from(v).into()),
+        Value::Long(v) => Ok(BigInt256::from(v).into()),
+        _ => Err(EvalError::UnexpectedValue(format!(
+            "Downcast: cannot downcast {0:?} to BigInt",
+            in_v
+        ))),
+    }
+}
+
+fn downcast_to_long(in_v: Value) -> Result<Value, EvalError> {
+    match in_v {
+        Value::Byte(v) => Ok((v as i64).into()),
+        Value::Short(v) => Ok((v as i64).into()),
+        Value::Int(v) => Ok((v as i64).into()),
+        Value::Long(_) => Ok(in_v),
+        _ => Err(EvalError::UnexpectedValue(format!(
+            "Downcast: cannot downcast {0:?} to Long",
+            in_v
+        ))),
+    }
+}
+
+fn downcast_to_int(in_v: Value) -> Result<Value, EvalError> {
+    match in_v {
+        Value::Byte(x) => Ok((x as i32).into()),
+        Value::Short(s) => Ok((s as i32).into()),
+        Value::Int(_) => Ok(in_v),
+        Value::Long(l) => match i32::try_from(l).ok() {
+            Some(v) => Ok(v.into()),
+            _ => Err(EvalError::UnexpectedValue(
+                "Downcast: Int overflow".to_string(),
+            )),
+        },
+        _ => Err(EvalError::UnexpectedValue(format!(
+            "Downcast: cannot downcast {0:?} to Int",
+            in_v
+        ))),
+    }
+}
+
+fn downcast_to_short(in_v: Value) -> Result<Value, EvalError> {
+    match in_v {
+        Value::Short(_) => Ok(in_v),
+        Value::Int(i) => match i16::try_from(i).ok() {
+            Some(v) => Ok(v.into()),
+            _ => Err(EvalError::UnexpectedValue(
+                "Downcast: Short overflow".to_string(),
+            )),
+        },
+        Value::Long(l) => match i16::try_from(l).ok() {
+            Some(v) => Ok(v.into()),
+            _ => Err(EvalError::UnexpectedValue(
+                "Downcast: Short overflow".to_string(),
+            )),
+        },
+        _ => Err(EvalError::UnexpectedValue(format!(
+            "Downcast: cannot downcast {0:?} to Short",
+            in_v
+        ))),
+    }
+}
+
+fn downcast_to_byte(in_v: Value) -> Result<Value, EvalError> {
+    match in_v {
+        Value::Byte(_) => Ok(in_v),
+        Value::Short(s) => match i8::try_from(s).ok() {
+            Some(v) => Ok(v.into()),
+            _ => Err(EvalError::UnexpectedValue(
+                "Downcast: Byte overflow".to_string(),
+            )),
+        },
+        Value::Int(i) => match i8::try_from(i).ok() {
+            Some(v) => Ok(v.into()),
+            _ => Err(EvalError::UnexpectedValue(
+                "Downcast: Byte overflow".to_string(),
+            )),
+        },
+        Value::Long(l) => match i8::try_from(l).ok() {
+            Some(v) => Ok(v.into()),
+            _ => Err(EvalError::UnexpectedValue(
+                "Downcast: Byte overflow".to_string(),
+            )),
+        },
+        _ => Err(EvalError::UnexpectedValue(format!(
+            "Downcast: cannot downcast {0:?} to Byte",
+            in_v
+        ))),
+    }
+}
+
+impl Evaluable for Downcast {
+    fn eval(&self, env: &Env, ctx: &mut EvalContext) -> Result<Value, EvalError> {
+        let input_v = self.input.eval(env, ctx)?;
+        match self.tpe {
+            SType::SBigInt => downcast_to_bigint(input_v),
+            SType::SLong => downcast_to_long(input_v),
+            SType::SInt => downcast_to_int(input_v),
+            SType::SShort => downcast_to_short(input_v),
+            SType::SByte => downcast_to_byte(input_v),
+            _ => Err(EvalError::UnexpectedValue(format!(
+                "Downcast: expected numeric value, got {0:?}",
+                input_v
+            ))),
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod tests {
+    use ergotree_ir::mir::constant::Constant;
+    use sigma_test_util::force_any_val;
+
+    use crate::eval::tests::{eval_out_wo_ctx, try_eval_out_wo_ctx};
+
+    use super::*;
+
+    #[test]
+    fn to_bigint() {
+        let v_byte = force_any_val::<i8>();
+        let v_short = force_any_val::<i16>();
+        let v_int = force_any_val::<i32>();
+        let v_long = force_any_val::<i64>();
+
+        let c_byte: Constant = v_byte.into();
+        let c_short: Constant = v_short.into();
+        let c_int: Constant = v_int.into();
+        let c_long: Constant = v_long.into();
+
+        assert_eq!(
+            eval_out_wo_ctx::<BigInt256>(
+                &Downcast::new(c_byte.clone().into(), SType::SBigInt)
+                    .unwrap()
+                    .into()
+            ),
+            (v_byte as i64).into()
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<BigInt256>(
+                &Downcast::new(c_short.clone().into(), SType::SBigInt)
+                    .unwrap()
+                    .into()
+            ),
+            (v_short as i64).into()
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<BigInt256>(
+                &Downcast::new(c_int.clone().into(), SType::SBigInt)
+                    .unwrap()
+                    .into()
+            ),
+            (v_int as i64).into()
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<BigInt256>(
+                &Downcast::new(c_long.clone().into(), SType::SBigInt)
+                    .unwrap()
+                    .into()
+            ),
+            (v_long as i64).into()
+        );
+    }
+
+    #[test]
+    fn to_long() {
+        let v_byte = force_any_val::<i8>();
+        let v_short = force_any_val::<i16>();
+        let v_int = force_any_val::<i32>();
+        let v_long = force_any_val::<i64>();
+
+        let c_byte: Constant = v_byte.into();
+        let c_short: Constant = v_short.into();
+        let c_int: Constant = v_int.into();
+        let c_long: Constant = v_long.into();
+
+        assert_eq!(
+            eval_out_wo_ctx::<i64>(
+                &Downcast::new(c_byte.clone().into(), SType::SLong)
+                    .unwrap()
+                    .into()
+            ),
+            v_byte as i64
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<i64>(
+                &Downcast::new(c_short.clone().into(), SType::SLong)
+                    .unwrap()
+                    .into()
+            ),
+            v_short as i64
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<i64>(
+                &Downcast::new(c_int.clone().into(), SType::SLong)
+                    .unwrap()
+                    .into()
+            ),
+            v_int as i64
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<i64>(
+                &Downcast::new(c_long.clone().into(), SType::SLong)
+                    .unwrap()
+                    .into()
+            ),
+            v_long as i64
+        );
+    }
+
+    #[test]
+    fn to_int() {
+        let v_byte = force_any_val::<i8>();
+        let v_short = force_any_val::<i16>();
+        let v_int = force_any_val::<i32>();
+        let v_long = v_int as i64;
+        let v_long_oob = if v_long.is_positive() {
+            v_long + i32::MAX as i64
+        } else {
+            v_long - i32::MAX as i64
+        };
+
+        let c_byte: Constant = v_byte.into();
+        let c_short: Constant = v_short.into();
+        let c_int: Constant = v_int.into();
+        let c_long: Constant = v_long.into();
+        let c_long_oob: Constant = v_long_oob.into();
+
+        assert_eq!(
+            eval_out_wo_ctx::<i32>(
+                &Downcast::new(c_byte.clone().into(), SType::SInt)
+                    .unwrap()
+                    .into()
+            ),
+            v_byte as i32
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<i32>(
+                &Downcast::new(c_short.clone().into(), SType::SInt)
+                    .unwrap()
+                    .into()
+            ),
+            v_short as i32
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<i32>(
+                &Downcast::new(c_int.clone().into(), SType::SInt)
+                    .unwrap()
+                    .into()
+            ),
+            v_int as i32
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<i32>(
+                &Downcast::new(c_long.clone().into(), SType::SInt)
+                    .unwrap()
+                    .into()
+            ),
+            v_long as i32
+        );
+        assert!(try_eval_out_wo_ctx::<i32>(
+            &Downcast::new(c_long_oob.clone().into(), SType::SInt)
+                .unwrap()
+                .into()
+        )
+        .is_err())
+    }
+
+    #[test]
+    fn to_short() {
+        let v_short = force_any_val::<i16>();
+        let v_int = v_short as i32;
+        let v_int_oob = if v_int.is_positive() {
+            v_int + i16::MAX as i32
+        } else {
+            v_int - i16::MAX as i32
+        };
+        let v_long = v_short as i64;
+        let v_long_oob = if v_long.is_positive() {
+            v_long + i16::MAX as i64
+        } else {
+            v_long - i16::MAX as i64
+        };
+
+        let c_short: Constant = v_short.into();
+        let c_int: Constant = v_int.into();
+        let c_int_oob: Constant = v_int_oob.into();
+        let c_long: Constant = v_long.into();
+        let c_long_oob: Constant = v_long_oob.into();
+
+        assert_eq!(
+            eval_out_wo_ctx::<i16>(
+                &Downcast::new(c_short.clone().into(), SType::SShort)
+                    .unwrap()
+                    .into()
+            ),
+            v_short as i16
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<i16>(
+                &Downcast::new(c_int.clone().into(), SType::SShort)
+                    .unwrap()
+                    .into()
+            ),
+            v_int as i16
+        );
+        assert!(try_eval_out_wo_ctx::<i16>(
+            &Downcast::new(c_int_oob.clone().into(), SType::SShort)
+                .unwrap()
+                .into()
+        )
+        .is_err());
+
+        assert_eq!(
+            eval_out_wo_ctx::<i16>(
+                &Downcast::new(c_long.clone().into(), SType::SShort)
+                    .unwrap()
+                    .into()
+            ),
+            v_long as i16
+        );
+        assert!(try_eval_out_wo_ctx::<i16>(
+            &Downcast::new(c_long_oob.clone().into(), SType::SShort)
+                .unwrap()
+                .into()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn to_byte() {
+        let v_byte = force_any_val::<i8>();
+        let v_short = v_byte as i16;
+        let v_short_oob = if v_short.is_positive() {
+            v_short + i8::MAX as i16
+        } else {
+            v_short - i8::MAX as i16
+        };
+        let v_int = v_byte as i32;
+        let v_int_oob = if v_int.is_positive() {
+            v_int + i8::MAX as i32
+        } else {
+            v_int - i8::MAX as i32
+        };
+        let v_long = v_byte as i64;
+        let v_long_oob = if v_long.is_positive() {
+            v_long + i8::MAX as i64
+        } else {
+            v_long - i8::MAX as i64
+        };
+
+        let c_byte: Constant = v_byte.into();
+        let c_short: Constant = v_short.into();
+        let c_short_oob: Constant = v_short_oob.into();
+        let c_int: Constant = v_int.into();
+        let c_int_oob: Constant = v_int_oob.into();
+        let c_long: Constant = v_long.into();
+        let c_long_oob: Constant = v_long_oob.into();
+
+        assert_eq!(
+            eval_out_wo_ctx::<i8>(
+                &Downcast::new(c_byte.clone().into(), SType::SByte)
+                    .unwrap()
+                    .into()
+            ),
+            v_byte
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<i8>(
+                &Downcast::new(c_short.clone().into(), SType::SByte)
+                    .unwrap()
+                    .into()
+            ),
+            v_short as i8
+        );
+        assert!(try_eval_out_wo_ctx::<i8>(
+            &Downcast::new(c_short_oob.clone().into(), SType::SByte)
+                .unwrap()
+                .into()
+        )
+        .is_err());
+        assert_eq!(
+            eval_out_wo_ctx::<i8>(
+                &Downcast::new(c_int.clone().into(), SType::SByte)
+                    .unwrap()
+                    .into()
+            ),
+            v_int as i8
+        );
+        assert!(try_eval_out_wo_ctx::<i8>(
+            &Downcast::new(c_int_oob.clone().into(), SType::SByte)
+                .unwrap()
+                .into()
+        )
+        .is_err());
+        assert_eq!(
+            eval_out_wo_ctx::<i8>(
+                &Downcast::new(c_long.clone().into(), SType::SByte)
+                    .unwrap()
+                    .into()
+            ),
+            v_long as i8
+        );
+        assert!(try_eval_out_wo_ctx::<i8>(
+            &Downcast::new(c_long_oob.clone().into(), SType::SByte)
+                .unwrap()
+                .into()
+        )
+        .is_err());
+    }
+}

--- a/ergotree-interpreter/src/eval/expr.rs
+++ b/ergotree-interpreter/src/eval/expr.rs
@@ -48,6 +48,7 @@ impl Evaluable for Expr {
             Expr::Filter(op) => op.eval(env, ctx),
             Expr::BoolToSigmaProp(op) => op.eval(env, ctx),
             Expr::Upcast(op) => op.eval(env, ctx),
+            Expr::Downcast(op) => op.eval(env, ctx),
             Expr::If(op) => op.eval(env, ctx),
             Expr::Append(op) => op.eval(env, ctx),
             Expr::ByIndex(op) => op.eval(env, ctx),

--- a/ergotree-interpreter/src/lib.rs
+++ b/ergotree-interpreter/src/lib.rs
@@ -17,7 +17,6 @@
 #![deny(clippy::todo)]
 #![deny(clippy::unimplemented)]
 #![deny(clippy::panic)]
-
 mod contracts;
 mod util;
 

--- a/ergotree-ir/src/mir.rs
+++ b/ergotree-ir/src/mir.rs
@@ -42,6 +42,8 @@ pub mod create_provedlog;
 pub mod decode_point;
 pub mod deserialize_context;
 pub mod deserialize_register;
+/// Numerical downcast
+pub mod downcast;
 /// Exponentiate op for GroupElement
 pub mod exponentiate;
 pub mod expr;
@@ -94,6 +96,7 @@ pub mod subst_const;
 /// Tuple of elements
 pub mod tuple;
 pub mod unary_op;
+/// Numerical upcast
 pub mod upcast;
 /// Variable definition
 pub mod val_def;

--- a/ergotree-ir/src/mir/downcast.rs
+++ b/ergotree-ir/src/mir/downcast.rs
@@ -1,0 +1,111 @@
+//! Numerical downcast
+
+use super::expr::Expr;
+use super::expr::InvalidArgumentError;
+use crate::serialization::op_code::OpCode;
+use crate::serialization::sigma_byte_reader::SigmaByteRead;
+use crate::serialization::sigma_byte_writer::SigmaByteWrite;
+use crate::serialization::SigmaParsingError;
+use crate::serialization::SigmaSerializable;
+use crate::serialization::SigmaSerializeResult;
+use crate::types::stype::SType;
+
+use crate::has_opcode::HasStaticOpCode;
+
+/// Numerical downcast
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct Downcast {
+    /// Numerical value to be downcast
+    pub input: Box<Expr>,
+    /// Target type for the input value to be downcast to
+    pub tpe: SType,
+}
+
+impl Downcast {
+    /// Create new object, returns an error if any of the requirements failed
+    pub fn new(input: Expr, target_tpe: SType) -> Result<Self, InvalidArgumentError> {
+        if !target_tpe.is_numeric() {
+            return Err(InvalidArgumentError(format!(
+                "Downcast: expected target type to be numeric, got {:?}",
+                target_tpe
+            )));
+        }
+        let post_eval_tpe = input.post_eval_tpe();
+        if post_eval_tpe.is_numeric() {
+            Ok(Self {
+                input: input.into(),
+                tpe: target_tpe,
+            })
+        } else {
+            Err(InvalidArgumentError(format!(
+                "Downcast: expected input value type to be numeric, got {:?}",
+                post_eval_tpe
+            )))
+        }
+    }
+
+    /// Type
+    pub fn tpe(&self) -> SType {
+        self.tpe.clone()
+    }
+}
+
+impl HasStaticOpCode for Downcast {
+    const OP_CODE: OpCode = OpCode::DOWNCAST;
+}
+
+impl SigmaSerializable for Downcast {
+    fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> SigmaSerializeResult {
+        self.input.sigma_serialize(w)?;
+        self.tpe.sigma_serialize(w)
+    }
+
+    fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, SigmaParsingError> {
+        let input = Expr::sigma_parse(r)?.into();
+        let tpe = SType::sigma_parse(r)?;
+        Ok(Downcast { input, tpe })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+#[allow(clippy::unwrap_used)]
+/// Arbitrary impl
+mod arbitrary {
+    use crate::mir::expr::arbitrary::ArbExprParams;
+
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for Downcast {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            any_with::<Expr>(ArbExprParams {
+                tpe: SType::SLong,
+                depth: 2,
+            })
+            .prop_map(|input| Downcast::new(input, SType::SInt).unwrap())
+            .boxed()
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "arbitrary")]
+#[allow(clippy::panic)]
+pub mod proptests {
+
+    use super::*;
+    use crate::serialization::sigma_serialize_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+
+        #[test]
+        fn ser_roundtrip(v in any::<Downcast>()) {
+            let expr: Expr = v.into();
+            prop_assert_eq![sigma_serialize_roundtrip(&expr), expr];
+        }
+    }
+}

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -69,6 +69,7 @@ use crate::mir::byte_array_to_bigint::ByteArrayToBigInt;
 use crate::mir::create_prove_dh_tuple::CreateProveDhTuple;
 use crate::mir::deserialize_context::DeserializeContext;
 use crate::mir::deserialize_register::DeserializeRegister;
+use crate::mir::downcast::Downcast;
 use crate::mir::get_var::GetVar;
 use crate::mir::xor_of::XorOf;
 use bounded_vec::BoundedVecOutOfBounds;
@@ -181,6 +182,8 @@ pub enum Expr {
     BoolToSigmaProp(BoolToSigmaProp),
     /// Upcast numeric value
     Upcast(Upcast),
+    /// Downcast numeric value
+    Downcast(Downcast),
     /// Create proveDlog from GroupElement(PK)
     CreateProveDlog(CreateProveDlog),
     /// Create proveDlog from GroupElement(PK)
@@ -250,6 +253,7 @@ impl Expr {
             Expr::Filter(v) => v.tpe(),
             Expr::BoolToSigmaProp(v) => v.tpe(),
             Expr::Upcast(v) => v.tpe(),
+            Expr::Downcast(v) => v.tpe(),
             Expr::If(v) => v.tpe(),
             Expr::ByIndex(v) => v.tpe(),
             Expr::ExtractScriptBytes(v) => v.tpe(),

--- a/ergotree-ir/src/serialization/expr.rs
+++ b/ergotree-ir/src/serialization/expr.rs
@@ -36,6 +36,7 @@ use crate::mir::create_provedlog::CreateProveDlog;
 use crate::mir::decode_point::DecodePoint;
 use crate::mir::deserialize_context::DeserializeContext;
 use crate::mir::deserialize_register::DeserializeRegister;
+use crate::mir::downcast::Downcast;
 use crate::mir::exponentiate::Exponentiate;
 use crate::mir::expr::Expr;
 use crate::mir::extract_amount::ExtractAmount;
@@ -160,6 +161,7 @@ impl Expr {
                 ForAll::OP_CODE => Ok(ForAll::sigma_parse(r)?.into()),
                 BoolToSigmaProp::OP_CODE => Ok(BoolToSigmaProp::sigma_parse(r)?.into()),
                 Upcast::OP_CODE => Ok(Upcast::sigma_parse(r)?.into()),
+                Downcast::OP_CODE => Ok(Downcast::sigma_parse(r)?.into()),
                 If::OP_CODE => Ok(If::sigma_parse(r)?.into()),
                 ByIndex::OP_CODE => Ok(ByIndex::sigma_parse(r)?.into()),
                 SizeOf::OP_CODE => Ok(SizeOf::sigma_parse(r)?.into()),
@@ -252,6 +254,7 @@ impl SigmaSerializable for Expr {
             Expr::Filter(op) => op.sigma_serialize_w_opcode(w),
             Expr::BoolToSigmaProp(op) => op.sigma_serialize_w_opcode(w),
             Expr::Upcast(op) => op.sigma_serialize_w_opcode(w),
+            Expr::Downcast(op) => op.sigma_serialize_w_opcode(w),
             Expr::If(op) => op.sigma_serialize_w_opcode(w),
             Expr::ByIndex(op) => op.sigma_serialize_w_opcode(w),
             Expr::ExtractScriptBytes(op) => op.sigma_serialize_w_opcode(w),


### PR DESCRIPTION
PR for https://github.com/ergoplatform/sigma-rust/issues/402

There were a few casts not implemented on the Scala side, so I left them out here as well.  For example:
BigInt -> BigInt/Long/Int/Short/Byte
Byte -> Short

Also. in the `eval` code downcast functions, I was wondering what your thoughts are on using match guards to check for overflows, rather than try_from. This way, it would match on the default error case and avoid the repeated error matching.