### PR TITLE
deny wildcard enum match in clippy;

### DIFF
--- a/bindings/ergo-lib-wasm/src/lib.rs
+++ b/bindings/ergo-lib-wasm/src/lib.rs
@@ -13,6 +13,7 @@
 // Clippy warnings
 #![allow(clippy::new_without_default)]
 #![allow(clippy::len_without_is_empty)]
+#![deny(clippy::wildcard_enum_match_arm)]
 
 pub mod address;
 pub mod ast;

--- a/ergo-lib/src/lib.rs
+++ b/ergo-lib/src/lib.rs
@@ -12,6 +12,7 @@
 // Clippy exclusions
 #![allow(clippy::unit_arg)]
 #![deny(rustdoc::broken_intra_doc_links)]
+#![deny(clippy::wildcard_enum_match_arm)]
 
 pub mod chain;
 pub mod constants;

--- a/ergotree-interpreter/src/lib.rs
+++ b/ergotree-interpreter/src/lib.rs
@@ -17,6 +17,7 @@
 #![deny(clippy::todo)]
 #![deny(clippy::unimplemented)]
 #![deny(clippy::panic)]
+
 mod contracts;
 mod util;
 

--- a/sigma-ser/src/lib.rs
+++ b/sigma-ser/src/lib.rs
@@ -15,6 +15,7 @@
 #![deny(clippy::todo)]
 #![deny(clippy::unimplemented)]
 #![deny(clippy::panic)]
+#![deny(clippy::wildcard_enum_match_arm)]
 
 /// VLQ encoder
 pub mod vlq_encode;


### PR DESCRIPTION
Close #434

It did not work in `ergotree-ir` and `ergotree-interpreter` crates since there is heavy use of matching on one variant in type, values, and expressions.