### PR TITLE
fixes after prover review for AtLeast code path;

### DIFF
--- a/ergotree-interpreter/src/sigma_protocol/prover.rs
+++ b/ergotree-interpreter/src/sigma_protocol/prover.rs
@@ -290,9 +290,9 @@ fn mark_real<P: Prover + ?Sized>(
                         // If the node is THRESHOLD(k), mark it "real" if at least k of its children are marked real; else mark it "simulated"
                         let simulated = cast_to_unp(ct.children.clone())?
                             .iter()
-                            .filter(|c| c.simulated())
+                            .filter(|c| c.is_real())
                             .count()
-                            >= ct.k as usize;
+                            < ct.k as usize;
                         Some(
                             CthresholdUnproven {
                                 simulated,
@@ -838,7 +838,10 @@ fn step9_real_threshold(ct: CthresholdUnproven) -> Result<Option<ProofTree>, Pro
             let challenge_opt = match child {
                 ProofTree::UncheckedTree(ut) => match ut {
                     UncheckedTree::UncheckedLeaf(ul) => Some(ul.challenge()),
-                    UncheckedTree::UncheckedConjecture(_) => None,
+                    UncheckedTree::UncheckedConjecture(_) => return Err(ProverError::Unexpected(
+                        "proving: CthresholdUnproven.children has unexpected UncheckedConjecture"
+                            .to_string(),
+                    )),
                 },
                 ProofTree::UnprovenTree(unpt) => unpt.challenge(),
             };


### PR DESCRIPTION
After reviewing the prover for AtLeast handling (bug hunting in #536) by comparing it to the Scala reference implementation I found two differences. Both of them are not fixing the AtLeast code path though.