### PR TITLE
From ecpoint bytes

### DIFF
--- a/bindings/ergo-lib-wasm/src/ast.rs
+++ b/bindings/ergo-lib-wasm/src/ast.rs
@@ -182,6 +182,13 @@ impl Constant {
         Ok(c.into())
     }
 
+    /// Parse raw [`EcPoint`] value from bytes and make [`groupElement`] constant
+    pub fn from_ecpoint_bytes_group_element(bytes: &[u8]) -> Result<Constant, JsValue> {
+        let ecp = EcPoint::sigma_parse_bytes(bytes).map_err(to_js)?;
+        let c = ergo_lib::ergotree_ir::mir::constant::Constant::from(ecp);
+        Ok(c.into())
+    }
+
     /// Create `(Coll[Byte], Coll[Byte])` tuple Constant
     pub fn from_tuple_coll_bytes(bytes1: &[u8], bytes2: &[u8]) -> Constant {
         let t = (bytes1.to_vec(), bytes2.to_vec());

--- a/bindings/ergo-lib-wasm/src/ast.rs
+++ b/bindings/ergo-lib-wasm/src/ast.rs
@@ -164,6 +164,17 @@ impl Constant {
             .collect())
     }
 
+    /// Create `Coll[Coll[Byte]]` from array byte array
+    #[allow(clippy::boxed_local)]
+    pub fn from_coll_coll_byte(arr: Vec<Uint8Array>) -> Constant {
+        let mut acc: Vec<Vec<u8>> = vec![];
+        for bytes in arr.iter() {
+            acc.push(bytes.to_vec());
+        }
+        let c = ergo_lib::ergotree_ir::mir::constant::Constant::from(acc);
+        c.into()
+    }
+
     /// Parse raw [`EcPoint`] value from bytes and make [`ProveDlog`] constant
     pub fn from_ecpoint_bytes(bytes: &[u8]) -> Result<Constant, JsValue> {
         let ecp = EcPoint::sigma_parse_bytes(bytes).map_err(to_js)?;

--- a/bindings/ergo-lib-wasm/tests/test_constant.js
+++ b/bindings/ergo-lib-wasm/tests/test_constant.js
@@ -61,6 +61,15 @@ it('Constant from EcPoint bytes', async () => {
   expect(c != null);
 });
 
+it('roundtrip array of byte arrays', async () => {
+  let bytes1 = new Uint8Array([1, 1, 2, 255]);
+  let bytes2 = new Uint8Array([5, 6, 7, 255]);
+  let concat = [bytes1,bytes2];
+  let c = Constant.from_coll_coll_byte(concat);
+  let decoded_c_value = c.to_coll_coll_byte();
+  expect(decoded_c_value.toString()).equal(concat.toString());
+});
+
 it('roundtrip tuple of byte arrays', async () => {
   let bytes1 = new Uint8Array([1, 1, 2, 255]);
   let bytes2 = new Uint8Array([5, 6, 7, 255]);

--- a/ergotree-ir/src/types/stype.rs
+++ b/ergotree-ir/src/types/stype.rs
@@ -142,6 +142,12 @@ impl LiftIntoSType for bool {
     }
 }
 
+impl LiftIntoSType for u8 {
+    fn stype() -> SType {
+        SType::SByte
+    }
+}
+
 impl LiftIntoSType for i8 {
     fn stype() -> SType {
         SType::SByte


### PR DESCRIPTION
`from_ecpoint_bytes_group_element` is equivalent of `ErgoValue<GroupElement>` in Scala version.