### PR TITLE
Test ErgoBox::MAX_TOKENS_COUNT+ tokens selection

### DIFF
--- a/bindings/ergo-lib-c-core/src/ergo_box.rs
+++ b/bindings/ergo-lib-c-core/src/ergo_box.rs
@@ -217,7 +217,7 @@ pub unsafe fn ergo_box_new(
     let ergo_box = chain::ergo_box::ErgoBox::new(
         value.0,
         chain_ergo_tree,
-        tokens.try_into().unwrap(),
+        tokens.try_into()?,
         NonMandatoryRegisters::empty(),
         creation_height,
         tx_id.0.clone(),

--- a/bindings/ergo-lib-c-core/src/ergo_box.rs
+++ b/bindings/ergo-lib-c-core/src/ergo_box.rs
@@ -16,16 +16,17 @@
 //! A transaction is unsealing a box. As a box can not be open twice, any further valid transaction
 //! can not be linked to the same box.
 
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 use ergo_lib::ergotree_ir::chain::{self, ergo_box::NonMandatoryRegisters};
 
 use crate::{
+    collections::{CollectionPtr, ConstCollectionPtr},
     constant::{Constant, ConstantPtr},
     contract::ConstContractPtr,
     ergo_tree::{ErgoTree, ErgoTreePtr},
     json::ErgoBoxJsonEip12,
-    token::{ConstTokensPtr, Token, Tokens, TokensPtr},
+    token::Token,
     transaction::ConstTxIdPtr,
     util::{const_ptr_as_ref, mut_ptr_as_mut},
     Error,
@@ -153,13 +154,11 @@ pub unsafe fn ergo_box_candidate_creation_height(
 /// Get tokens for box
 pub unsafe fn ergo_box_candidate_tokens(
     ergo_box_candidate_ptr: ConstErgoBoxCandidatePtr,
-    tokens_out: *mut TokensPtr,
+    tokens_out: *mut CollectionPtr<Token>,
 ) -> Result<(), Error> {
     let candidate = const_ptr_as_ref(ergo_box_candidate_ptr, "ergo_box_candidate_ptr")?;
     let tokens_out = mut_ptr_as_mut(tokens_out, "tokens_out")?;
-    *tokens_out = Box::into_raw(Box::new(Tokens(
-        candidate.0.tokens.clone().map(|bv| bv.mapped(Token)),
-    )));
+    *tokens_out = Box::into_raw(Box::new(candidate.0.tokens.clone().into()));
     Ok(())
 }
 
@@ -205,7 +204,7 @@ pub unsafe fn ergo_box_new(
     contract_ptr: ConstContractPtr,
     tx_id_ptr: ConstTxIdPtr,
     index: u16,
-    tokens_ptr: ConstTokensPtr,
+    tokens_ptr: ConstCollectionPtr<Token>,
     ergo_box_out: *mut ErgoBoxPtr,
 ) -> Result<(), Error> {
     let value = const_ptr_as_ref(value_ptr, "value_ptr")?;
@@ -218,7 +217,7 @@ pub unsafe fn ergo_box_new(
     let ergo_box = chain::ergo_box::ErgoBox::new(
         value.0,
         chain_ergo_tree,
-        tokens.0.clone().map(|tokens| tokens.mapped(|t| t.0)),
+        tokens.try_into().unwrap(),
         NonMandatoryRegisters::empty(),
         creation_height,
         tx_id.0.clone(),
@@ -249,13 +248,11 @@ pub unsafe fn ergo_box_creation_height(ergo_box_ptr: ConstErgoBoxPtr) -> Result<
 /// Get tokens for box
 pub unsafe fn ergo_box_tokens(
     ergo_box_ptr: ConstErgoBoxPtr,
-    tokens_out: *mut TokensPtr,
+    tokens_out: *mut CollectionPtr<Token>,
 ) -> Result<(), Error> {
     let ergo_box = const_ptr_as_ref(ergo_box_ptr, "ergo_box_ptr")?;
     let tokens_out = mut_ptr_as_mut(tokens_out, "tokens_out")?;
-    *tokens_out = Box::into_raw(Box::new(Tokens(
-        ergo_box.0.tokens.clone().map(|tokens| tokens.mapped(Token)),
-    )));
+    *tokens_out = Box::into_raw(Box::new(ergo_box.0.tokens.clone().into()));
     Ok(())
 }
 
@@ -330,18 +327,17 @@ pub type ConstErgoBoxAssetsDataPtr = *const ErgoBoxAssetsData;
 /// Create new instance
 pub unsafe fn ergo_box_assets_data_new(
     value_ptr: ConstBoxValuePtr,
-    tokens_ptr: ConstTokensPtr,
+    tokens_ptr: ConstCollectionPtr<Token>,
     ergo_box_assets_data_out: *mut ErgoBoxAssetsDataPtr,
 ) -> Result<(), Error> {
     let value = const_ptr_as_ref(value_ptr, "value_ptr")?;
     let tokens = const_ptr_as_ref(tokens_ptr, "tokens_ptr")?;
     let ergo_box_assets_data_out =
         mut_ptr_as_mut(ergo_box_assets_data_out, "ergo_box_assets_data_out")?;
-    let tokens = tokens.0.clone().map(|tokens| tokens.mapped(|t| t.0));
     *ergo_box_assets_data_out = Box::into_raw(Box::new(ErgoBoxAssetsData(
         ergo_lib::wallet::box_selector::ErgoBoxAssetsData {
             value: value.0,
-            tokens,
+            tokens: tokens.try_into()?,
         },
     )));
     Ok(())
@@ -363,19 +359,12 @@ pub unsafe fn ergo_box_assets_data_value(
 /// Tokens part of the box
 pub unsafe fn ergo_box_assets_data_tokens(
     ergo_box_assets_data_ptr: ConstErgoBoxAssetsDataPtr,
-    tokens_out: *mut TokensPtr,
+    tokens_out: *mut CollectionPtr<Token>,
 ) -> Result<(), Error> {
     let ergo_box_assets_data =
         const_ptr_as_ref(ergo_box_assets_data_ptr, "ergo_box_assets_data_ptr")?;
     let tokens_out = mut_ptr_as_mut(tokens_out, "tokens_out")?;
-
-    *tokens_out = Box::into_raw(Box::new(Tokens(
-        ergo_box_assets_data
-            .0
-            .tokens
-            .clone()
-            .map(|tokens| tokens.mapped(Token)),
-    )));
+    *tokens_out = Box::into_raw(Box::new(ergo_box_assets_data.0.tokens.clone().into()));
     Ok(())
 }
 

--- a/bindings/ergo-lib-c-core/src/tx_builder.rs
+++ b/bindings/ergo-lib-c-core/src/tx_builder.rs
@@ -1,4 +1,5 @@
 //! Unsigned transaction builder
+
 use ergo_lib::wallet;
 
 use crate::{
@@ -8,7 +9,7 @@ use crate::{
     context_extension::ContextExtensionPtr,
     data_input::DataInput,
     ergo_box::{BoxIdPtr, BoxValue, BoxValuePtr, ConstBoxValuePtr, ErgoBoxCandidate},
-    token::ConstTokensPtr,
+    token::Token,
     transaction::{UnsignedTransaction, UnsignedTransactionPtr},
     util::{const_ptr_as_ref, mut_ptr_as_mut},
     Error,
@@ -96,17 +97,11 @@ pub unsafe fn tx_builder_set_context_extension(
 /// Permits the burn of the given token amount, i.e. allows this token amount to be omitted in the outputs
 pub unsafe fn tx_builder_set_token_burn_permit(
     tx_builder_mut: TxBuilderPtr,
-    target_tokens_ptr: ConstTokensPtr,
+    target_tokens_ptr: ConstCollectionPtr<Token>,
 ) -> Result<(), Error> {
     let target_tokens = const_ptr_as_ref(target_tokens_ptr, "target_tokens_ptr")?;
     let tx_builder_mut = mut_ptr_as_mut(tx_builder_mut, "tx_builder_mut")?;
-    tx_builder_mut.0.set_token_burn_permit(
-        target_tokens
-            .0
-            .clone()
-            .map(|tokens| tokens.mapped(|t| t.0).as_vec().clone())
-            .unwrap_or_else(Vec::new),
-    );
+    tx_builder_mut.0.set_token_burn_permit(target_tokens.into());
     Ok(())
 }
 

--- a/bindings/ergo-lib-c/src/box_selector.rs
+++ b/bindings/ergo-lib-c/src/box_selector.rs
@@ -2,7 +2,7 @@ use ergo_lib_c_core::{
     box_selector::*,
     collections::{CollectionPtr, ConstCollectionPtr},
     ergo_box::{ConstBoxValuePtr, ErgoBox, ErgoBoxAssetsData},
-    token::ConstTokensPtr,
+    token::Token,
     Error,
 };
 
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn ergo_lib_simple_box_selector_select(
     simple_box_selector_ptr: ConstSimpleBoxSelectorPtr,
     inputs_ptr: ConstCollectionPtr<ErgoBox>,
     target_balance_ptr: ConstBoxValuePtr,
-    target_tokens_ptr: ConstTokensPtr,
+    target_tokens_ptr: ConstCollectionPtr<Token>,
     box_selection_out: *mut BoxSelectionPtr,
 ) -> ErrorPtr {
     let res = simple_box_selector_select(

--- a/bindings/ergo-lib-c/src/ergo_box.rs
+++ b/bindings/ergo-lib-c/src/ergo_box.rs
@@ -16,11 +16,12 @@
 //! A transaction is unsealing a box. As a box can not be open twice, any further valid transaction
 //! can not be linked to the same box.
 use ergo_lib_c_core::{
+    collections::{CollectionPtr, ConstCollectionPtr},
     constant::ConstantPtr,
     contract::ConstContractPtr,
     ergo_box::*,
     ergo_tree::ErgoTreePtr,
-    token::{ConstTokensPtr, TokensPtr},
+    token::Token,
     transaction::ConstTxIdPtr,
     Error,
 };
@@ -162,7 +163,7 @@ pub unsafe extern "C" fn ergo_lib_ergo_box_candidate_creation_height(
 #[no_mangle]
 pub unsafe extern "C" fn ergo_lib_ergo_box_candidate_tokens(
     ergo_box_candidate_ptr: ConstErgoBoxCandidatePtr,
-    tokens_out: *mut TokensPtr,
+    tokens_out: *mut CollectionPtr<Token>,
 ) {
     #[allow(clippy::unwrap_used)]
     ergo_box_candidate_tokens(ergo_box_candidate_ptr, tokens_out).unwrap();
@@ -213,7 +214,7 @@ pub unsafe extern "C" fn ergo_lib_ergo_box_new(
     contract_ptr: ConstContractPtr,
     tx_id_ptr: ConstTxIdPtr,
     index: u16,
-    tokens_ptr: ConstTokensPtr,
+    tokens_ptr: ConstCollectionPtr<Token>,
     ergo_box_out: *mut ErgoBoxPtr,
 ) -> ErrorPtr {
     let res = ergo_box_new(
@@ -249,7 +250,7 @@ pub unsafe extern "C" fn ergo_lib_ergo_box_creation_height(ergo_box_ptr: ConstEr
 #[no_mangle]
 pub unsafe extern "C" fn ergo_lib_ergo_box_tokens(
     ergo_box_ptr: ConstErgoBoxPtr,
-    tokens_out: *mut TokensPtr,
+    tokens_out: *mut CollectionPtr<Token>,
 ) {
     #[allow(clippy::unwrap_used)]
     ergo_box_tokens(ergo_box_ptr, tokens_out).unwrap();
@@ -355,7 +356,7 @@ make_ffi_eq!(ErgoBox);
 #[no_mangle]
 pub unsafe extern "C" fn ergo_lib_ergo_box_assets_data_new(
     value_ptr: ConstBoxValuePtr,
-    tokens_ptr: ConstTokensPtr,
+    tokens_ptr: ConstCollectionPtr<Token>,
     ergo_box_assets_data_out: *mut ErgoBoxAssetsDataPtr,
 ) {
     #[allow(clippy::unwrap_used)]
@@ -376,7 +377,7 @@ pub unsafe extern "C" fn ergo_lib_ergo_box_assets_data_value(
 #[no_mangle]
 pub unsafe extern "C" fn ergo_lib_ergo_box_assets_data_tokens(
     ergo_box_assets_data_ptr: ConstErgoBoxAssetsDataPtr,
-    tokens_out: *mut TokensPtr,
+    tokens_out: *mut CollectionPtr<Token>,
 ) {
     #[allow(clippy::unwrap_used)]
     ergo_box_assets_data_tokens(ergo_box_assets_data_ptr, tokens_out).unwrap();

--- a/bindings/ergo-lib-c/src/token.rs
+++ b/bindings/ergo-lib-c/src/token.rs
@@ -138,3 +138,4 @@ pub unsafe extern "C" fn ergo_lib_token_delete(ptr: TokenPtr) {
 }
 
 make_ffi_eq!(Token);
+make_collection!(Tokens, Token);

--- a/bindings/ergo-lib-c/src/token.rs
+++ b/bindings/ergo-lib-c/src/token.rs
@@ -6,7 +6,7 @@ use std::{
     os::raw::c_char,
 };
 
-use crate::{delete_ptr, ErrorPtr, ReturnOption};
+use crate::{delete_ptr, ErrorPtr};
 
 // `TokenId` bindings ------------------------------------------------------------------------------
 
@@ -138,54 +138,3 @@ pub unsafe extern "C" fn ergo_lib_token_delete(ptr: TokenPtr) {
 }
 
 make_ffi_eq!(Token);
-
-// `Tokens` bindings -------------------------------------------------------------------------------
-
-/// Create an empty collection
-#[no_mangle]
-pub unsafe extern "C" fn ergo_lib_tokens_new(tokens_out: *mut TokensPtr) {
-    #[allow(clippy::unwrap_used)]
-    tokens_new(tokens_out).unwrap();
-}
-
-/// Returns length of collection
-#[no_mangle]
-pub unsafe extern "C" fn ergo_lib_tokens_len(tokens_ptr: ConstTokensPtr) -> usize {
-    #[allow(clippy::unwrap_used)]
-    tokens_len(tokens_ptr).unwrap()
-}
-
-/// If token at given index exists, allocate a copy and store in `token_out`.
-#[no_mangle]
-pub unsafe extern "C" fn ergo_lib_tokens_get(
-    tokens_ptr: ConstTokensPtr,
-    index: usize,
-    token_out: *mut TokenPtr,
-) -> ReturnOption {
-    match tokens_get(tokens_ptr, index, token_out) {
-        Ok(is_some) => ReturnOption {
-            is_some,
-            error: std::ptr::null_mut(),
-        },
-        Err(e) => ReturnOption {
-            is_some: false, // Just a dummy value
-            error: Error::c_api_from(Err(e)),
-        },
-    }
-}
-
-/// Add token to the end of the collection. There is a maximum capacity of ErgoBox::MAX_TOKENS_COUNT token, and adding
-/// more returns an error.
-#[no_mangle]
-pub unsafe extern "C" fn ergo_lib_tokens_add(
-    token_ptr: ConstTokenPtr,
-    tokens_ptr: TokensPtr,
-) -> ErrorPtr {
-    Error::c_api_from(tokens_add(tokens_ptr, token_ptr))
-}
-
-/// Drop `Tokens`
-#[no_mangle]
-pub unsafe extern "C" fn ergo_lib_tokens_delete(ptr: TokensPtr) {
-    delete_ptr(ptr)
-}

--- a/bindings/ergo-lib-c/src/tx_builder.rs
+++ b/bindings/ergo-lib-c/src/tx_builder.rs
@@ -7,7 +7,7 @@ use ergo_lib_c_core::{
     context_extension::ContextExtensionPtr,
     data_input::DataInput,
     ergo_box::{BoxIdPtr, BoxValuePtr, ConstBoxValuePtr, ErgoBoxCandidate},
-    token::ConstTokensPtr,
+    token::Token,
     transaction::UnsignedTransactionPtr,
     tx_builder::*,
     Error, ErrorPtr,
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn ergo_lib_tx_builder_set_context_extension(
 #[no_mangle]
 pub unsafe extern "C" fn ergo_lib_tx_builder_set_token_burn_permit(
     tx_builder_mut: TxBuilderPtr,
-    target_tokens_ptr: ConstTokensPtr,
+    target_tokens_ptr: ConstCollectionPtr<Token>,
 ) {
     #[allow(clippy::unwrap_used)]
     tx_builder_set_token_burn_permit(tx_builder_mut, target_tokens_ptr).unwrap();

--- a/bindings/ergo-lib-ios/Sources/ErgoLib/Token.swift
+++ b/bindings/ergo-lib-ios/Sources/ErgoLib/Token.swift
@@ -173,8 +173,7 @@ class Tokens {
     /// Add a ``Token`` to the end of the collection. Note that the collection has a maximum
     /// capacity of ErgoBox::MAX_TOKENS_COUNT tokens. Will throw error if adding more.
     func add(token: Token) throws {
-        let error = ergo_lib_tokens_add(token.pointer, self.pointer)
-        try checkError(error)
+        ergo_lib_tokens_add(token.pointer, self.pointer)
     }
         
     deinit {

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/TokenTests.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/TokenTests.swift
@@ -53,7 +53,8 @@ final class TokenIdTests: XCTestCase {
         XCTAssertEqual(tokens.len(), UInt(maxTokensCount))
         XCTAssertNotNil(tokens.get(index: maxTokensCount - 1))
         
-        // Add max + 1 token, expecting error
-        XCTAssertThrowsError(try tokens.add(token: token))
+        // Add max + 1 token
+        tokens.add(token: token)
+        XCTAssertEqual(tokens.len(), UInt(maxTokensCount) + 1)
     }
 }

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/TokenTests.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/TokenTests.swift
@@ -54,7 +54,7 @@ final class TokenIdTests: XCTestCase {
         XCTAssertNotNil(tokens.get(index: maxTokensCount - 1))
         
         // Add max + 1 token
-        tokens.add(token: token)
+        try tokens.add(token: token)
         XCTAssertEqual(tokens.len(), UInt(maxTokensCount) + 1)
     }
 }

--- a/bindings/ergo-lib-wasm/src/box_selector.rs
+++ b/bindings/ergo-lib-wasm/src/box_selector.rs
@@ -68,15 +68,17 @@ impl SimpleBoxSelector {
         target_balance: &BoxValue,
         target_tokens: &Tokens,
     ) -> Result<BoxSelection, JsValue> {
-        let target_tokens: Option<chain::ergo_box::BoxTokens> = target_tokens.clone().into();
         self.0
             .select(
                 inputs.clone().into(),
                 target_balance.clone().into(),
                 target_tokens
-                    .as_ref()
-                    .map(chain::ergo_box::BoxTokens::as_slice)
-                    .unwrap_or(&[]),
+                    .clone()
+                    .0
+                    .into_iter()
+                    .map(|t| t.into())
+                    .collect::<Vec<chain::token::Token>>()
+                    .as_slice(),
             )
             .map_err(to_js)
             .map(BoxSelection)

--- a/bindings/ergo-lib-wasm/src/tx_builder.rs
+++ b/bindings/ergo-lib-wasm/src/tx_builder.rs
@@ -12,7 +12,6 @@ use crate::{
     address::Address, box_coll::ErgoBoxCandidates, ergo_box::BoxValue,
     transaction::UnsignedTransaction,
 };
-use ergo_lib::ergotree_ir::chain;
 
 /// Unsigned transaction builder
 #[wasm_bindgen]
@@ -64,14 +63,8 @@ impl TxBuilder {
 
     /// Permits the burn of the given token amount, i.e. allows this token amount to be omitted in the outputs
     pub fn set_token_burn_permit(&mut self, tokens: &Tokens) {
-        let tokens: Option<chain::ergo_box::BoxTokens> = tokens.clone().into();
-        self.0.set_token_burn_permit(
-            tokens
-                .as_ref()
-                .map(chain::ergo_box::BoxTokens::as_vec)
-                .unwrap_or(&vec![])
-                .clone(),
-        )
+        self.0
+            .set_token_burn_permit(tokens.clone().0.into_iter().map(|t| t.into()).collect())
     }
 
     /// Build the unsigned transaction


### PR DESCRIPTION
Close #594

Done:
- PBT to check that the target tokens count in box selection is not limited by max token per box limit;
- make `Tokens` in Wasm and C to be a wrapper around `Vec<Token>` not constrained by any limit;