### PR TITLE
Add SUnit variant of SType

### DIFF
--- a/ergotree-ir/src/mir/constant.rs
+++ b/ergotree-ir/src/mir/constant.rs
@@ -51,6 +51,8 @@ pub struct Constant {
 #[derive(PartialEq, Eq, Clone)]
 /// Possible values for `Constant`
 pub enum Literal {
+    /// Unit
+    Unit,
     /// Boolean
     Boolean(bool),
     /// i8
@@ -94,6 +96,7 @@ impl std::fmt::Debug for Literal {
             Literal::Coll(CollKind::WrappedColl { elem_tpe: _, items }) => items.fmt(f),
             Literal::Opt(boxed_opt) => boxed_opt.fmt(f),
             Literal::Tup(items) => items.fmt(f),
+            Literal::Unit => ().fmt(f),
             Literal::Boolean(v) => v.fmt(f),
             Literal::Byte(v) => v.fmt(f),
             Literal::Short(v) => v.fmt(f),
@@ -221,6 +224,10 @@ impl TryFrom<Value> for Constant {
             Value::Int(i) => Ok(Constant::from(i)),
             Value::Long(l) => Ok(Constant::from(l)),
             Value::BigInt(b) => Ok(Constant::from(b)),
+            Value::Unit => Ok(Constant {
+                tpe: SType::SUnit,
+                v: Literal::Unit,
+            }),
             Value::SigmaProp(s) => Ok(Constant::from(*s)),
             Value::GroupElement(e) => Ok(Constant::from(*e)),
             Value::CBox(i) => Ok(Constant::from(i)),

--- a/ergotree-ir/src/mir/value.rs
+++ b/ergotree-ir/src/mir/value.rs
@@ -147,6 +147,8 @@ pub enum Value {
     Int(i32),
     /// Long
     Long(i64),
+    /// Unit struct
+    Unit,
     /// Big integer
     BigInt(BigInt256),
     /// GroupElement
@@ -221,6 +223,7 @@ impl From<Literal> for Value {
             Literal::Int(i) => Value::Int(i),
             Literal::Long(l) => Value::Long(l),
             Literal::BigInt(b) => Value::BigInt(b),
+            Literal::Unit => Value::Unit,
             Literal::SigmaProp(s) => Value::SigmaProp(s),
             Literal::GroupElement(e) => Value::GroupElement(e),
             Literal::CBox(b) => Value::CBox(b),

--- a/ergotree-ir/src/serialization/data.rs
+++ b/ergotree-ir/src/serialization/data.rs
@@ -29,6 +29,7 @@ impl DataSerializer {
     pub fn sigma_serialize<W: SigmaByteWrite>(c: &Literal, w: &mut W) -> SigmaSerializeResult {
         // for reference see http://github.com/ScorexFoundation/sigmastate-interpreter/blob/25251c1313b0131835f92099f02cef8a5d932b5e/sigmastate/src/main/scala/sigmastate/serialization/DataSerializer.scala#L26-L26
         Ok(match c {
+            Literal::Unit => (),
             Literal::Boolean(v) => w.put_u8(if *v { 1 } else { 0 })?,
             Literal::Byte(v) => w.put_i8(*v)?,
             Literal::Short(v) => w.put_i16(*v)?,
@@ -107,6 +108,7 @@ impl DataSerializer {
                     Err(e) => return Err(SigmaParsingError::ValueOutOfBounds(e)),
                 }
             }
+            SUnit => Literal::Unit,
             SGroupElement => Literal::GroupElement(Box::new(EcPoint::sigma_parse(r)?)),
             SSigmaProp => {
                 Literal::SigmaProp(Box::new(SigmaProp::new(SigmaBoolean::sigma_parse(r)?)))

--- a/ergotree-ir/src/serialization/types.rs
+++ b/ergotree-ir/src/serialization/types.rs
@@ -101,6 +101,7 @@ pub enum TypeCode {
     TUPLE = (TypeCode::MAX_PRIM_TYPECODE + 1) * 8, // 12 * 8 = 96
 
     SANY = 97,
+    SUNIT = 98,
     SBOX = 99,
     SAVL_TREE = 100,
     SCONTEXT = 101,
@@ -316,6 +317,7 @@ impl SType {
             }
 
             TypeCode::SANY => SAny,
+            TypeCode::SUNIT => SUnit,
             TypeCode::SBOX => SBox,
             TypeCode::SAVL_TREE => SAvlTree,
             TypeCode::SCONTEXT => SContext,
@@ -343,6 +345,7 @@ impl SigmaSerializable for SType {
         match self {
             SType::SFunc(_) => Err(SigmaSerializationError::NotSupported("SFunc")),
             SType::SAny => TypeCode::SANY.sigma_serialize(w),
+            SType::SUnit => TypeCode::SUNIT.sigma_serialize(w),
             SType::SBoolean => TypeCode::SBOOLEAN.sigma_serialize(w),
             SType::SByte => TypeCode::SBYTE.sigma_serialize(w),
             SType::SShort => TypeCode::SSHORT.sigma_serialize(w),
@@ -375,16 +378,16 @@ impl SigmaSerializable for SType {
                     SBigInt => TypeCode::OPTION_COLL_BIGINT.sigma_serialize(w),
                     SGroupElement => TypeCode::OPTION_COLL_GROUP_ELEMENT.sigma_serialize(w),
                     SSigmaProp => TypeCode::OPTION_COLL_SIGMAPROP.sigma_serialize(w),
-                    STypeVar(_) | SAny | SBox | SAvlTree | SOption(_) | SColl(_) | STuple(_)
-                    | SFunc(_) | SContext | SHeader | SPreHeader | SGlobal => {
+                    STypeVar(_) | SAny | SUnit | SBox | SAvlTree | SOption(_) | SColl(_)
+                    | STuple(_) | SFunc(_) | SContext | SHeader | SPreHeader | SGlobal => {
                         // if not "embeddable" type fallback to generic Option type code following
                         // elem type code
                         TypeCode::OPTION.sigma_serialize(w)?;
                         elem_type.sigma_serialize(w)
                     }
                 },
-                STypeVar(_) | SAny | SBox | SAvlTree | SOption(_) | STuple(_) | SFunc(_)
-                | SContext | SHeader | SPreHeader | SGlobal => {
+                STypeVar(_) | SAny | SUnit | SBox | SAvlTree | SOption(_) | STuple(_)
+                | SFunc(_) | SContext | SHeader | SPreHeader | SGlobal => {
                     // if not "embeddable" type fallback to generic Option type code following
                     // elem type code
                     TypeCode::OPTION.sigma_serialize(w)?;
@@ -410,16 +413,16 @@ impl SigmaSerializable for SType {
                     SBigInt => TypeCode::NESTED_COLL_BIGINT.sigma_serialize(w),
                     SGroupElement => TypeCode::NESTED_COLL_GROUP_ELEMENT.sigma_serialize(w),
                     SSigmaProp => TypeCode::NESTED_COLL_SIGMAPROP.sigma_serialize(w),
-                    STypeVar(_) | SAny | SBox | SAvlTree | SOption(_) | SColl(_) | STuple(_)
-                    | SFunc(_) | SContext | SHeader | SPreHeader | SGlobal => {
+                    STypeVar(_) | SAny | SUnit | SBox | SAvlTree | SOption(_) | SColl(_)
+                    | STuple(_) | SFunc(_) | SContext | SHeader | SPreHeader | SGlobal => {
                         // if not "embeddable" type fallback to generic Coll type code following
                         // elem type code
                         TypeCode::COLL.sigma_serialize(w)?;
                         elem_type.sigma_serialize(w)
                     }
                 },
-                STypeVar(_) | SAny | SBox | SAvlTree | SOption(_) | STuple(_) | SFunc(_)
-                | SContext | SHeader | SPreHeader | SGlobal => {
+                STypeVar(_) | SAny | SUnit | SBox | SAvlTree | SOption(_) | STuple(_)
+                | SFunc(_) | SContext | SHeader | SPreHeader | SGlobal => {
                     // if not "embeddable" type fallback to generic Coll type code following
                     // elem type code
                     TypeCode::COLL.sigma_serialize(w)?;
@@ -506,10 +509,10 @@ impl SigmaSerializable for SType {
                         t1.sigma_serialize(w)
                     }
                     (
-                        STypeVar(_) | SAny | SBox | SAvlTree | SOption(_) | SColl(_) | STuple(_)
-                        | SFunc(_) | SContext | SHeader | SPreHeader | SGlobal,
-                        STypeVar(_) | SAny | SBox | SAvlTree | SOption(_) | SColl(_) | STuple(_)
-                        | SFunc(_) | SContext | SHeader | SPreHeader | SGlobal,
+                        STypeVar(_) | SAny | SUnit | SBox | SAvlTree | SOption(_) | SColl(_)
+                        | STuple(_) | SFunc(_) | SContext | SHeader | SPreHeader | SGlobal,
+                        STypeVar(_) | SAny | SUnit | SBox | SAvlTree | SOption(_) | SColl(_)
+                        | STuple(_) | SFunc(_) | SContext | SHeader | SPreHeader | SGlobal,
                     ) => {
                         // Pair of non-primitive types (`(SBox, SAvlTree)`, `((Int, Byte), (Boolean,Box))`, etc.)
                         TypeCode::TUPLE_PAIR1.sigma_serialize(w)?;

--- a/ergotree-ir/src/types/stype.rs
+++ b/ergotree-ir/src/types/stype.rs
@@ -25,6 +25,8 @@ pub enum SType {
     STypeVar(STypeVar),
     /// TBD
     SAny,
+    /// Unit struct
+    SUnit,
     /// Boolean
     SBoolean,
     /// Signed byte


### PR DESCRIPTION
This adds the `SUnit` variant to `ergotree-ir::types::SType` as well as `ergotree-ir::mir::constant`'s `Literal` and `Value` enums.

There may be less obvious places that need to be adapted to?

Ran into some `SUnit` register values in this [tx](https://explorer.ergoplatform.com/en/transactions/9876cbd8e1760c5470ead94b050895f92b44ce8da46e5516ce73dff948d20274).