### PR TITLE
fix RNG panic in electron/vue on desktop

### DIFF
--- a/bindings/ergo-lib-wasm/Cargo.toml
+++ b/bindings/ergo-lib-wasm/Cargo.toml
@@ -26,7 +26,8 @@ bounded-integer = { version = "^0.5", features = ["types"] }
 futures = "0.3"
 
 # used in elliptic-curve(in ergo-lib), compiled here with WASM support
-# getrandom = {version = "0.2.7", features = ["js"]}
+getrandom = {version = "0.2.7", features = ["js"]}
+
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for

--- a/bindings/ergo-lib-wasm/Cargo.toml
+++ b/bindings/ergo-lib-wasm/Cargo.toml
@@ -26,7 +26,7 @@ bounded-integer = { version = "^0.5", features = ["types"] }
 futures = "0.3"
 
 # used in elliptic-curve(in ergo-lib), compiled here with WASM support
-getrandom = {version = "0.2.7", features = ["js"]}
+# getrandom = {version = "0.2.7", features = ["js"]}
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for

--- a/bindings/ergo-lib-wasm/Cargo.toml
+++ b/bindings/ergo-lib-wasm/Cargo.toml
@@ -26,7 +26,7 @@ bounded-integer = { version = "^0.5", features = ["types"] }
 futures = "0.3"
 
 # used in elliptic-curve(in ergo-lib), compiled here with WASM support
-getrandom = {version = "0.2.3", features = ["js"]}
+getrandom = {version = "0.2.7", features = ["js"]}
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for

--- a/bindings/ergo-lib-wasm/src/wallet.rs
+++ b/bindings/ergo-lib-wasm/src/wallet.rs
@@ -61,6 +61,7 @@ impl Wallet {
         boxes_to_spend: &ErgoBoxes,
         data_boxes: &ErgoBoxes,
     ) -> Result<Transaction, JsValue> {
+        crate::utils::set_panic_hook();
         let boxes_to_spend = boxes_to_spend.clone().into();
         let data_boxes = data_boxes.clone().into();
         let tx_context = ergo_lib::wallet::signing::TransactionContext::new(

--- a/ergo-chain-generation/Cargo.toml
+++ b/ergo-chain-generation/Cargo.toml
@@ -12,7 +12,7 @@ blake2 = "0.9"
 byteorder = "1"
 ergo-lib = {version = "^0.19.0", path = "../ergo-lib"}
 num-bigint = "0.4.0"
-rand = "0.8.4"
+rand = "0.8.5"
 sigma-test-util = { version = "^0.3.0", path = "../sigma-test-util" }
 ergo-chain-types = { version = "^0.6", path = "../ergo-chain-types" }
 ergo-nipopow = { version = "^0.6", path = "../ergo-nipopow" }

--- a/ergo-lib/Cargo.toml
+++ b/ergo-lib/Cargo.toml
@@ -37,7 +37,7 @@ sha2 = { version = "0.9.8" }
 hmac = { version = "0.11.0" }
 k256 = { version = "0.10.0", features = ["arithmetic", "ecdsa"] }
 pbkdf2 = "0.8"
-rand = "0.8.4"
+rand = "0.8.5"
 bitvec = { version = "0.22.3", optional = true }
 unicode-normalization = "0.1.19"
 lazy_static = "1.4"

--- a/ergo-rest/Cargo.toml
+++ b/ergo-rest/Cargo.toml
@@ -46,7 +46,7 @@ js-sys = "0.3"
 wasm-bindgen = "0.2"
 # Depdencies for `reqwest`
 serde_json = "1.0"
-# getrandom = { version = "0.2.7", features = ["js"] }
+getrandom = { version = "0.2.7", features = ["js"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"

--- a/ergo-rest/Cargo.toml
+++ b/ergo-rest/Cargo.toml
@@ -46,7 +46,7 @@ js-sys = "0.3"
 wasm-bindgen = "0.2"
 # Depdencies for `reqwest`
 serde_json = "1.0"
-getrandom = { version = "0.2", features = ["js"] }
+# getrandom = { version = "0.2.7", features = ["js"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"

--- a/ergo-rest/Cargo.toml
+++ b/ergo-rest/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3"
 thiserror = "1"
 derive_more = "0.99"
 proptest-derive = {version = "0.3.0", optional = true }
-rand = "0.8.4"
+rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = { version = "1.0", optional = true }
 url = "2.2"

--- a/ergotree-interpreter/Cargo.toml
+++ b/ergotree-interpreter/Cargo.toml
@@ -24,7 +24,6 @@ k256 = { version = "0.10.0", features = ["arithmetic", "ecdsa"] }
 elliptic-curve = {version = "0.11.6", features = [ "ff"]}
 blake2 = "0.9"
 rand = "0.8.5"
-getrandom = { version = "0.2.7", features = ["js"] }
 lazy_static = "1.4"
 thiserror = "1"
 derive_more = "0.99"

--- a/ergotree-interpreter/Cargo.toml
+++ b/ergotree-interpreter/Cargo.toml
@@ -24,6 +24,7 @@ k256 = { version = "0.10.0", features = ["arithmetic", "ecdsa"] }
 elliptic-curve = {version = "0.11.6", features = [ "ff"]}
 blake2 = "0.9"
 rand = "0.8.5"
+getrandom = { version = "0.2.7", features = ["js"] }
 lazy_static = "1.4"
 thiserror = "1"
 derive_more = "0.99"

--- a/ergotree-interpreter/Cargo.toml
+++ b/ergotree-interpreter/Cargo.toml
@@ -23,7 +23,7 @@ indexmap = "1.3.2"
 k256 = { version = "0.10.0", features = ["arithmetic", "ecdsa"] }
 elliptic-curve = {version = "0.11.6", features = [ "ff"]}
 blake2 = "0.9"
-rand = "0.8.4"
+rand = "0.8.5"
 lazy_static = "1.4"
 thiserror = "1"
 derive_more = "0.99"

--- a/ergotree-ir/Cargo.toml
+++ b/ergotree-ir/Cargo.toml
@@ -21,7 +21,7 @@ ergo-chain-types = { version = "^0.6.0", path = "../ergo-chain-types" }
 elliptic-curve = {version = "0.11.6", features = [ "ff"]}
 thiserror = "1"
 # used in elliptic-curve(in ergo-lib), compiled here with WASM support
-getrandom = {version = "0.2.7", features = ["js"]}
+# getrandom = {version = "0.2.7", features = ["js"]}
 lazy_static = "1.4"
 derive_more = "0.99"
 impl-trait-for-tuples = "0.2.0"

--- a/ergotree-ir/Cargo.toml
+++ b/ergotree-ir/Cargo.toml
@@ -21,7 +21,7 @@ ergo-chain-types = { version = "^0.6.0", path = "../ergo-chain-types" }
 elliptic-curve = {version = "0.11.6", features = [ "ff"]}
 thiserror = "1"
 # used in elliptic-curve(in ergo-lib), compiled here with WASM support
-getrandom = {version = "0.2.3", features = ["js"]}
+getrandom = {version = "0.2.7", features = ["js"]}
 lazy_static = "1.4"
 derive_more = "0.99"
 impl-trait-for-tuples = "0.2.0"

--- a/ergotree-ir/Cargo.toml
+++ b/ergotree-ir/Cargo.toml
@@ -62,5 +62,5 @@ json = ["serde", "serde_json", "serde_with", "bounded-vec/serde"]
 
 [dev-dependencies]
 sigma-test-util = { version = "^0.3.0", path = "../sigma-test-util" }
-rand = "0.8.3"
+rand = "0.8.5"
 pretty_assertions = "0.7.2"

--- a/gf2_192/Cargo.toml
+++ b/gf2_192/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 derive_more = "0.99"
-rand = "0.8.4"
+rand = "0.8.5"
 thiserror = "1"
 proptest-derive = {version = "0.3.0", optional = true }
 


### PR DESCRIPTION
trace:
```
panicked at 'could not initialize thread_rng: Node.js crypto module is unavailable', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/rand-0.8.5/src/rngs/thread.rs:72:17

Stack:

Error
    at __wbg_new_693216e109162396 (webpack-internal:///./node_modules/ergo-lib-wasm-browser/ergo_lib_wasm_bg.js:6914:17)
    at console_error_panic_hook::hook::h992992de3f0fa9b9 (wasm://wasm/00ffe776:wasm-function[1812]:0x198005)
    at core::ops::function::Fn::call::hc810e5369804b9f1 (wasm://wasm/00ffe776:wasm-function[10901]:0x29a677)
    at std::panicking::rust_panic_with_hook::h1c368a27f9b0afe1 (wasm://wasm/00ffe776:wasm-function[2967]:0x1e955f)
    at std::panicking::begin_panic_handler::{{closure}}::h8e1f8b682ca33009 (wasm://wasm/00ffe776:wasm-function[4676]:0x236ce4)
    at std::sys_common::backtrace::__rust_end_short_backtrace::h7f7da41799766719 (wasm://wasm/00ffe776:wasm-function[9950]:0x2973b2)
    at rust_begin_unwind (wasm://wasm/00ffe776:wasm-function[7859]:0x281b8c)
    at core::panicking::panic_fmt::hcdb13a4b2416cf82 (wasm://wasm/00ffe776:wasm-function[7922]:0x2829f3)
    at std::thread::local::lazy::LazyKeyInner<T>::initialize::hc4dfa70367192fbc (wasm://wasm/00ffe776:wasm-function[1709]:0x18ea94)
    at rand::rngs::thread::THREAD_RNG_KEY::__getit::h8a182064bee393d6 (wasm://wasm/00ffe776:wasm-function[9567]:0x295009)
```

Fix:
> Looks like this https://github.com/rust-random/getrandom/issues/256#issuecomment-1152904556 works 🥳 
> still running some tests but that seems to be the solution for us. Using browser wasm version and adding the at the end of the bindings file

Even better fix:
Figure out why `cardano-serialization-lib` JS bindings work and use the same approach.