### PR TITLE
ContextExtension support in TxBuilder

### DIFF
--- a/bindings/ergo-lib-c-core/src/tx_builder.rs
+++ b/bindings/ergo-lib-c-core/src/tx_builder.rs
@@ -5,8 +5,9 @@ use crate::{
     address::{Address, AddressPtr, ConstAddressPtr},
     box_selector::{BoxSelection, BoxSelectionPtr, ConstBoxSelectionPtr},
     collections::{Collection, CollectionPtr, ConstCollectionPtr},
+    context_extension::ContextExtensionPtr,
     data_input::DataInput,
-    ergo_box::{BoxValue, BoxValuePtr, ConstBoxValuePtr, ErgoBoxCandidate},
+    ergo_box::{BoxIdPtr, BoxValue, BoxValuePtr, ConstBoxValuePtr, ErgoBoxCandidate},
     transaction::{UnsignedTransaction, UnsignedTransactionPtr},
     util::{const_ptr_as_ref, mut_ptr_as_mut},
     Error,
@@ -77,6 +78,22 @@ pub unsafe fn tx_builder_set_data_inputs(
     tx_builder_mut
         .0
         .set_data_inputs(data_inputs.0.clone().into_iter().map(|d| d.0).collect());
+    Ok(())
+}
+
+/// Set context extension for a given input
+pub unsafe fn tx_builder_set_context_extension(
+    tx_builder_mut: TxBuilderPtr,
+    box_id_ptr: BoxIdPtr,
+    ctx_ext_ptr: ContextExtensionPtr,
+) -> Result<(), Error> {
+    let box_id = const_ptr_as_ref(box_id_ptr, "box_id_ptr")?;
+    let ctx_ext = const_ptr_as_ref(ctx_ext_ptr, "ctx_ext_ptr")?;
+    // let data_inputs = const_ptr_as_ref(data_inputs_ptr, "data_inputs_ptr")?;
+    let tx_builder_mut = mut_ptr_as_mut(tx_builder_mut, "tx_builder_mut")?;
+    tx_builder_mut
+        .0
+        .set_context_extension(box_id.0.clone(), ctx_ext.0.clone());
     Ok(())
 }
 

--- a/bindings/ergo-lib-c/src/tx_builder.rs
+++ b/bindings/ergo-lib-c/src/tx_builder.rs
@@ -4,8 +4,9 @@ use ergo_lib_c_core::{
     address::{AddressPtr, ConstAddressPtr},
     box_selector::{BoxSelectionPtr, ConstBoxSelectionPtr},
     collections::{CollectionPtr, ConstCollectionPtr},
+    context_extension::ContextExtensionPtr,
     data_input::DataInput,
-    ergo_box::{BoxValuePtr, ConstBoxValuePtr, ErgoBoxCandidate},
+    ergo_box::{BoxIdPtr, BoxValuePtr, ConstBoxValuePtr, ErgoBoxCandidate},
     transaction::UnsignedTransactionPtr,
     tx_builder::*,
     Error, ErrorPtr,
@@ -59,6 +60,17 @@ pub unsafe extern "C" fn ergo_lib_tx_builder_set_data_inputs(
 ) {
     #[allow(clippy::unwrap_used)]
     tx_builder_set_data_inputs(tx_builder_mut, data_inputs_ptr).unwrap();
+}
+
+/// Set context extension for a given input
+#[no_mangle]
+pub unsafe extern "C" fn ergo_lib_tx_builder_set_context_extension(
+    tx_builder_mut: TxBuilderPtr,
+    box_id_ptr: BoxIdPtr,
+    ctx_ext_ptr: ContextExtensionPtr,
+) {
+    #[allow(clippy::unwrap_used)]
+    tx_builder_set_context_extension(tx_builder_mut, box_id_ptr, ctx_ext_ptr).unwrap();
 }
 
 /// Build the unsigned transaction

--- a/bindings/ergo-lib-ios/Sources/ErgoLib/TxBuilder.swift
+++ b/bindings/ergo-lib-ios/Sources/ErgoLib/TxBuilder.swift
@@ -46,6 +46,11 @@ class TxBuilder {
     func setDataInputs(dataInputs: DataInputs) {
         ergo_lib_tx_builder_set_data_inputs(self.pointer, dataInputs.pointer)
     }
+
+    /// Set context extension for a given input
+    func setContextExtension(boxId: BoxId, ctxExt: ContextExtension) {
+        ergo_lib_tx_builder_set_context_extension(self.pointer, boxId.pointer, ctxExt.pointer)
+    }
     
     /// Get ``DataInputs``
     func getDataInputs() -> DataInputs {

--- a/bindings/ergo-lib-wasm/src/tx_builder.rs
+++ b/bindings/ergo-lib-wasm/src/tx_builder.rs
@@ -3,7 +3,9 @@ use ergo_lib::wallet;
 use wasm_bindgen::prelude::*;
 
 use crate::box_selector::BoxSelection;
+use crate::context_extension::ContextExtension;
 use crate::data_input::DataInputs;
+use crate::ergo_box::BoxId;
 use crate::error_conversion::to_js;
 use crate::{
     address::Address, box_coll::ErgoBoxCandidates, ergo_box::BoxValue,
@@ -53,6 +55,12 @@ impl TxBuilder {
     /// Set transaction's data inputs
     pub fn set_data_inputs(&mut self, data_inputs: &DataInputs) {
         self.0.set_data_inputs(data_inputs.into())
+    }
+
+    /// Set context extension for a given input
+    pub fn set_context_extension(&mut self, box_id: &BoxId, context_extension: &ContextExtension) {
+        self.0
+            .set_context_extension(box_id.clone().into(), context_extension.clone().into());
     }
 
     /// Build the unsigned transaction

--- a/ergo-lib/src/wallet/tx_builder.rs
+++ b/ergo-lib/src/wallet/tx_builder.rs
@@ -232,21 +232,14 @@ impl<S: ErgoBoxAssets + ErgoBoxId + Clone> TxBuilder<S> {
                 }
             })?;
 
-        let unsigned_inputs = self
-            .box_selection
-            .boxes
-            .clone()
-            .into_iter()
-            .map(|b| {
-                let ctx_ext = self
-                    .context_extensions
-                    .get(&b.box_id())
-                    .cloned()
-                    .unwrap_or_else(ContextExtension::empty);
-                UnsignedInput::new(b.box_id(), ctx_ext)
-            })
-            .collect::<Vec<UnsignedInput>>()
-            .try_into()?;
+        let unsigned_inputs = self.box_selection.boxes.clone().mapped(|b| {
+            let ctx_ext = self
+                .context_extensions
+                .get(&b.box_id())
+                .cloned()
+                .unwrap_or_else(ContextExtension::empty);
+            UnsignedInput::new(b.box_id(), ctx_ext)
+        });
         Ok(UnsignedTransaction::new(
             unsigned_inputs,
             self.data_inputs.clone().try_into().ok(),
@@ -586,18 +579,21 @@ mod tests {
                          outputs in vec(any_with::<ErgoBoxCandidate>((BoxValue::MIN_RAW * 1000 ..BoxValue::MIN_RAW * 2000).into()), 1..2),
                          change_address in any::<Address>(),
                          miners_fee in any_with::<BoxValue>((BoxValue::MIN_RAW * 100..BoxValue::MIN_RAW * 200).into()),
-                         data_inputs in vec(any::<DataInput>(), 0..2)) {
+                         data_inputs in vec(any::<DataInput>(), 0..2),
+                         ctx_ext in any::<ContextExtension>()) {
             prop_assume!(sum_tokens_from_boxes(outputs.as_slice()).unwrap().is_empty());
             let min_change_value = BoxValue::SAFE_USER_MIN;
             let all_outputs = checked_sum(outputs.iter().map(|b| b.value)).unwrap()
-                                                                             .checked_add(&miners_fee)
-                                                                             .unwrap();
+                .checked_add(&miners_fee)
+                .unwrap();
             let all_inputs = checked_sum(inputs.iter().map(|b| b.value)).unwrap();
             prop_assume!(all_outputs < all_inputs);
-            let total_output_value: BoxValue = checked_sum(outputs.iter().map(|b| b.value)).unwrap()
-                                                                                                      .checked_add(&miners_fee).unwrap();
+            let total_output_value: BoxValue = checked_sum(outputs.iter().map(|b| b.value))
+                .unwrap()
+                .checked_add(&miners_fee).unwrap();
+            let selection = SimpleBoxSelector::new().select(inputs.clone(), total_output_value, &[]).unwrap();
             let mut tx_builder = TxBuilder::new(
-                SimpleBoxSelector::new().select(inputs.clone(), total_output_value, &[]).unwrap(),
+                selection.clone(),
                 outputs.clone(),
                 1,
                 miners_fee,
@@ -605,6 +601,7 @@ mod tests {
                 min_change_value,
             );
             tx_builder.set_data_inputs(data_inputs.clone());
+            tx_builder.set_context_extension(selection.boxes.first().box_id(), ctx_ext.clone());
             let tx = tx_builder.build().unwrap();
             prop_assert!(outputs.into_iter().all(|i| tx.output_candidates.iter().any(|o| *o == i)),
                          "tx.output_candidates is missing some outputs");
@@ -620,6 +617,7 @@ mod tests {
                 b.value == miners_fee
             }), "box with miner's fee {:?} is not found in outputs: {:?}", miners_fee, tx.output_candidates);
             prop_assert_eq!(tx.data_inputs.map(|i| i.as_vec().clone()).unwrap_or_default(), data_inputs, "unexpected data inputs");
+            prop_assert_eq!(&tx.inputs.first().extension, &ctx_ext);
         }
     }
 }

--- a/ergotree-ir/src/chain/header.rs
+++ b/ergotree-ir/src/chain/header.rs
@@ -314,7 +314,7 @@ mod arbitrary {
                 // Timestamps between 2000-2050
                 946_674_000_000..2_500_400_300_000u64,
                 any::<u32>(), // Note: n_bits must fit in u32
-                0..1_000_000u32,
+                1_000_000u32..10_000_000u32,
                 prop::sample::select(vec![1_u8, 2]),
                 any::<Box<AutolykosSolution>>(),
                 uniform3(1u8..),

--- a/ergotree-ir/src/chain/preheader.rs
+++ b/ergotree-ir/src/chain/preheader.rs
@@ -43,7 +43,7 @@ mod arbitrary {
                 // Timestamps between 2000-2050
                 946_674_000_000..2_500_400_300_000u64,
                 any::<u64>(),
-                0..1_000_000u32,
+                1_000_000u32..10_000_000u32,
                 any::<Box<EcPoint>>(),
                 uniform3(1u8..),
             )


### PR DESCRIPTION
Add `TxBuilder::set_context_extension` to set a `ContextExtension` for a given input.