### PR TITLE
Add prove -> verify `atleast` test

### DIFF
--- a/ergotree-interpreter/src/sigma_protocol/verifier.rs
+++ b/ergotree-interpreter/src/sigma_protocol/verifier.rs
@@ -115,8 +115,6 @@ pub fn verify_signature(
 fn check_commitments(sp: UncheckedTree, message: &[u8]) -> Result<bool, VerifierError> {
     // Perform Verifier Step 4
     let new_root = compute_commitments(sp);
-    println!("new_root challenge {:?}", new_root.challenge());
-
     let mut s = fiat_shamir_tree_to_bytes(&new_root.clone().into())?;
     s.append(&mut message.to_vec());
     // Verifier Steps 5-6: Convert the tree to a string `s` for input to the Fiat-Shamir hash function,
@@ -124,9 +122,6 @@ fn check_commitments(sp: UncheckedTree, message: &[u8]) -> Result<bool, Verifier
     // Accept the proof if the challenge at the root of the tree is equal to the Fiat-Shamir hash of `s`
     // (and, if applicable,  the associated data). Reject otherwise.
     let expected_challenge = fiat_shamir_hash_fn(s.as_slice());
-
-    println!("expected_challenge {:?}", expected_challenge);
-
     Ok(new_root.challenge() == expected_challenge.into())
 }
 

--- a/ergotree-interpreter/src/sigma_protocol/verifier.rs
+++ b/ergotree-interpreter/src/sigma_protocol/verifier.rs
@@ -437,7 +437,7 @@ mod tests {
             );
             let input = Constant {
                 tpe: SType::SColl(SType::SSigmaProp.into()),
-                v: inputs.clone(),
+                v: inputs,
             }
             .into();
             let expr: Expr = Atleast::new(bound, input).unwrap().into();

--- a/ergotree-interpreter/src/sigma_protocol/verifier.rs
+++ b/ergotree-interpreter/src/sigma_protocol/verifier.rs
@@ -115,6 +115,8 @@ pub fn verify_signature(
 fn check_commitments(sp: UncheckedTree, message: &[u8]) -> Result<bool, VerifierError> {
     // Perform Verifier Step 4
     let new_root = compute_commitments(sp);
+    println!("new_root challenge {:?}", new_root.challenge());
+
     let mut s = fiat_shamir_tree_to_bytes(&new_root.clone().into())?;
     s.append(&mut message.to_vec());
     // Verifier Steps 5-6: Convert the tree to a string `s` for input to the Fiat-Shamir hash function,
@@ -122,6 +124,9 @@ fn check_commitments(sp: UncheckedTree, message: &[u8]) -> Result<bool, Verifier
     // Accept the proof if the challenge at the root of the tree is equal to the Fiat-Shamir hash of `s`
     // (and, if applicable,  the associated data). Reject otherwise.
     let expected_challenge = fiat_shamir_hash_fn(s.as_slice());
+
+    println!("expected_challenge {:?}", expected_challenge);
+
     Ok(new_root.challenge() == expected_challenge.into())
 }
 
@@ -180,9 +185,14 @@ mod tests {
     use crate::sigma_protocol::prover::{Prover, TestProver};
 
     use super::*;
+    use ergotree_ir::mir::atleast::Atleast;
+    use ergotree_ir::mir::constant::{Constant, Literal};
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::sigma_and::SigmaAnd;
     use ergotree_ir::mir::sigma_or::SigmaOr;
+    use ergotree_ir::mir::value::CollKind;
+    use ergotree_ir::sigma_protocol::sigma_boolean::SigmaProp;
+    use ergotree_ir::types::stype::SType;
     use proptest::collection::vec;
     use proptest::prelude::*;
     use sigma_test_util::force_any_val;
@@ -413,5 +423,47 @@ mod tests {
             }
         }
 
+        #[test]
+        fn test_prover_verifier_atleast(secret1 in any::<DlogProverInput>(),
+                                            secret2 in any::<DlogProverInput>(),
+                                             secret3 in any::<DlogProverInput>(),
+                                             message in vec(any::<u8>(), 100..200)) {
+            let bound = Expr::Const(2i32.into());
+            let inputs = Literal::Coll(
+                CollKind::from_vec(
+                    SType::SSigmaProp,
+                    vec![
+                        SigmaProp::from(secret1.public_image()).into(),
+                        SigmaProp::from(secret2.public_image()).into(),
+                        SigmaProp::from(secret3.public_image()).into(),
+                    ],
+                )
+                .unwrap(),
+            );
+            let input = Constant {
+                tpe: SType::SColl(SType::SSigmaProp.into()),
+                v: inputs.clone(),
+            }
+            .into();
+            let expr: Expr = Atleast::new(bound, input).unwrap().into();
+            let tree = ErgoTree::try_from(expr).unwrap();
+            let prover = TestProver {
+                secrets: vec![secret1.into(), secret3.into()],
+            };
+
+            let res = prover.prove(&tree,
+                &Env::empty(),
+                Rc::new(force_any_val::<Context>()),
+                message.as_slice(),
+                &HintsBag::empty());
+            let proof = res.unwrap().proof;
+            let verifier = TestVerifier;
+            let ver_res = verifier.verify(&tree,
+                                            &Env::empty(),
+                                            Rc::new(force_any_val::<Context>()),
+                                            proof,
+                                            message.as_slice());
+            prop_assert_eq!(ver_res.unwrap().result, true)
+        }
     }
 }


### PR DESCRIPTION
closes #248 

Addresses the task in the issue:

`test prover with verifier by generating arbitrary AtLeast IR node proving it and then passing through the verifier (see verifier::tests for examples);`