### PR TITLE
`TxBuilder` explicit token burn permission and token preservation

### DIFF
--- a/bindings/ergo-lib-c-core/src/tx_builder.rs
+++ b/bindings/ergo-lib-c-core/src/tx_builder.rs
@@ -8,6 +8,7 @@ use crate::{
     context_extension::ContextExtensionPtr,
     data_input::DataInput,
     ergo_box::{BoxIdPtr, BoxValue, BoxValuePtr, ConstBoxValuePtr, ErgoBoxCandidate},
+    token::ConstTokensPtr,
     transaction::{UnsignedTransaction, UnsignedTransactionPtr},
     util::{const_ptr_as_ref, mut_ptr_as_mut},
     Error,
@@ -89,11 +90,27 @@ pub unsafe fn tx_builder_set_context_extension(
 ) -> Result<(), Error> {
     let box_id = const_ptr_as_ref(box_id_ptr, "box_id_ptr")?;
     let ctx_ext = const_ptr_as_ref(ctx_ext_ptr, "ctx_ext_ptr")?;
-    // let data_inputs = const_ptr_as_ref(data_inputs_ptr, "data_inputs_ptr")?;
     let tx_builder_mut = mut_ptr_as_mut(tx_builder_mut, "tx_builder_mut")?;
     tx_builder_mut
         .0
         .set_context_extension(box_id.0.clone(), ctx_ext.0.clone());
+    Ok(())
+}
+
+/// Permits the burn of the given token amount, i.e. allows this token amount to be omitted in the outputs
+pub unsafe fn tx_builder_set_token_burn_permit(
+    tx_builder_mut: TxBuilderPtr,
+    target_tokens_ptr: ConstTokensPtr,
+) -> Result<(), Error> {
+    let target_tokens = const_ptr_as_ref(target_tokens_ptr, "target_tokens_ptr")?;
+    let tx_builder_mut = mut_ptr_as_mut(tx_builder_mut, "tx_builder_mut")?;
+    tx_builder_mut.0.set_token_burn_permit(
+        target_tokens
+            .0
+            .clone()
+            .map(|tokens| tokens.mapped(|t| t.0).as_vec().clone())
+            .unwrap_or_else(Vec::new),
+    );
     Ok(())
 }
 

--- a/bindings/ergo-lib-c/src/tx_builder.rs
+++ b/bindings/ergo-lib-c/src/tx_builder.rs
@@ -7,6 +7,7 @@ use ergo_lib_c_core::{
     context_extension::ContextExtensionPtr,
     data_input::DataInput,
     ergo_box::{BoxIdPtr, BoxValuePtr, ConstBoxValuePtr, ErgoBoxCandidate},
+    token::ConstTokensPtr,
     transaction::UnsignedTransactionPtr,
     tx_builder::*,
     Error, ErrorPtr,
@@ -71,6 +72,16 @@ pub unsafe extern "C" fn ergo_lib_tx_builder_set_context_extension(
 ) {
     #[allow(clippy::unwrap_used)]
     tx_builder_set_context_extension(tx_builder_mut, box_id_ptr, ctx_ext_ptr).unwrap();
+}
+
+/// Permits the burn of the given token amount, i.e. allows this token amount to be omitted in the outputs
+#[no_mangle]
+pub unsafe extern "C" fn ergo_lib_tx_builder_set_token_burn_permit(
+    tx_builder_mut: TxBuilderPtr,
+    target_tokens_ptr: ConstTokensPtr,
+) {
+    #[allow(clippy::unwrap_used)]
+    tx_builder_set_token_burn_permit(tx_builder_mut, target_tokens_ptr).unwrap();
 }
 
 /// Build the unsigned transaction

--- a/bindings/ergo-lib-ios/Sources/ErgoLib/TxBuilder.swift
+++ b/bindings/ergo-lib-ios/Sources/ErgoLib/TxBuilder.swift
@@ -51,6 +51,11 @@ class TxBuilder {
     func setContextExtension(boxId: BoxId, ctxExt: ContextExtension) {
         ergo_lib_tx_builder_set_context_extension(self.pointer, boxId.pointer, ctxExt.pointer)
     }
+
+    /// Permits the burn of the given token amount, i.e. allows this token amount to be omitted in the outputs
+    func setTokenBurnPermit(tokens: Tokens) {
+        ergo_lib_tx_builder_set_token_burn_permit(self.pointer, tokens.pointer)
+    }
     
     /// Get ``DataInputs``
     func getDataInputs() -> DataInputs {

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/TransactionTests.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/TransactionTests.swift
@@ -191,7 +191,7 @@ final class TransactionTests: XCTestCase {
         let dataInputs = DataInputs()
         let txBuilder = TxBuilder(boxSelection: boxSelection, outputCandidates: txOutputs, currentHeight: UInt32(0), feeAmount: fee, changeAddress: changeAddress, minChangeValue: minChangeValue)
         txBuilder.setDataInputs(dataInputs: dataInputs)
-        txBuilder.setTokenBurnPermit(tokens)
+        txBuilder.setTokenBurnPermit(tokens: tokens)
         XCTAssertNoThrow(try txBuilder.build())
     }
     

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/TransactionTests.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/TransactionTests.swift
@@ -191,6 +191,7 @@ final class TransactionTests: XCTestCase {
         let dataInputs = DataInputs()
         let txBuilder = TxBuilder(boxSelection: boxSelection, outputCandidates: txOutputs, currentHeight: UInt32(0), feeAmount: fee, changeAddress: changeAddress, minChangeValue: minChangeValue)
         txBuilder.setDataInputs(dataInputs: dataInputs)
+        txBuilder.setTokenBurnPermit(tokens)
         XCTAssertNoThrow(try txBuilder.build())
     }
     

--- a/bindings/ergo-lib-wasm/src/tx_builder.rs
+++ b/bindings/ergo-lib-wasm/src/tx_builder.rs
@@ -7,10 +7,12 @@ use crate::context_extension::ContextExtension;
 use crate::data_input::DataInputs;
 use crate::ergo_box::BoxId;
 use crate::error_conversion::to_js;
+use crate::token::Tokens;
 use crate::{
     address::Address, box_coll::ErgoBoxCandidates, ergo_box::BoxValue,
     transaction::UnsignedTransaction,
 };
+use ergo_lib::ergotree_ir::chain;
 
 /// Unsigned transaction builder
 #[wasm_bindgen]
@@ -61,6 +63,18 @@ impl TxBuilder {
     pub fn set_context_extension(&mut self, box_id: &BoxId, context_extension: &ContextExtension) {
         self.0
             .set_context_extension(box_id.clone().into(), context_extension.clone().into());
+    }
+
+    /// Permits the burn of the given token amount, i.e. allows this token amount to be omitted in the outputs
+    pub fn set_token_burn_permit(&mut self, tokens: &Tokens) {
+        let tokens: Option<chain::ergo_box::BoxTokens> = tokens.clone().into();
+        self.0.set_token_burn_permit(
+            tokens
+                .as_ref()
+                .map(chain::ergo_box::BoxTokens::as_vec)
+                .unwrap_or(&vec![])
+                .clone(),
+        )
     }
 
     /// Build the unsigned transaction

--- a/bindings/ergo-lib-wasm/tests/test_transaction.js
+++ b/bindings/ergo-lib-wasm/tests/test_transaction.js
@@ -153,6 +153,7 @@ it('TxBuilder burn token test', async () => {
   const data_inputs = new ergo_wasm.DataInputs();
   const tx_builder = ergo_wasm.TxBuilder.new(box_selection, tx_outputs, 0, fee, change_address, min_change_value);
   tx_builder.set_data_inputs(data_inputs);
+  tx_builder.set_token_burn_permit(tokens);
   const tx = tx_builder.build();
   assert(tx != null);
 });
@@ -301,5 +302,5 @@ it('signing multi signature transaction (issue 597)', async () => {
   const prover = ergo_wasm.Wallet.from_secrets(sks)
   assert(prover != null);
   const signed = prover.sign_reduced_transaction(reduced)
-  console.log(JSON.stringify(signed.to_json()))
+  // console.log(JSON.stringify(signed.to_json()))
 });

--- a/ergo-lib/src/wallet/box_selector.rs
+++ b/ergo-lib/src/wallet/box_selector.rs
@@ -199,10 +199,14 @@ pub fn subtract_tokens(
     let mut res: HashMap<TokenId, TokenAmount> = tokens1.clone();
     tokens2.iter().try_for_each(|(id, t_amt)| {
         if let Some(amt) = res.get_mut(id) {
-            *amt = amt.checked_sub(t_amt)?;
+            if amt == t_amt {
+                res.remove(id);
+            } else {
+                *amt = amt.checked_sub(t_amt)?;
+            }
         } else {
             // trying to subtract a token not foung in tokens1
-            return Err(TokenAmountError::Overflow);
+            return Err(TokenAmountError::OutOfBounds(-(*t_amt.as_u64() as i64)));
         }
         Ok(())
     })?;

--- a/ergo-lib/src/wallet/box_selector.rs
+++ b/ergo-lib/src/wallet/box_selector.rs
@@ -205,7 +205,7 @@ pub fn subtract_tokens(
                 *amt = amt.checked_sub(t_amt)?;
             }
         } else {
-            // trying to subtract a token not foung in tokens1
+            // trying to subtract a token not found in tokens1
             return Err(TokenAmountError::OutOfBounds(-(*t_amt.as_u64() as i64)));
         }
         Ok(())

--- a/ergo-lib/src/wallet/box_selector.rs
+++ b/ergo-lib/src/wallet/box_selector.rs
@@ -189,6 +189,26 @@ pub fn sum_tokens_from_hashmaps(
     Ok(res)
 }
 
+/// Subtract tokens2 from tokens1
+/// subtracting amounts of the same token or removing the token if amount is the same
+/// Returns an error if trying to subtract more tokens than there are in tokens1
+pub fn subtract_tokens(
+    tokens1: &HashMap<TokenId, TokenAmount>,
+    tokens2: &HashMap<TokenId, TokenAmount>,
+) -> Result<HashMap<TokenId, TokenAmount>, TokenAmountError> {
+    let mut res: HashMap<TokenId, TokenAmount> = tokens1.clone();
+    tokens2.iter().try_for_each(|(id, t_amt)| {
+        if let Some(amt) = res.get_mut(id) {
+            *amt = amt.checked_sub(t_amt)?;
+        } else {
+            // trying to subtract a token not foung in tokens1
+            return Err(TokenAmountError::Overflow);
+        }
+        Ok(())
+    })?;
+    Ok(res)
+}
+
 /// Arbitrary impl for ErgoBoxAssetsData
 #[allow(clippy::unwrap_used, clippy::panic)]
 #[cfg(feature = "arbitrary")]

--- a/ergo-lib/src/wallet/tx_builder.rs
+++ b/ergo-lib/src/wallet/tx_builder.rs
@@ -241,6 +241,7 @@ impl<S: ErgoBoxAssets + ErgoBoxId + Clone> TxBuilder<S> {
                 ])),
             })?;
 
+        // check that token burn permit is not exceeded
         let burned_tokens = subtract_tokens(&input_tokens, &output_tokens_without_minted)
             .map_err(TxBuilderError::TokensInOutputsExceedInputs)?;
         let token_burn_permits = vec_tokens_to_map(self.token_burn_permit.clone())

--- a/ergo-lib/src/wallet/tx_builder.rs
+++ b/ergo-lib/src/wallet/tx_builder.rs
@@ -312,7 +312,7 @@ pub enum TxBuilderError {
     InvalidInputsCount(#[from] BoundedVecOutOfBounds),
     #[error("Empty input box")]
     EmptyInputBoxSelection,
-    #[error("Token burn permit exceeded, permit {permit:?}, try to burn {try_to_burn:?}, call set_token_burn_permit() to increase the limit")]
+    #[error("Token burn permit exceeded. Permitted limit: {permit:?}, trying to burn: {try_to_burn:?}. Revisit the input to `set_token_burn_permit()` to increase the limit")]
     TokenBurnPermitExceeded { permit: Token, try_to_burn: Token },
     #[error("Token burn permit is missing, try to burn {try_to_burn:?}, call set_token_burn_permit() to set the limit")]
     TokenBurnPermitMissing { try_to_burn: Token },

--- a/ergo-lib/src/wallet/tx_builder.rs
+++ b/ergo-lib/src/wallet/tx_builder.rs
@@ -314,7 +314,7 @@ pub enum TxBuilderError {
     EmptyInputBoxSelection,
     #[error("Token burn permit exceeded. Permitted limit: {permit:?}, trying to burn: {try_to_burn:?}. Revisit the input to `set_token_burn_permit()` to increase the limit")]
     TokenBurnPermitExceeded { permit: Token, try_to_burn: Token },
-    #[error("Token burn permit is missing, try to burn {try_to_burn:?}, call set_token_burn_permit() to set the limit")]
+    #[error("Token burn permit is missing. Trying to burn: {try_to_burn:?}. Call `set_token_burn_permit()` to set the limit")]
     TokenBurnPermitMissing { try_to_burn: Token },
     #[error("Unused token burn permit: token id {token_id:?}, amount {amount:?}")]
     TokenBurnPermitUnused { token_id: TokenId, amount: u64 },

--- a/ergotree-ir/src/chain/token.rs
+++ b/ergotree-ir/src/chain/token.rs
@@ -100,7 +100,7 @@ impl TokenAmount {
             .checked_add(rhs.0)
             .ok_or(TokenAmountError::Overflow)?;
         if raw > Self::MAX_RAW {
-            Err(TokenAmountError::OutOfBounds(raw))
+            Err(TokenAmountError::OutOfBounds(raw as i64))
         } else {
             Ok(Self(raw))
         }
@@ -113,7 +113,7 @@ impl TokenAmount {
             .checked_sub(rhs.0)
             .ok_or(TokenAmountError::Overflow)?;
         if raw < Self::MIN_RAW {
-            Err(TokenAmountError::OutOfBounds(raw))
+            Err(TokenAmountError::OutOfBounds(raw as i64))
         } else {
             Ok(Self(raw))
         }
@@ -130,7 +130,7 @@ impl TokenAmount {
 pub enum TokenAmountError {
     /// Value is out of bounds
     #[error("Token amount is out of bounds: {0}")]
-    OutOfBounds(u64),
+    OutOfBounds(i64),
     /// Overflow
     #[error("Overflow")]
     Overflow,
@@ -143,7 +143,7 @@ impl TryFrom<u64> for TokenAmount {
         if (TokenAmount::MIN_RAW..=TokenAmount::MAX_RAW).contains(&v) {
             Ok(TokenAmount(v))
         } else {
-            Err(TokenAmountError::OutOfBounds(v))
+            Err(TokenAmountError::OutOfBounds(v as i64))
         }
     }
 }


### PR DESCRIPTION
Close #595

This PR adds a required explicit permit to burn tokens in `TxBuilder`. So that token burn can only occur with the caller's permission.
The caller, in order to allow token burn, need to call `TxBuilder.set_token_burn_permit(tokens)` and state the amount of tokens allowed to be burned. The checks for token preservation are added in `TxBuilder::build()` so that `input token + minted token - permitted burned tokens = output tokens` always holds. Moreover, if the output boxes burn fewer tokens than was asked in a permit, an error is raised as well.
Besides that, `TxBuilderError` errors become more specific and precise, with all generic errors lacking context gone (`TokenAmountError`, `BoxValueError`, etc.).