### PR TITLE
Wallet from mnemonic impl

### DIFF
--- a/bindings/ergo-lib-wasm/src/wallet.rs
+++ b/bindings/ergo-lib-wasm/src/wallet.rs
@@ -1,4 +1,5 @@
 //! Wallet-like features
+use derive_more::{From, Into};
 use ergo_lib::chain::transaction::TxIoVec;
 use wasm_bindgen::prelude::*;
 
@@ -13,6 +14,7 @@ use crate::{
 
 /// A collection of secret keys. This simplified signing by matching the secret keys to the correct inputs automatically.
 #[wasm_bindgen]
+#[derive(From, Into)]
 pub struct Wallet(ergo_lib::wallet::Wallet);
 
 #[wasm_bindgen]
@@ -75,11 +77,5 @@ impl Wallet {
             .sign_reduced_transaction(reduced_tx.clone().into())
             .map_err(to_js)
             .map(Transaction::from)
-    }
-}
-
-impl From<ergo_lib::wallet::Wallet> for Wallet {
-    fn from(t: ergo_lib::wallet::Wallet) -> Self {
-        Wallet(t)
     }
 }

--- a/bindings/ergo-lib-wasm/src/wallet.rs
+++ b/bindings/ergo-lib-wasm/src/wallet.rs
@@ -18,9 +18,10 @@ pub struct Wallet(ergo_lib::wallet::Wallet);
 #[wasm_bindgen]
 impl Wallet {
     /// Create wallet instance loading secret key from mnemonic
+    /// Returns None if a DlogSecretKey cannot be parsed from the provided phrase
     #[wasm_bindgen]
-    pub fn from_mnemonic(_mnemonic_phrase: &str, _mnemonic_pass: &str) -> Wallet {
-        todo!()
+    pub fn from_mnemonic(mnemonic_phrase: &str, mnemonic_pass: &str) -> Option<Wallet> {
+        Some(ergo_lib::wallet::Wallet::from_mnemonic(mnemonic_phrase, mnemonic_pass)?.into())
     }
 
     /// Create wallet using provided secret key
@@ -74,5 +75,11 @@ impl Wallet {
             .sign_reduced_transaction(reduced_tx.clone().into())
             .map_err(to_js)
             .map(Transaction::from)
+    }
+}
+
+impl From<ergo_lib::wallet::Wallet> for Wallet {
+    fn from(t: ergo_lib::wallet::Wallet) -> Self {
+        Wallet(t)
     }
 }

--- a/ergo-lib/Cargo.toml
+++ b/ergo-lib/Cargo.toml
@@ -32,7 +32,7 @@ num-bigint = "0.4.0"
 proptest-derive = {version = "0.3.0", optional = true }
 sha2 = { version = "0.9.8" }
 hmac = { version = "0.11.0" }
-ring = { version = "0.16.20" }
+pbkdf2 = "0.8"
 
 [dependencies.proptest]
 # wasm support, via https://altsysrq.github.io/proptest-book/proptest/wasm.html

--- a/ergo-lib/Cargo.toml
+++ b/ergo-lib/Cargo.toml
@@ -32,6 +32,7 @@ num-bigint = "0.4.0"
 proptest-derive = {version = "0.3.0", optional = true }
 sha2 = { version = "0.9.8" }
 hmac = { version = "0.11.0" }
+ring = { version = "0.16.20" }
 
 [dependencies.proptest]
 # wasm support, via https://altsysrq.github.io/proptest-book/proptest/wasm.html

--- a/ergo-lib/src/wallet.rs
+++ b/ergo-lib/src/wallet.rs
@@ -3,6 +3,7 @@
 pub mod box_selector;
 pub mod derivation_path;
 pub mod ext_pub_key;
+pub mod mnemonic;
 pub mod secret_key;
 pub mod signing;
 pub mod tx_builder;
@@ -41,6 +42,11 @@ impl From<TxSigningError> for WalletError {
 }
 
 impl Wallet {
+    /// Create wallet instance loading secret key from mnemonic
+    pub fn from_mnemonic(mnemonic_phrase: &str, mnemonic_pass: &str) -> Wallet {
+        todo!();
+    }
+
     /// Create Wallet from secrets
     pub fn from_secrets(secrets: Vec<SecretKey>) -> Wallet {
         let prover = TestProver {

--- a/ergo-lib/src/wallet.rs
+++ b/ergo-lib/src/wallet.rs
@@ -44,13 +44,14 @@ impl From<TxSigningError> for WalletError {
 
 impl Wallet {
     /// Create wallet instance loading secret key from mnemonic
-    pub fn from_mnemonic(mnemonic_phrase: &str, mnemonic_pass: &str) -> Wallet {
+    /// Returns None if a DlogSecretKey cannot be parsed from the provided phrase
+    pub fn from_mnemonic(mnemonic_phrase: &str, mnemonic_pass: &str) -> Option<Wallet> {
         let seed = Mnemonic::to_seed(mnemonic_phrase, mnemonic_pass);
         let mut dlog_bytes: [u8; 32] = Default::default();
         dlog_bytes.copy_from_slice(&seed[..32]);
-        let secret = SecretKey::dlog_from_bytes(&dlog_bytes).unwrap();
+        let secret = SecretKey::dlog_from_bytes(&dlog_bytes)?;
 
-        Wallet::from_secrets(vec![secret])
+        Some(Wallet::from_secrets(vec![secret]))
     }
 
     /// Create Wallet from secrets

--- a/ergo-lib/src/wallet.rs
+++ b/ergo-lib/src/wallet.rs
@@ -18,6 +18,7 @@ use thiserror::Error;
 use crate::chain::ergo_state_context::ErgoStateContext;
 use crate::chain::transaction::reduced::ReducedTransaction;
 use crate::chain::transaction::Transaction;
+use crate::wallet::mnemonic::Mnemonic;
 
 use self::signing::sign_reduced_transaction;
 use self::signing::TransactionContext;
@@ -44,7 +45,12 @@ impl From<TxSigningError> for WalletError {
 impl Wallet {
     /// Create wallet instance loading secret key from mnemonic
     pub fn from_mnemonic(mnemonic_phrase: &str, mnemonic_pass: &str) -> Wallet {
-        todo!();
+        let seed = Mnemonic::to_seed(mnemonic_phrase, mnemonic_pass);
+        let mut dlog_bytes: [u8; 32] = Default::default();
+        dlog_bytes.copy_from_slice(&seed[..32]);
+        let secret = SecretKey::dlog_from_bytes(&dlog_bytes).unwrap();
+
+        Wallet::from_secrets(vec![secret])
     }
 
     /// Create Wallet from secrets

--- a/ergo-lib/src/wallet/mnemonic.rs
+++ b/ergo-lib/src/wallet/mnemonic.rs
@@ -1,0 +1,78 @@
+//! Docuuemsn
+
+use std::num::NonZeroU32;
+
+use ring::{digest::SHA512_OUTPUT_LEN, pbkdf2};
+
+type MnemonicSeed = [u8; SHA512_OUTPUT_LEN];
+
+/// a
+pub struct Mnemonic();
+
+impl Mnemonic {
+    /// Allowed numbers of words in mnemonics
+    pub const ALLOWED_SENTENCE_SIZES: [u32; 5] = [12, 15, 18, 21, 24];
+
+    /// f
+    pub const ALLOWED_STRENGTHS: [u32; 5] = [128, 160, 192, 224, 256];
+
+    /// f
+    pub const ALLOWED_ENTROPHY_LENGTHS: [u32; 0] = [];
+
+    /// x
+    pub const BITS_GROUP_SIZE: u32 = 11;
+
+    /// Number of iterations specified in BIP39 standard
+    pub const PBKDF2_ITERATIONS: u32 = 2048;
+
+    /// N
+    pub const PBKDF2_KEY_LENGTH: u32 = 512;
+
+    /// x
+    pub fn to_seed(mnemonic_phrase: &str, mnemonic_pass: &str) -> MnemonicSeed {
+        let mut seed: MnemonicSeed = [0u8; SHA512_OUTPUT_LEN];
+        pbkdf2::derive(
+            pbkdf2::PBKDF2_HMAC_SHA512,
+            NonZeroU32::new(Mnemonic::PBKDF2_ITERATIONS).unwrap(),
+            format!("mnemonic{}", mnemonic_pass).as_bytes(),
+            mnemonic_phrase.as_bytes(),
+            &mut seed,
+        );
+
+        seed
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mnemonic_to_seed() {
+        let mnemonic = "change me do not use me change me do not use me";
+        let seed = Mnemonic::to_seed(mnemonic, "");
+        let expected: MnemonicSeed = [
+            197, 178, 83, 123, 82, 178, 123, 144, 59, 52, 196, 35, 120, 60, 237, 23, 196, 137, 228,
+            56, 94, 198, 212, 157, 106, 25, 167, 248, 146, 236, 211, 145, 125, 179, 102, 117, 222,
+            54, 188, 190, 59, 141, 188, 111, 128, 56, 119, 244, 21, 91, 223, 131, 72, 44, 165, 240,
+            252, 66, 130, 166, 26, 200, 66, 163,
+        ];
+
+        assert_eq!(seed, expected);
+    }
+
+    #[test]
+    fn test_mnemonic_to_seed_with_pass() {
+        let mnemonic = "change me do not use me change me do not use me";
+        let seed = Mnemonic::to_seed(mnemonic, "password123");
+        let expected: MnemonicSeed = [
+            223, 227, 8, 139, 136, 226, 235, 133, 136, 72, 46, 140, 86, 217, 205, 228, 151, 196,
+            225, 246, 63, 210, 155, 72, 12, 187, 14, 208, 34, 115, 49, 213, 19, 1, 207, 194, 212,
+            97, 172, 206, 100, 40, 104, 236, 182, 24, 163, 123, 79, 215, 93, 72, 220, 97, 137, 103,
+            76, 85, 251, 175, 216, 7, 214, 156,
+        ];
+
+        assert_eq!(seed, expected);
+    }
+}

--- a/ergo-lib/src/wallet/mnemonic.rs
+++ b/ergo-lib/src/wallet/mnemonic.rs
@@ -7,7 +7,8 @@ use sha2::Sha512;
 /// Length of mnemonic seed in bytes
 const SHA512_OUTPUT_LEN: usize = 512 / 8;
 
-type MnemonicSeed = [u8; SHA512_OUTPUT_LEN];
+/// Mnemonic seed
+pub type MnemonicSeed = [u8; SHA512_OUTPUT_LEN];
 
 /// Mnemonic type
 pub struct Mnemonic();

--- a/ergo-lib/src/wallet/mnemonic.rs
+++ b/ergo-lib/src/wallet/mnemonic.rs
@@ -41,27 +41,19 @@ mod tests {
     fn test_mnemonic_to_seed() {
         let mnemonic = "change me do not use me change me do not use me";
         let seed = Mnemonic::to_seed(mnemonic, "");
-        let expected: MnemonicSeed = [
-            197, 178, 83, 123, 82, 178, 123, 144, 59, 52, 196, 35, 120, 60, 237, 23, 196, 137, 228,
-            56, 94, 198, 212, 157, 106, 25, 167, 248, 146, 236, 211, 145, 125, 179, 102, 117, 222,
-            54, 188, 190, 59, 141, 188, 111, 128, 56, 119, 244, 21, 91, 223, 131, 72, 44, 165, 240,
-            252, 66, 130, 166, 26, 200, 66, 163,
-        ];
+        let encoded_seed = base16::encode_lower(&seed);
+        let expected = "c5b2537b52b27b903b34c423783ced17c489e4385ec6d49d6a19a7f892ecd3917db36675de36bcbe3b8dbc6f803877f4155bdf83482ca5f0fc4282a61ac842a3";
 
-        assert_eq!(&seed[..], expected);
+        assert_eq!(encoded_seed, expected);
     }
 
     #[test]
     fn test_mnemonic_to_seed_with_pass() {
         let mnemonic = "change me do not use me change me do not use me";
         let seed = Mnemonic::to_seed(mnemonic, "password123");
-        let expected: MnemonicSeed = [
-            223, 227, 8, 139, 136, 226, 235, 133, 136, 72, 46, 140, 86, 217, 205, 228, 151, 196,
-            225, 246, 63, 210, 155, 72, 12, 187, 14, 208, 34, 115, 49, 213, 19, 1, 207, 194, 212,
-            97, 172, 206, 100, 40, 104, 236, 182, 24, 163, 123, 79, 215, 93, 72, 220, 97, 137, 103,
-            76, 85, 251, 175, 216, 7, 214, 156,
-        ];
+        let encoded_seed = base16::encode_lower(&seed);
+        let expected = "dfe3088b88e2eb8588482e8c56d9cde497c4e1f63fd29b480cbb0ed0227331d51301cfc2d461acce642868ecb618a37b4fd75d48dc6189674c55fbafd807d69c";
 
-        assert_eq!(seed, expected);
+        assert_eq!(encoded_seed, expected);
     }
 }


### PR DESCRIPTION
Adds `Wallet.from_mnemonic`

~~Added a dependency to assist with `pbkdf2` as I didn't see anything in the codebase already for that, chose [`ring`](https://github.com/briansmith/ring) because it looks pretty active.~~

Added RustCrypto dependency for `pbkdf2`

`expected` seed bytes in tests where taken from [ `AddressGenerationDemo`](https://github.com/ergoplatform/ergo/blob/master/ergo-wallet/src/test/java/org/ergoplatform/wallet/AddressGenerationDemo.java#L16) to confirm implementation