### PR TITLE
changing hints bag and adding add_hint function

### DIFF
--- a/ergotree-interpreter/src/sigma_protocol/prover/hint.rs
+++ b/ergotree-interpreter/src/sigma_protocol/prover/hint.rs
@@ -149,13 +149,18 @@ impl CommitmentHint {
 /// Collection of hints to be used by a prover
 pub struct HintsBag {
     /// Hints stored in a bag
-    hints: Vec<Hint>,
+    pub hints: Vec<Hint>,
 }
 
 impl HintsBag {
     /// Bag without hints
     pub fn empty() -> Self {
         HintsBag { hints: vec![] }
+    }
+
+    /// Adding new hint to hints
+    pub fn add_hint(&mut self, hint:Hint){
+        self.hints.push(hint);
     }
 
     /// Commitments from all CommitmentHints in the bag

--- a/ergotree-interpreter/src/sigma_protocol/prover/hint.rs
+++ b/ergotree-interpreter/src/sigma_protocol/prover/hint.rs
@@ -159,7 +159,7 @@ impl HintsBag {
     }
 
     /// Adding new hint to hints
-    pub fn add_hint(&mut self, hint:Hint){
+    pub fn add_hint(&mut self, hint: Hint) {
         self.hints.push(hint);
     }
 


### PR DESCRIPTION
For accessing hints inside HintsBag I need to make hints public.

For adding a new hint to the HintsBag I wrote the add_hint function like the Scala version. if it is accepted I will add another function for adding Vector of hints to the HintsBag.