### PR TITLE
Verify P2PK inputs in transaction

### DIFF
--- a/bindings/ergo-lib-wasm/src/error_conversion.rs
+++ b/bindings/ergo-lib-wasm/src/error_conversion.rs
@@ -6,6 +6,7 @@ use std::num::ParseIntError;
 
 use base16::DecodeError;
 use bounded_vec::BoundedVecOutOfBounds;
+use ergo_lib::chain::transaction::TransactionSignatureVerificationError;
 use ergo_lib::ergo_chain_types::DigestNError;
 use ergo_lib::ergo_nipopow::NipopowProofError;
 #[cfg(feature = "rest")]
@@ -73,6 +74,7 @@ from_error_to_wrap!(WalletError);
 from_error_to_wrap!(DecodeError);
 from_error_to_wrap!(TryFromSliceError);
 from_error_to_wrap!(AddrParseError);
+from_error_to_wrap!(TransactionSignatureVerificationError);
 
 macro_rules! from_error_to_wrap_via_debug {
     ($t:ident) => {

--- a/bindings/ergo-lib-wasm/src/transaction.rs
+++ b/bindings/ergo-lib-wasm/src/transaction.rs
@@ -5,6 +5,7 @@ use crate::box_coll::ErgoBoxes;
 use crate::context_extension::ContextExtension;
 use crate::data_input::DataInputs;
 use crate::ergo_box::BoxId;
+use crate::ergo_box::ErgoBox;
 use crate::error_conversion::to_js;
 use crate::input::{Inputs, UnsignedInputs};
 use crate::json::TransactionJsonEip12;
@@ -265,6 +266,13 @@ impl Transaction {
     pub fn sigma_parse_bytes(data: Vec<u8>) -> Result<Transaction, JsValue> {
         ergo_lib::chain::transaction::Transaction::sigma_parse_bytes(&data)
             .map(Transaction)
+            .map_err(to_js)
+    }
+
+    /// Check the signature of the given input which guarded by P2PK script
+    pub fn verify_p2pk_input(&self, input_idx: usize, ergo_box: ErgoBox) -> Result<bool, JsValue> {
+        self.0
+            .verify_p2pk_input(input_idx, ergo_box.into())
             .map_err(to_js)
     }
 }

--- a/bindings/ergo-lib-wasm/src/transaction.rs
+++ b/bindings/ergo-lib-wasm/src/transaction.rs
@@ -269,11 +269,10 @@ impl Transaction {
             .map_err(to_js)
     }
 
-    /// Check the signature of the given input which guarded by P2PK script
-    pub fn verify_p2pk_input(&self, input_idx: usize, ergo_box: ErgoBox) -> Result<bool, JsValue> {
-        self.0
-            .verify_p2pk_input(input_idx, ergo_box.into())
-            .map_err(to_js)
+    /// Check the signature of the transaction's input corresponding
+    /// to the given input box, guarded by P2PK script
+    pub fn verify_p2pk_input(&self, input_box: ErgoBox) -> Result<bool, JsValue> {
+        self.0.verify_p2pk_input(input_box.into()).map_err(to_js)
     }
 }
 

--- a/ergo-lib/src/chain/transaction.rs
+++ b/ergo-lib/src/chain/transaction.rs
@@ -177,6 +177,7 @@ impl Transaction {
         // since we have a tx with tx_id at this point serialization is safe to unwrap
         let message = self.bytes_to_sign().unwrap();
         for (idx, input) in self.inputs.clone().enumerated().into_iter() {
+            // TODO: check if only proof bytes are not empty
             // TODO: get by box id
             let tree = input_boxes[idx].ergo_tree.clone();
             if !verify_signature(

--- a/ergo-lib/src/chain/transaction.rs
+++ b/ergo-lib/src/chain/transaction.rs
@@ -168,28 +168,48 @@ impl Transaction {
         self.tx_id.clone()
     }
 
-    /// Checks signatures of the transaction inputs assuming inputs guarded by PK ONLY
-    pub fn verify_p2k_only_signature(
+    /// Check the signature of the given input which guarded by P2PK script
+    pub fn verify_p2pk_input(
         &self,
-        input_boxes: Vec<ErgoBox>,
+        input_idx: usize,
+        ergo_box: ErgoBox,
     ) -> Result<bool, VerifierError> {
         #[allow(clippy::unwrap_used)]
-        // since we have a tx with tx_id at this point serialization is safe to unwrap
+        // since we have a tx with tx_id at this point, serialization is safe to unwrap
         let message = self.bytes_to_sign().unwrap();
-        for (idx, input) in self.inputs.clone().enumerated().into_iter() {
-            // TODO: check if only proof bytes are not empty
-            // TODO: get by box id
-            let tree = input_boxes[idx].ergo_tree.clone();
-            if !verify_signature(
-                extract_sigma_boolean(tree.proposition()?.as_ref())?,
-                message.as_slice(),
-                input.spending_proof.proof.to_bytes().as_slice(),
-            )? {
-                return Ok(false);
-            }
-        }
-        Ok(true)
+        #[allow(clippy::unwrap_used)]
+        // TODO: return error
+        let input = self.inputs.get(input_idx).unwrap();
+        let sb = extract_sigma_boolean(ergo_box.ergo_tree.proposition()?.as_ref())?;
+        verify_signature(
+            sb,
+            message.as_slice(),
+            input.spending_proof.proof.clone().to_bytes().as_slice(),
+        )
     }
+
+    // /// Checks signatures of the transaction inputs assuming inputs guarded by PK ONLY
+    // pub fn verify_p2k_only_signature(
+    //     &self,
+    //     input_boxes: Vec<ErgoBox>,
+    // ) -> Result<bool, VerifierError> {
+    //     #[allow(clippy::unwrap_used)]
+    //     // since we have a tx with tx_id at this point serialization is safe to unwrap
+    //     let message = self.bytes_to_sign().unwrap();
+    //     for (idx, input) in self.inputs.clone().enumerated().into_iter() {
+    //         // TODO: check if only proof bytes are not empty
+    //         // TODO: get by box id
+    //         let tree = input_boxes[idx].ergo_tree.clone();
+    //         if !verify_signature(
+    //             extract_sigma_boolean(tree.proposition()?.as_ref())?,
+    //             message.as_slice(),
+    //             input.spending_proof.proof.to_bytes().as_slice(),
+    //         )? {
+    //             return Ok(false);
+    //         }
+    //     }
+    //     Ok(true)
+    // }
 }
 
 /// Returns distinct token ids from all given ErgoBoxCandidate's

--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -1,5 +1,7 @@
 //! Interpreter
 use bounded_vec::BoundedVecOutOfBounds;
+use ergotree_ir::mir::constant::TryExtractInto;
+use ergotree_ir::sigma_protocol::sigma_boolean::SigmaProp;
 use sigma_ser::ScorexParsingError;
 use sigma_ser::ScorexSerializationError;
 use std::rc::Rc;
@@ -186,6 +188,14 @@ pub fn reduce_to_crypto(
                 _ => Err(EvalError::InvalidResultType),
             }
         })
+}
+
+/// Expects SigmaProp constant value and returns it's value. Otherwise, returns an error.
+pub fn extract_sigma_boolean(expr: &Expr) -> Result<SigmaBoolean, EvalError> {
+    match expr {
+        Expr::Const(c) => Ok(c.clone().try_extract_into::<SigmaProp>()?.into()),
+        _ => Err(EvalError::InvalidResultType),
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Close #612

Todo:
- [x] remove `input_idx` and find input by box id;
- [x] clean up todo and commented code;