### PR TITLE
update docs for building on ios

### DIFF
--- a/bindings/ergo-lib-ios/README.md
+++ b/bindings/ergo-lib-ios/README.md
@@ -5,7 +5,7 @@
 
 First build `ergo-lib-c`
 ```
-cargo build --release -p ergo-lib-c
+cargo build --release --features rest -p ergo-lib-c
 ```
 
 This creates a static library under `<project_root_directory>/target/release`. Next we use `cbindgen`
@@ -30,8 +30,9 @@ swift build -Xlinker -L../../target/release/
 
 To run tests we must also pass in the library directory:
 ```
-swift test -Xlinker -L../../target/release/
+swift test -Xlinker -L../../target/release/ --skip RestNodeApiTests
 ```
+The `RestNodeApiTests` assume you have an ergo node running on localhost.
  
 
 ### Building Xcode 13 project for `iPhoneSimulator` (for Intel macs)


### PR DESCRIPTION
The cbindgen config seems to default to generating headers for the "rest" feature (line 144). The swift bindings also seem to assume the built `libergo` has the rest symbols defined. I found it a little strange because `ergo-lib-c` doesn't build the rest feature by default. Maybe there's some context I'm missing.

I also suggested skipping the REST API tests by default. I was just trying to get the library to build and didn't have an ergo node running.