### PR TITLE
Audit unwraps and panics in `ergo-lib`

### DIFF
--- a/ergo-lib/src/chain/contract.rs
+++ b/ergo-lib/src/chain/contract.rs
@@ -38,6 +38,7 @@ impl Contract {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/ergo-lib/src/chain/ergo_box/box_builder.rs
+++ b/ergo-lib/src/chain/ergo_box/box_builder.rs
@@ -120,8 +120,11 @@ impl ErgoBoxCandidateBuilder {
     }
 
     /// Calculate minimal box value for the current box serialized size(in bytes)
+    #[allow(clippy::unwrap_used)]
     pub fn calc_min_box_value(&self) -> Result<BoxValue, ErgoBoxCandidateBuilderError> {
         let box_size_bytes = self.calc_box_size_bytes()?;
+
+        // Won't be overflowing an i64, so unwrap is safe.
         Ok(
             BoxValue::try_from(box_size_bytes as i64 * BoxValue::MIN_VALUE_PER_BOX_BYTE as i64)
                 .unwrap(),
@@ -168,6 +171,7 @@ impl ErgoBoxCandidateBuilder {
         self.tokens.push(token);
     }
 
+    #[allow(clippy::unwrap_used)]
     fn build_box(&self) -> Result<ErgoBoxCandidate, ErgoBoxCandidateBuilderError> {
         let mut tokens = self.tokens.clone();
         let mut additional_registers = self.additional_registers.clone();
@@ -243,6 +247,8 @@ impl ErgoBoxCandidateBuilder {
             creation_height: self.creation_height,
         };
         let box_size_bytes = b.sigma_serialize_bytes()?.len();
+
+        // Won't be overflowing an i64, so unwrap is safe.
         let min_box_value: BoxValue = (box_size_bytes as i64 * self.min_value_per_byte as i64)
             .try_into()
             .unwrap();
@@ -263,6 +269,7 @@ impl ErgoBoxCandidateBuilder {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
 
     use ergotree_ir::base16_str::Base16Str;

--- a/ergo-lib/src/chain/ergo_box/box_builder.rs
+++ b/ergo-lib/src/chain/ergo_box/box_builder.rs
@@ -120,11 +120,11 @@ impl ErgoBoxCandidateBuilder {
     }
 
     /// Calculate minimal box value for the current box serialized size(in bytes)
-    #[allow(clippy::unwrap_used)]
     pub fn calc_min_box_value(&self) -> Result<BoxValue, ErgoBoxCandidateBuilderError> {
         let box_size_bytes = self.calc_box_size_bytes()?;
 
         // Won't be overflowing an i64, so unwrap is safe.
+        #[allow(clippy::unwrap_used)]
         Ok(
             BoxValue::try_from(box_size_bytes as i64 * BoxValue::MIN_VALUE_PER_BOX_BYTE as i64)
                 .unwrap(),
@@ -171,7 +171,6 @@ impl ErgoBoxCandidateBuilder {
         self.tokens.push(token);
     }
 
-    #[allow(clippy::unwrap_used)]
     fn build_box(&self) -> Result<ErgoBoxCandidate, ErgoBoxCandidateBuilderError> {
         let mut tokens = self.tokens.clone();
         let mut additional_registers = self.additional_registers.clone();
@@ -249,6 +248,7 @@ impl ErgoBoxCandidateBuilder {
         let box_size_bytes = b.sigma_serialize_bytes()?.len();
 
         // Won't be overflowing an i64, so unwrap is safe.
+        #[allow(clippy::unwrap_used)]
         let min_box_value: BoxValue = (box_size_bytes as i64 * self.min_value_per_byte as i64)
             .try_into()
             .unwrap();

--- a/ergo-lib/src/chain/json/context_extension.rs
+++ b/ergo-lib/src/chain/json/context_extension.rs
@@ -40,6 +40,7 @@ impl From<ContextExtension> for ContextExtensionSerde {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/ergo-lib/src/chain/json/transaction.rs
+++ b/ergo-lib/src/chain/json/transaction.rs
@@ -36,6 +36,7 @@ pub struct UnsignedTransactionJson {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use crate::chain::transaction::unsigned::UnsignedTransaction;
     use crate::chain::transaction::Transaction;

--- a/ergo-lib/src/chain/transaction.rs
+++ b/ergo-lib/src/chain/transaction.rs
@@ -169,6 +169,7 @@ where
 }
 
 impl SigmaSerializable for Transaction {
+    #[allow(clippy::unwrap_used)]
     fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> SigmaSerializeResult {
         // reference implementation - https://github.com/ScorexFoundation/sigmastate-interpreter/blob/9b20cb110effd1987ff76699d637174a4b2fb441/sigmastate/src/main/scala/org/ergoplatform/ErgoLikeTransaction.scala#L112-L112
         w.put_usize_as_u16_unwrapped(self.inputs.len())?;
@@ -184,6 +185,9 @@ impl SigmaSerializable for Transaction {
         // This optimization is crucial to allow up to MaxTokens (== 255) in a box.
         // Without it total size of all token ids 255 * 32 = 8160, way beyond MaxBoxSize (== 4K)
         let distinct_token_ids = distinct_token_ids(self.output_candidates.clone());
+
+        // Note that `self.output_candidates` is of type `TxIoVec` which has a max length of
+        // `u16::MAX`. Therefore the following unwrap is safe.
         w.put_u32(u32::try_from(distinct_token_ids.len()).unwrap())?;
         distinct_token_ids
             .iter()
@@ -319,6 +323,7 @@ impl TryFrom<json::transaction::TransactionJson> for Transaction {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 pub mod tests {
     use std::convert::TryInto;
 

--- a/ergo-lib/src/chain/transaction/data_input.rs
+++ b/ergo-lib/src/chain/transaction/data_input.rs
@@ -37,6 +37,7 @@ impl SigmaSerializable for DataInput {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use ergotree_ir::serialization::sigma_serialize_roundtrip;
 

--- a/ergo-lib/src/chain/transaction/input.rs
+++ b/ergo-lib/src/chain/transaction/input.rs
@@ -129,6 +129,7 @@ impl SigmaSerializable for Input {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use ergotree_ir::serialization::sigma_serialize_roundtrip;

--- a/ergo-lib/src/chain/transaction/input/prover_result.rs
+++ b/ergo-lib/src/chain/transaction/input/prover_result.rs
@@ -74,6 +74,7 @@ impl SigmaSerializable for ProverResult {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
     use ergotree_ir::serialization::sigma_serialize_roundtrip;

--- a/ergo-lib/src/chain/transaction/reduced.rs
+++ b/ergo-lib/src/chain/transaction/reduced.rs
@@ -138,6 +138,7 @@ impl SigmaSerializable for ReducedTransaction {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
 

--- a/ergo-lib/src/chain/transaction/unsigned.rs
+++ b/ergo-lib/src/chain/transaction/unsigned.rs
@@ -138,6 +138,7 @@ impl TryFrom<json::transaction::UnsignedTransactionJson> for UnsignedTransaction
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 pub mod tests {
     use super::*;
 

--- a/ergo-lib/src/lib.rs
+++ b/ergo-lib/src/lib.rs
@@ -13,6 +13,11 @@
 #![allow(clippy::unit_arg)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::wildcard_enum_match_arm)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::todo)]
+#![deny(clippy::unimplemented)]
+#![deny(clippy::panic)]
 
 pub mod chain;
 pub mod constants;

--- a/ergo-lib/src/wallet/box_selector.rs
+++ b/ergo-lib/src/wallet/box_selector.rs
@@ -57,7 +57,7 @@ pub enum BoxSelectorError {
 
     /// Token amount err
     #[error("TokenAmountError: {0:?}")]
-    TokenAmountError(TokenAmountError),
+    TokenAmountError(#[from] TokenAmountError),
 }
 
 impl From<BoxValueError> for BoxSelectorError {

--- a/ergo-lib/src/wallet/box_selector.rs
+++ b/ergo-lib/src/wallet/box_selector.rs
@@ -150,6 +150,7 @@ pub fn sum_tokens_from_boxes<T: ErgoBoxAssets>(bs: &[T]) -> HashMap<TokenId, Tok
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
 
     use ergotree_ir::chain::ergo_box::box_value::arbitrary::ArbBoxValueRange;

--- a/ergo-lib/src/wallet/box_selector/simple.rs
+++ b/ergo-lib/src/wallet/box_selector/simple.rs
@@ -173,7 +173,7 @@ impl Default for SimpleBoxSelector {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use std::convert::TryFrom;
 

--- a/ergo-lib/src/wallet/ext_pub_key.rs
+++ b/ergo-lib/src/wallet/ext_pub_key.rs
@@ -48,7 +48,10 @@ impl ExtPubKey {
         })
     }
 
+    #[allow(clippy::unwrap_used)]
     fn pub_key_bytes(&self) -> PubKeyBytes {
+        // Unwraps are fine here since `self.public_key` is valid through the checking constructor
+        // above.
         self.public_key
             .sigma_serialize_bytes()
             .unwrap()
@@ -58,7 +61,9 @@ impl ExtPubKey {
     }
 
     /// Soft derivation of the child public key with a given index
+    #[allow(clippy::unwrap_used)]
     pub fn derive(&self, index: ChildIndexNormal) -> Self {
+        // Unwrap is fine due to `ChainCode` type having fixed length of 32.
         let mut mac = HmacSha512::new_from_slice(&self.chain_code).unwrap();
         mac.update(&self.pub_key_bytes());
         mac.update(
@@ -98,6 +103,7 @@ impl From<ExtPubKey> for Address {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use crate::wallet::derivation_path::ChildIndexHardened;
 

--- a/ergo-lib/src/wallet/secret_key.rs
+++ b/ergo-lib/src/wallet/secret_key.rs
@@ -51,6 +51,7 @@ impl From<DlogProverInput> for SecretKey {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use std::convert::TryInto;

--- a/ergo-lib/src/wallet/signing.rs
+++ b/ergo-lib/src/wallet/signing.rs
@@ -219,6 +219,7 @@ pub fn sign_reduced_transaction(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
     use ergotree_interpreter::sigma_protocol::private_input::DlogProverInput;

--- a/ergo-lib/src/wallet/tx_builder.rs
+++ b/ergo-lib/src/wallet/tx_builder.rs
@@ -251,12 +251,13 @@ impl<S: ErgoBoxAssets + ErgoBoxId + Clone> TxBuilder<S> {
 }
 
 /// Suggested transaction fee (1100000 nanoERGs, semi-default value used across wallets and dApps as of Oct 2020)
-#[allow(non_snake_case)]
+#[allow(non_snake_case, clippy::unwrap_used)]
 pub fn SUGGESTED_TX_FEE() -> BoxValue {
     BoxValue::new(1100000u64).unwrap()
 }
 
 /// Create a box with miner's contract and a given value
+#[allow(clippy::unwrap_used)]
 pub fn new_miner_fee_box(
     fee_amount: BoxValue,
     creation_height: u32,

--- a/ergo-lib/src/wallet/tx_builder.rs
+++ b/ergo-lib/src/wallet/tx_builder.rs
@@ -200,10 +200,8 @@ impl<S: ErgoBoxAssets + ErgoBoxId + Clone> TxBuilder<S> {
             ));
         }
         // check that inputs have enough tokens
-        let input_tokens = sum_tokens_from_boxes(self.box_selection.boxes.as_slice())
-            .map_err(TxBuilderError::TokenAmountError)?;
-        let output_tokens = sum_tokens_from_boxes(output_candidates.as_slice())
-            .map_err(TxBuilderError::TokenAmountError)?;
+        let input_tokens = sum_tokens_from_boxes(self.box_selection.boxes.as_slice())?;
+        let output_tokens = sum_tokens_from_boxes(output_candidates.as_slice())?;
         let first_input_box_id: TokenId = self
             .box_selection
             .boxes
@@ -307,7 +305,7 @@ pub enum TxBuilderError {
     EmptyInputBoxSelection,
     /// Token amount err
     #[error("TokenAmountError: {0:?}")]
-    TokenAmountError(TokenAmountError),
+    TokenAmountError(#[from] TokenAmountError),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #265.

In summary I've only removed unwraps relating to `TokenAmount::checked_[add|sub]`. For the other non-obvious unwraps (to me) I've added a comment explaining why it's safe.