### PR TITLE
Arbitrary JS type to Constant conversion

### DIFF
--- a/bindings/ergo-lib-wasm/Cargo.toml
+++ b/bindings/ergo-lib-wasm/Cargo.toml
@@ -52,7 +52,6 @@ features = ["serde"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.29"
-ergotree-ir = { version = "^0.19.0", path = "../../ergotree-ir", features = ["arbitrary"] }
 ergo-lib = { version = "^0.19.0", path = "../../ergo-lib", features = ["arbitrary"] }
 
 [dev-dependencies.proptest]

--- a/bindings/ergo-lib-wasm/Cargo.toml
+++ b/bindings/ergo-lib-wasm/Cargo.toml
@@ -36,6 +36,7 @@ getrandom = {version = "0.2.3", features = ["js"]}
 console_error_panic_hook = { version = "0.1.6", optional = true }
 
 derive_more = "0.99"
+num-traits = "0.2.14"
 
 [dependencies.serde_with]
 version = "1.9.1"

--- a/bindings/ergo-lib-wasm/Cargo.toml
+++ b/bindings/ergo-lib-wasm/Cargo.toml
@@ -18,12 +18,14 @@ rest = ["ergo-lib/rest"]
 base16 = "0.2.1"
 serde = { version = "1.0", features = ["derive"]}
 ergo-lib = { version = "^0.19.0", path = "../../ergo-lib"}
+sigma-util = { version = "^0.7.0", path = "../../sigma-util"}
 serde_json = "1.0"
 js-sys = "0.3"
 web-sys = {version = "0.3", features = ["Url"]}
 url = "2.2"
 bounded-integer = { version = "^0.5", features = ["types"] }
 futures = "0.3"
+thiserror = "1"
 
 # used in elliptic-curve(in ergo-lib), compiled here with WASM support
 getrandom = {version = "0.2.3", features = ["js"]}

--- a/bindings/ergo-lib-wasm/src/ast.rs
+++ b/bindings/ergo-lib-wasm/src/ast.rs
@@ -1,5 +1,7 @@
 //! Ergo constant values
 
+use crate::ast::js_conv::constant_from_js;
+use crate::ast::js_conv::constant_to_js;
 use crate::ergo_box::ErgoBox;
 use crate::error_conversion::to_js;
 use crate::utils::I64;
@@ -16,6 +18,8 @@ use wasm_bindgen::prelude::*;
 extern crate derive_more;
 use derive_more::{From, Into};
 use ergo_lib::ergotree_ir::bigint256::BigInt256;
+
+pub(crate) mod js_conv;
 
 /// Ergo constant(evaluated) values
 #[wasm_bindgen]
@@ -265,5 +269,15 @@ impl Constant {
     /// Returns true if constant value is Unit
     pub fn is_unit(&self) -> bool {
         self.0.tpe == ergo_lib::ergotree_ir::types::stype::SType::SUnit
+    }
+
+    /// Create a Constant from JS value
+    pub fn from_js(value: &JsValue) -> Result<Constant, JsValue> {
+        constant_from_js(value).map(Into::into).map_err(to_js)
+    }
+
+    /// Extract JS value from Constant
+    pub fn to_js(&self) -> Result<JsValue, JsValue> {
+        constant_to_js(self.0.clone()).map_err(to_js)
     }
 }

--- a/bindings/ergo-lib-wasm/src/ast.rs
+++ b/bindings/ergo-lib-wasm/src/ast.rs
@@ -28,6 +28,16 @@ pub struct Constant(ergo_lib::ergotree_ir::mir::constant::Constant);
 
 #[wasm_bindgen]
 impl Constant {
+    /// Returns the debug representation of the type of the constant
+    pub fn dbg_tpe(&self) -> String {
+        format!("{:?}", self.0.tpe)
+    }
+
+    /// Returns the debug representation of the value of the constant
+    pub fn dbg_inner(&self) -> String {
+        format!("{:?}", self.0)
+    }
+
     /// Decode from Base16-encoded ErgoTree serialized value
     pub fn decode_from_base16(base16_bytes_str: String) -> Result<Constant, JsValue> {
         let bytes = Base16DecodedBytes::try_from(base16_bytes_str.clone()).map_err(|_| {

--- a/bindings/ergo-lib-wasm/src/ast.rs
+++ b/bindings/ergo-lib-wasm/src/ast.rs
@@ -281,12 +281,12 @@ impl Constant {
         self.0.tpe == ergo_lib::ergotree_ir::types::stype::SType::SUnit
     }
 
-    /// Create a Constant from JS value
+    /// Create a Constant from JS value (numbers are represented as Int, Set is represented as Tuple (temporary))
     pub fn from_js(value: &JsValue) -> Result<Constant, JsValue> {
         constant_from_js(value).map(Into::into).map_err(to_js)
     }
 
-    /// Extract JS value from Constant
+    /// Extract JS value from Constant (numbers are represented as Int, Set is represented as Tuple (temporary))
     pub fn to_js(&self) -> Result<JsValue, JsValue> {
         constant_to_js(self.0.clone()).map_err(to_js)
     }

--- a/bindings/ergo-lib-wasm/src/ast.rs
+++ b/bindings/ergo-lib-wasm/src/ast.rs
@@ -19,7 +19,7 @@ extern crate derive_more;
 use derive_more::{From, Into};
 use ergo_lib::ergotree_ir::bigint256::BigInt256;
 
-pub(crate) mod js_conv;
+pub mod js_conv;
 
 /// Ergo constant(evaluated) values
 #[wasm_bindgen]
@@ -281,12 +281,12 @@ impl Constant {
         self.0.tpe == ergo_lib::ergotree_ir::types::stype::SType::SUnit
     }
 
-    /// Create a Constant from JS value (numbers are represented as Int, use array_as_tuple() to encode tuples)
+    /// Create a Constant from JS value (Number -> Int, String -> Long, BigInt -> BigInt, use array_as_tuple() to encode tuples)
     pub fn from_js(value: &JsValue) -> Result<Constant, JsValue> {
         constant_from_js(value).map(Into::into).map_err(to_js)
     }
 
-    /// Extract JS value from Constant (tuples are encoded as arrays)
+    /// Extract JS value from Constant (Int -> Number, Long -> String, BigInt -> BigInt, tuples are encoded as arrays)
     pub fn to_js(&self) -> Result<JsValue, JsValue> {
         constant_to_js(self.0.clone()).map_err(to_js)
     }

--- a/bindings/ergo-lib-wasm/src/ast.rs
+++ b/bindings/ergo-lib-wasm/src/ast.rs
@@ -281,12 +281,24 @@ impl Constant {
         self.0.tpe == ergo_lib::ergotree_ir::types::stype::SType::SUnit
     }
 
-    /// Create a Constant from JS value (Number -> Int, String -> Long, BigInt -> BigInt, use array_as_tuple() to encode tuples)
+    /// Create a Constant from JS value
+    /// JS types are converted to the following Ergo types:
+    /// Number -> Int,
+    /// String -> Long,
+    /// BigInt -> BigInt,
+    /// use array_as_tuple() to encode Ergo tuples
     pub fn from_js(value: &JsValue) -> Result<Constant, JsValue> {
         constant_from_js(value).map(Into::into).map_err(to_js)
     }
 
-    /// Extract JS value from Constant (Int -> Number, Long -> String, BigInt -> BigInt, tuples are encoded as arrays)
+    /// Extract JS value from Constant
+    /// Ergo types are converted to the following JS types:
+    /// Byte -> Number,
+    /// Short -> Number,
+    /// Int -> Number,
+    /// Long -> String,
+    /// BigInt -> BigInt,
+    /// Ergo tuples are encoded as arrays
     pub fn to_js(&self) -> Result<JsValue, JsValue> {
         constant_to_js(self.0.clone()).map_err(to_js)
     }

--- a/bindings/ergo-lib-wasm/src/ast.rs
+++ b/bindings/ergo-lib-wasm/src/ast.rs
@@ -281,12 +281,12 @@ impl Constant {
         self.0.tpe == ergo_lib::ergotree_ir::types::stype::SType::SUnit
     }
 
-    /// Create a Constant from JS value (numbers are represented as Int, Set is represented as Tuple (temporary))
+    /// Create a Constant from JS value (numbers are represented as Int, use array_as_tuple() to encode tuples)
     pub fn from_js(value: &JsValue) -> Result<Constant, JsValue> {
         constant_from_js(value).map(Into::into).map_err(to_js)
     }
 
-    /// Extract JS value from Constant (numbers are represented as Int, Set is represented as Tuple (temporary))
+    /// Extract JS value from Constant (tuples are encoded as arrays)
     pub fn to_js(&self) -> Result<JsValue, JsValue> {
         constant_to_js(self.0.clone()).map_err(to_js)
     }

--- a/bindings/ergo-lib-wasm/src/ast/js_conv.rs
+++ b/bindings/ergo-lib-wasm/src/ast/js_conv.rs
@@ -103,7 +103,7 @@ pub(crate) fn constant_to_js(c: Constant) -> Result<JsValue, ConvError> {
             _ => return Err(ConvError::Unexpected(c)),
         },
         SType::STuple(ref item_tpes) => {
-            let arr: Vec<JsValue> = match c.v {
+            let vec: Vec<JsValue> = match c.v {
                 Literal::Tup(v) => v
                     .into_iter()
                     .zip(item_tpes.clone().items.into_iter())
@@ -111,12 +111,11 @@ pub(crate) fn constant_to_js(c: Constant) -> Result<JsValue, ConvError> {
                     .collect::<Result<Vec<JsValue>, _>>()?,
                 _ => return Err(ConvError::Unexpected(c.clone())),
             };
-            let set = Set::new(&arr[0]);
-            // for some reason JsValue of Uint8Array above gets into the Set as a separated bytes as ints
-            set.clear();
-            for elem in arr.iter() {
-                set.add(elem);
+            let arr = Array::new();
+            for item in vec {
+                arr.push(&item);
             }
+            let set = Set::new(&arr);
             set.into()
         }
         _ => return Err(ConvError::Unexpected(c.clone())),

--- a/bindings/ergo-lib-wasm/src/ast/js_conv.rs
+++ b/bindings/ergo-lib-wasm/src/ast/js_conv.rs
@@ -1,10 +1,10 @@
-// TODO: remove
+//! Arbitrary JS type to Ergo data type conversion.
+
 #![allow(clippy::wildcard_enum_match_arm)]
-#![allow(dead_code)]
-#![allow(unused_imports)]
 
 use std::convert::TryFrom;
 
+use ergo_lib::ergotree_ir::bigint256::BigInt256;
 use ergo_lib::ergotree_ir::mir::constant::Constant;
 use ergo_lib::ergotree_ir::mir::constant::Literal;
 use ergo_lib::ergotree_ir::mir::constant::TryExtractFromError;
@@ -17,8 +17,8 @@ use ergo_lib::ergotree_ir::types::stype::SType;
 use js_sys::Array;
 use js_sys::JsString;
 use js_sys::Number;
-use js_sys::Set;
 use js_sys::Uint8Array;
+use num_traits::Num;
 use sigma_util::AsVecI8;
 use sigma_util::AsVecU8;
 use thiserror::Error;
@@ -26,16 +26,20 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 
+const TUPLE_TOKEN: &str = "Tuple";
+
+/// Encode a JS array as an Ergo tuple.
 #[wasm_bindgen]
 pub fn array_as_tuple(items: Vec<JsValue>) -> JsValue {
     let arr = Array::new();
-    arr.push(&JsValue::from_str("Tuple"));
+    arr.push(&JsValue::from_str(TUPLE_TOKEN));
     for item in items {
         arr.push(&item);
     }
     arr.into()
 }
 
+#[allow(missing_docs)]
 #[derive(Debug, Error)]
 pub enum ConvError {
     #[error("not supported: {0:?}")]
@@ -44,9 +48,18 @@ pub enum ConvError {
     Unexpected(Constant),
     #[error("IO error: {0}")]
     TryExtractFromError(#[from] TryExtractFromError),
+    #[error("Failed to parse Long from string: {0}")]
+    FailedToParseLongFromString(String),
+    #[error("Failed to convert JS BigInt to Ergo BigInt: {0}")]
+    FailedToConvertJsBigInt(js_sys::BigInt),
+    #[error(
+        "Invalid tuple encoding, expected the first array item to be '{}''",
+        TUPLE_TOKEN
+    )]
+    InvalidTupleEncoding,
 }
 
-pub fn constant_from_js(val: &JsValue) -> Result<Constant, ConvError> {
+pub(crate) fn constant_from_js(val: &JsValue) -> Result<Constant, ConvError> {
     if let Ok(bytes) = val.clone().dyn_into::<Uint8Array>() {
         Ok(Constant {
             tpe: SType::SColl(SType::SByte.into()),
@@ -56,8 +69,10 @@ pub fn constant_from_js(val: &JsValue) -> Result<Constant, ConvError> {
         })
     } else if let Ok(arr) = val.clone().dyn_into::<Array>() {
         if let Ok(str) = arr.get(0).dyn_into::<JsString>() {
-            // TODO: check string value to be "Tuple"
             // tuple
+            if str != TUPLE_TOKEN {
+                return Err(ConvError::InvalidTupleEncoding);
+            }
             let mut v: Vec<Constant> = Vec::new();
             for i in 1..arr.length() {
                 let elem_const = constant_from_js(&arr.get(i))?;
@@ -93,9 +108,17 @@ pub fn constant_from_js(val: &JsValue) -> Result<Constant, ConvError> {
             })
         }
     } else if let Ok(num) = val.clone().dyn_into::<Number>() {
-        // TODO: handle error
-        #[allow(clippy::unwrap_used)]
-        let c: Constant = (num.as_f64().unwrap() as i32).into();
+        let c: Constant = (num.value_of() as i32).into();
+        Ok(c)
+    } else if let Ok(long_js_str) = val.clone().dyn_into::<JsString>() {
+        let long_str: String = long_js_str.into();
+        let long: i64 = long_str
+            .parse::<i64>()
+            .map_err(|_| ConvError::FailedToParseLongFromString(long_str))?;
+        let c: Constant = long.into();
+        Ok(c)
+    } else if let Ok(bigint_js) = val.clone().dyn_into::<js_sys::BigInt>() {
+        let c: Constant = js_bigint_to_ergo_bigint(bigint_js)?.into();
         Ok(c)
     } else {
         Err(ConvError::NotSupported(val.clone()))
@@ -105,7 +128,11 @@ pub fn constant_from_js(val: &JsValue) -> Result<Constant, ConvError> {
 pub(crate) fn constant_to_js(c: Constant) -> Result<JsValue, ConvError> {
     Ok(match c.tpe {
         SType::SBoolean => c.v.try_extract_into::<bool>()?.into(),
+        SType::SShort => c.v.try_extract_into::<i16>()?.into(),
+        SType::SByte => c.v.try_extract_into::<i8>()?.into(),
         SType::SInt => c.v.try_extract_into::<i32>()?.into(),
+        SType::SLong => c.v.try_extract_into::<i64>()?.to_string().into(),
+        SType::SBigInt => ergo_bigint_to_js_bigint(c.v.try_extract_into::<BigInt256>()?).into(),
         SType::SColl(_) => match c.v {
             Literal::Coll(CollKind::NativeColl(NativeColl::CollByte(v))) => {
                 Uint8Array::from(v.as_vec_u8().as_slice()).into()
@@ -139,4 +166,19 @@ pub(crate) fn constant_to_js(c: Constant) -> Result<JsValue, ConvError> {
         }
         _ => return Err(ConvError::Unexpected(c.clone())),
     })
+}
+
+fn ergo_bigint_to_js_bigint(bigint: BigInt256) -> js_sys::BigInt {
+    let bigint_str = bigint.to_string();
+    #[allow(clippy::unwrap_used)]
+    // since BigInt256 bounds are less the JS BigInt it should not fail
+    js_sys::BigInt::new(&bigint_str.into()).unwrap()
+}
+
+fn js_bigint_to_ergo_bigint(bigint: js_sys::BigInt) -> Result<BigInt256, ConvError> {
+    #[allow(clippy::unwrap_used)]
+    // safe, because it can only return an error on invalid radix
+    let bigint_js_str: String = bigint.to_string(10).unwrap().into();
+    BigInt256::from_str_radix(bigint_js_str.as_str(), 10)
+        .map_err(|_| ConvError::FailedToConvertJsBigInt(bigint))
 }

--- a/bindings/ergo-lib-wasm/src/ast/js_conv.rs
+++ b/bindings/ergo-lib-wasm/src/ast/js_conv.rs
@@ -1,40 +1,124 @@
-#![allow(clippy::todo)] // TODO: remove
+// TODO: remove
+#![allow(clippy::wildcard_enum_match_arm)]
+
+use std::convert::TryFrom;
 
 use ergo_lib::ergotree_ir::mir::constant::Constant;
 use ergo_lib::ergotree_ir::mir::constant::Literal;
+use ergo_lib::ergotree_ir::mir::constant::TryExtractFromError;
+use ergo_lib::ergotree_ir::mir::constant::TryExtractInto;
 use ergo_lib::ergotree_ir::mir::value::CollKind;
+use ergo_lib::ergotree_ir::mir::value::NativeColl;
+use ergo_lib::ergotree_ir::types::stuple::STuple;
+use ergo_lib::ergotree_ir::types::stuple::TupleItems;
 use ergo_lib::ergotree_ir::types::stype::SType;
 use js_sys::Array;
 use js_sys::Number;
+use js_sys::Set;
+use js_sys::Uint8Array;
+use sigma_util::AsVecI8;
+use sigma_util::AsVecU8;
+use thiserror::Error;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 
-#[derive(Debug)]
-pub(crate) enum ConvError {}
+#[derive(Debug, Error)]
+pub enum ConvError {
+    #[error("not supported: {0:?}")]
+    NotSupported(JsValue),
+    #[error("unexpected: {0:?}")]
+    Unexpected(Constant),
+    #[error("IO error: {0}")]
+    TryExtractFromError(#[from] TryExtractFromError),
+}
 
-#[allow(clippy::unwrap_used)]
-pub(crate) fn constant_from_js(val: &JsValue) -> Result<Constant, ConvError> {
-    match val.clone().dyn_into::<Array>() {
-        Ok(arr) => {
-            // TODO: check if it's a tuple
-            let mut v: Vec<Literal> = Vec::new();
-            for i in 0..arr.length() {
-                v.push((arr.get(i).dyn_into::<Number>().unwrap().as_f64().unwrap() as i32).into());
-            }
-            Ok(Constant {
-                tpe: SType::SColl(SType::SInt.into()),
-                v: Literal::Coll(CollKind::WrappedColl {
-                    elem_tpe: SType::SInt,
-                    items: v,
-                }),
-            })
+pub fn constant_from_js(val: &JsValue) -> Result<Constant, ConvError> {
+    if let Ok(bytes) = val.clone().dyn_into::<Uint8Array>() {
+        Ok(Constant {
+            tpe: SType::SColl(SType::SByte.into()),
+            v: Literal::Coll(CollKind::NativeColl(NativeColl::CollByte(
+                bytes.to_vec().as_vec_i8(),
+            ))),
+        })
+    } else if let Ok(arr) = val.clone().dyn_into::<Array>() {
+        let mut cs: Vec<Constant> = Vec::new();
+        for i in 0..arr.length() {
+            let elem_const = constant_from_js(&arr.get(i))?;
+            cs.push(elem_const);
         }
-        Err(_) => todo!(),
+        let elem_tpe = cs[0].tpe.clone();
+        Ok(Constant {
+            tpe: SType::SColl(elem_tpe.clone().into()),
+            v: Literal::Coll(CollKind::WrappedColl {
+                elem_tpe,
+                items: cs.into_iter().map(|c| c.v).collect(),
+            }),
+        })
+    } else if let Ok(set) = val.clone().dyn_into::<Set>() {
+        let mut v: Vec<Constant> = Vec::new();
+        for elem in set.keys() {
+            #[allow(clippy::unwrap_used)]
+            v.push(constant_from_js(&elem.unwrap())?);
+        }
+        #[allow(clippy::unwrap_used)]
+        Ok(Constant {
+            tpe: SType::STuple(STuple {
+                items: TupleItems::try_from(
+                    v.clone().into_iter().map(|c| c.tpe).collect::<Vec<SType>>(),
+                )
+                .unwrap(),
+            }),
+            v: Literal::Tup(
+                TupleItems::try_from(v.into_iter().map(|c| c.v).collect::<Vec<Literal>>()).unwrap(),
+            ),
+        })
+    } else if let Ok(num) = val.clone().dyn_into::<Number>() {
+        // TODO: handle error
+        #[allow(clippy::unwrap_used)]
+        let c: Constant = (num.as_f64().unwrap() as i32).into();
+        Ok(c)
+    } else {
+        Err(ConvError::NotSupported(val.clone()))
     }
 }
 
 pub(crate) fn constant_to_js(c: Constant) -> Result<JsValue, ConvError> {
-    let arr = Array::new();
-    arr.push(&JsValue::from_f64(5.0));
-    Ok(arr.into())
+    Ok(match c.tpe {
+        SType::SBoolean => c.v.try_extract_into::<bool>()?.into(),
+        SType::SInt => c.v.try_extract_into::<i32>()?.into(),
+        SType::SColl(_) => match c.v {
+            Literal::Coll(CollKind::NativeColl(NativeColl::CollByte(v))) => {
+                Uint8Array::from(v.as_vec_u8().as_slice()).into()
+            }
+            Literal::Coll(CollKind::WrappedColl { elem_tpe, items }) => {
+                let arr = Array::new();
+                for item in items {
+                    arr.push(&constant_to_js(Constant {
+                        tpe: elem_tpe.clone(),
+                        v: item,
+                    })?);
+                }
+                arr.into()
+            }
+            _ => return Err(ConvError::Unexpected(c)),
+        },
+        SType::STuple(ref item_tpes) => {
+            let arr: Vec<JsValue> = match c.v {
+                Literal::Tup(v) => v
+                    .into_iter()
+                    .zip(item_tpes.clone().items.into_iter())
+                    .map(|(v, tpe)| constant_to_js(Constant { tpe, v }))
+                    .collect::<Result<Vec<JsValue>, _>>()?,
+                _ => return Err(ConvError::Unexpected(c.clone())),
+            };
+            let set = Set::new(&arr[0]);
+            // for some reason JsValue of Uint8Array above gets into the Set as a separated bytes as ints
+            set.clear();
+            for elem in arr.iter() {
+                set.add(elem);
+            }
+            set.into()
+        }
+        _ => return Err(ConvError::Unexpected(c.clone())),
+    })
 }

--- a/bindings/ergo-lib-wasm/src/ast/js_conv.rs
+++ b/bindings/ergo-lib-wasm/src/ast/js_conv.rs
@@ -1,0 +1,40 @@
+#![allow(clippy::todo)] // TODO: remove
+
+use ergo_lib::ergotree_ir::mir::constant::Constant;
+use ergo_lib::ergotree_ir::mir::constant::Literal;
+use ergo_lib::ergotree_ir::mir::value::CollKind;
+use ergo_lib::ergotree_ir::types::stype::SType;
+use js_sys::Array;
+use js_sys::Number;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::JsValue;
+
+#[derive(Debug)]
+pub(crate) enum ConvError {}
+
+#[allow(clippy::unwrap_used)]
+pub(crate) fn constant_from_js(val: &JsValue) -> Result<Constant, ConvError> {
+    match val.clone().dyn_into::<Array>() {
+        Ok(arr) => {
+            // TODO: check if it's a tuple
+            let mut v: Vec<Literal> = Vec::new();
+            for i in 0..arr.length() {
+                v.push((arr.get(i).dyn_into::<Number>().unwrap().as_f64().unwrap() as i32).into());
+            }
+            Ok(Constant {
+                tpe: SType::SColl(SType::SInt.into()),
+                v: Literal::Coll(CollKind::WrappedColl {
+                    elem_tpe: SType::SInt,
+                    items: v,
+                }),
+            })
+        }
+        Err(_) => todo!(),
+    }
+}
+
+pub(crate) fn constant_to_js(c: Constant) -> Result<JsValue, ConvError> {
+    let arr = Array::new();
+    arr.push(&JsValue::from_f64(5.0));
+    Ok(arr.into())
+}

--- a/bindings/ergo-lib-wasm/src/error_conversion.rs
+++ b/bindings/ergo-lib-wasm/src/error_conversion.rs
@@ -35,6 +35,8 @@ use serde_json::error::Error;
 use url::ParseError;
 use wasm_bindgen::JsValue;
 
+use crate::ast::js_conv::ConvError;
+
 /// Ideally we'd like to implement `From<E> for JsValue` for a range of different `ergo-lib` error
 /// types `E`, but Rust orphan rules prevent this. A way to get around this limitation is to wrap
 /// `Jsvalue` within a local type.
@@ -105,3 +107,4 @@ from_error_to_wrap_via_debug!(NodeError);
 from_error_to_wrap_via_debug!(ParseError);
 #[cfg(feature = "rest")]
 from_error_to_wrap_via_debug!(PeerDiscoveryError);
+from_error_to_wrap_via_debug!(ConvError);

--- a/bindings/ergo-lib-wasm/src/error_conversion.rs
+++ b/bindings/ergo-lib-wasm/src/error_conversion.rs
@@ -77,6 +77,21 @@ from_error_to_wrap!(DecodeError);
 from_error_to_wrap!(TryFromSliceError);
 from_error_to_wrap!(AddrParseError);
 from_error_to_wrap!(TransactionSignatureVerificationError);
+from_error_to_wrap!(ErgoTreeError);
+from_error_to_wrap!(ChildIndexError);
+from_error_to_wrap!(BoundedVecOutOfBounds);
+from_error_to_wrap!(ExtSecretKeyError);
+from_error_to_wrap!(DerivationPathError);
+from_error_to_wrap!(VerifierError);
+from_error_to_wrap!(ExtPubKeyError);
+from_error_to_wrap!(ParseIntError);
+#[cfg(feature = "rest")]
+from_error_to_wrap!(NodeError);
+#[cfg(feature = "rest")]
+from_error_to_wrap!(PeerDiscoveryError);
+#[cfg(feature = "rest")]
+from_error_to_wrap!(ParseError);
+from_error_to_wrap!(ConvError);
 
 macro_rules! from_error_to_wrap_via_debug {
     ($t:ident) => {
@@ -90,21 +105,6 @@ macro_rules! from_error_to_wrap_via_debug {
     };
 }
 
-from_error_to_wrap_via_debug!(ErgoTreeError);
 from_error_to_wrap_via_debug!(ErgoTreeConstantError);
 from_error_to_wrap_via_debug!(ErgoTreeConstantsParsingError);
-from_error_to_wrap_via_debug!(ParseIntError);
-from_error_to_wrap_via_debug!(ChildIndexError);
-from_error_to_wrap_via_debug!(BoundedVecOutOfBounds);
-from_error_to_wrap_via_debug!(ExtSecretKeyError);
-from_error_to_wrap_via_debug!(DerivationPathError);
-from_error_to_wrap_via_debug!(ExtPubKeyError);
 from_error_to_wrap_via_debug!(NipopowProofError);
-from_error_to_wrap_via_debug!(VerifierError);
-#[cfg(feature = "rest")]
-from_error_to_wrap_via_debug!(NodeError);
-#[cfg(feature = "rest")]
-from_error_to_wrap_via_debug!(ParseError);
-#[cfg(feature = "rest")]
-from_error_to_wrap_via_debug!(PeerDiscoveryError);
-from_error_to_wrap_via_debug!(ConvError);

--- a/bindings/ergo-lib-wasm/src/utils.rs
+++ b/bindings/ergo-lib-wasm/src/utils.rs
@@ -20,7 +20,8 @@ impl MinerAddress {
     }
 }
 
-/// Wrapper for i64 for JS/TS
+/// Wrapper for i64 for JS/TS because JS Number can only represent 53 bits
+/// see https://stackoverflow.com/questions/17320706/javascript-long-integer
 #[wasm_bindgen]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct I64(i64);

--- a/bindings/ergo-lib-wasm/tests/test_constant.js
+++ b/bindings/ergo-lib-wasm/tests/test_constant.js
@@ -134,33 +134,35 @@ it("roundtrip Coll[Coll[Byte]]", async () => {
 it("roundtrip Coll[(Coll[Byte], Coll[Byte])]", async () => {
   let bytes1 = new Uint8Array([1, 2, 3]);
   let bytes2 = new Uint8Array([3, 2, 1]);
-  let value = [new Set([bytes1, bytes2]), new Set([bytes2, bytes1])];
+  let value = [ergo_wasm.array_as_tuple([bytes1, bytes2]), ergo_wasm.array_as_tuple([bytes2, bytes1])];
+  let expected_value = [[bytes1, bytes2], [bytes2, bytes1]];
   let c_js = ergo_wasm.Constant.from_js(value);
   expect(c_js != null);
   expect(c_js.dbg_tpe()).equal("SColl(STuple([SColl(SByte), SColl(SByte)]))");
   // console.log(c_js.dbg_inner());
-  assert.deepEqual(c_js.to_js(), value);
-  let back_c = ergo_wasm.Constant.from_js(c_js.to_js());
-  expect(back_c != null);
-  expect(back_c.dbg_inner()).equal(c_js.dbg_inner());
+  assert.deepEqual(c_js.to_js(), expected_value);
 });
 
 it("roundtrip EIP-24 R7 monster type", async () => {
   let bytes1 = new Uint8Array([1, 2, 3]);
   let bytes2 = new Uint8Array([4, 5, 6]);
-  let value = new Set([
-    [new Set([bytes1, bytes2])],
-    new Set([
-      [new Set([bytes1, new Set([10, 11])])],
-      [new Set([bytes2, new Set([12, 13])])]
+  let value = ergo_wasm.array_as_tuple([
+    [ergo_wasm.array_as_tuple([bytes1, bytes2])],
+    ergo_wasm.array_as_tuple([
+      [ergo_wasm.array_as_tuple([bytes1, ergo_wasm.array_as_tuple([10, 11])])],
+      [ergo_wasm.array_as_tuple([bytes2, ergo_wasm.array_as_tuple([12, 13])])]
     ])
   ]);
+  let expected_value = [
+    [[bytes1, bytes2]],
+    [
+      [[bytes1, [10, 11]]],
+      [[bytes2, [12, 13]]]
+    ]
+  ];
   let c_js = ergo_wasm.Constant.from_js(value);
   expect(c_js != null);
   expect(c_js.dbg_tpe()).equal("STuple([SColl(STuple([SColl(SByte), SColl(SByte)])), STuple([SColl(STuple([SColl(SByte), STuple([SInt, SInt])])), SColl(STuple([SColl(SByte), STuple([SInt, SInt])]))])])");
   // console.log(c_js.dbg_inner());
-  assert.deepEqual(c_js.to_js(), value);
-  let back_c = ergo_wasm.Constant.from_js(c_js.to_js());
-  expect(back_c != null);
-  expect(back_c.dbg_inner()).equal(c_js.dbg_inner());
+  assert.deepEqual(c_js.to_js(), expected_value);
 });

--- a/bindings/ergo-lib-wasm/tests/test_constant.js
+++ b/bindings/ergo-lib-wasm/tests/test_constant.js
@@ -129,7 +129,6 @@ it("roundtrip Coll[Coll[Byte]]", async () => {
   expect(c_js != null);
   expect(c_js.dbg_tpe()).equal("SColl(SColl(SByte))");
   assert.deepEqual(c_js.to_js(), value);
-  // expect(c_js.to_js().toString()).equal(value.toString());
 });
 
 it("roundtrip Coll[(Coll[Byte], Coll[Byte])]", async () => {
@@ -139,11 +138,11 @@ it("roundtrip Coll[(Coll[Byte], Coll[Byte])]", async () => {
   let c_js = ergo_wasm.Constant.from_js(value);
   expect(c_js != null);
   expect(c_js.dbg_tpe()).equal("SColl(STuple([SColl(SByte), SColl(SByte)]))");
-  console.log(c_js.dbg_inner());
+  // console.log(c_js.dbg_inner());
+  assert.deepEqual(c_js.to_js(), value);
   let back_c = ergo_wasm.Constant.from_js(c_js.to_js());
   expect(back_c != null);
   expect(back_c.dbg_inner()).equal(c_js.dbg_inner());
-  // assert.deepEqual(c_js.to_js(), value);
 });
 
 it("roundtrip EIP-24 R7 monster type", async () => {
@@ -159,7 +158,9 @@ it("roundtrip EIP-24 R7 monster type", async () => {
   let c_js = ergo_wasm.Constant.from_js(value);
   expect(c_js != null);
   expect(c_js.dbg_tpe()).equal("STuple([SColl(STuple([SColl(SByte), SColl(SByte)])), STuple([SColl(STuple([SColl(SByte), STuple([SInt, SInt])])), SColl(STuple([SColl(SByte), STuple([SInt, SInt])]))])])");
-  console.log(value.toString());
-  console.log(c_js.dbg_inner());
+  // console.log(c_js.dbg_inner());
   assert.deepEqual(c_js.to_js(), value);
+  let back_c = ergo_wasm.Constant.from_js(c_js.to_js());
+  expect(back_c != null);
+  expect(back_c.dbg_inner()).equal(c_js.dbg_inner());
 });

--- a/bindings/ergo-lib-wasm/tests/test_constant.js
+++ b/bindings/ergo-lib-wasm/tests/test_constant.js
@@ -22,7 +22,7 @@ it("roundtrip Constant i32", async () => {
   expect(decoded_c_value).equal(value);
 });
 
-it("roundtrip Constant i64", async () => {
+it("roundtrip i64 via to_i64", async () => {
   let value_str = "9223372036854775807"; // i64 max value
   let c = ergo_wasm.Constant.from_i64(ergo_wasm.I64.from_str(value_str));
   let encoded = c.encode_to_base16();
@@ -165,4 +165,26 @@ it("roundtrip EIP-24 R7 monster type", async () => {
   expect(c_js.dbg_tpe()).equal("STuple([SColl(STuple([SColl(SByte), SColl(SByte)])), STuple([SColl(STuple([SColl(SByte), STuple([SInt, SInt])])), SColl(STuple([SColl(SByte), STuple([SInt, SInt])]))])])");
   // console.log(c_js.dbg_inner());
   assert.deepEqual(c_js.to_js(), expected_value);
+});
+
+it("roundtrip i64", async () => {
+  let value_str = "9223372036854775807"; // i64 max value
+  let c_js = ergo_wasm.Constant.from_js(value_str);
+  let decoded_c_value = c_js.to_js();
+  expect(c_js.dbg_tpe()).equal("SLong");
+  expect(decoded_c_value).equal(value_str);
+});
+
+it("roundtrip BigInt", async () => {
+  let bigint = BigInt(92233720368547758071111111111111111111111111n);
+  let c_js = ergo_wasm.Constant.from_js(bigint);
+  expect(c_js.dbg_tpe()).equal("SBigInt");
+  let decoded_c_value = c_js.to_js();
+  expect(decoded_c_value).equal(bigint);
+  assert.deepEqual(c_js.to_js(), bigint);
+});
+
+it("too big BigInt fail", async () => {
+  let bigint = BigInt(92233720368547758071111111111111111111111111111111111111111111111111111111111111111111111111n);
+  expect(function () {ergo_wasm.Constant.from_js(bigint);}).to.throw();
 });

--- a/bindings/ergo-lib-wasm/tests/test_constant.js
+++ b/bindings/ergo-lib-wasm/tests/test_constant.js
@@ -120,3 +120,10 @@ it("roundtrip ErgoBox", async () => {
   assert(decoded_c_value != null);
   expect(decoded_c_value.to_json().toString()).equal(box.to_json().toString());
 });
+
+it("roundtrip Constant array of i32 (universal)", async () => {
+  let value = [2147483647, 1, 2]; // i32 max value
+  let c = ergo_wasm.Constant.from_js(value);
+  let value_decoded = c.to_js();
+  expect(value_decoded.toString()).equal(value.toString());
+});

--- a/ergotree-ir/src/types/stuple.rs
+++ b/ergotree-ir/src/types/stuple.rs
@@ -22,10 +22,16 @@ impl TryFrom<Vec<SType>> for STuple {
 }
 
 /// Tuple type
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct STuple {
     /// Tuple element types
     pub items: TupleItems<SType>,
+}
+
+impl std::fmt::Debug for STuple {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.items.clone().to_vec().fmt(f)
+    }
 }
 
 impl STuple {


### PR DESCRIPTION
Close #611

Todo:
- [x] make `Tuple` type to encode tuples in JS (instead of `Set`);
- [x] implement the rest of the `SType` hierarchy;