### PR TITLE
Add {set_exports} script for {ergo-lib-wasm}

### DIFF
--- a/bindings/ergo-lib-wasm/package.json
+++ b/bindings/ergo-lib-wasm/package.json
@@ -10,8 +10,8 @@
         "doc": "jsdoc -c jsdoc.json pkg/ergo_wallet_wasm.js README.md -d docs",
         "build-nodejs": "rm -rf ./pkg-nodejs && wasm-pack build --target nodejs --out-dir pkg-nodejs && cd pkg-nodejs && node ../scripts/publish_helper -nodejs",
         "build-nodejs-alpha": "rm -rf ./pkg-nodejs && wasm-pack build --target nodejs --out-dir pkg-nodejs && cd pkg-nodejs && node ../scripts/publish_helper -nodejs && npm version minor && node ../scripts/set_alpha_version -nodejs $(git rev-parse --short HEAD)",
-        "build-browser": "rm -rf ./pkg-browser && wasm-pack build --target browser --out-dir pkg-browser --features rest && cd pkg-browser && node ../scripts/publish_helper -browser",
-        "build-browser-alpha": "rm -rf ./pkg-browser && wasm-pack build --target browser --out-dir pkg-browser --features rest && cd pkg-browser && node ../scripts/publish_helper -browser && npm version minor && node ../scripts/set_alpha_version -browser $(git rev-parse --short HEAD)",
+        "build-browser": "rm -rf ./pkg-browser && wasm-pack build --target browser --out-dir pkg-browser --features rest && cd pkg-browser && node ../scripts/publish_helper -browser && node ../scripts/set_exports",
+        "build-browser-alpha": "rm -rf ./pkg-browser && wasm-pack build --target browser --out-dir pkg-browser --features rest && cd pkg-browser && node ../scripts/publish_helper -browser && node ../scripts/set_exports && npm version minor && node ../scripts/set_alpha_version -browser $(git rev-parse --short HEAD)",
         "publish-nodejs": "npm run build-nodejs &&  cd pkg-nodejs && npm publish",
         "publish-browser": "npm run build-browser && cd pkg-browser && npm publish"
     },

--- a/bindings/ergo-lib-wasm/scripts/set_exports.js
+++ b/bindings/ergo-lib-wasm/scripts/set_exports.js
@@ -1,0 +1,19 @@
+const fs = require("fs");
+
+// Remove "module" from the generated (old) {package.json}
+const {
+  module: unusedModule,
+  ...oldPackageJson
+} = require(`../pkg-browser/package.json`);
+
+const newPackageJson = {
+  ...oldPackageJson,
+  type: "module",
+  exports: {
+    ".": "./ergo_lib_wasm",
+  },
+};
+
+console.log(newPackageJson);
+
+fs.writeFileSync("./package.json", JSON.stringify(newPackageJson, null, 2));


### PR DESCRIPTION
When {wasm-pack} is run with browser target, it generates a {package.json} in which there is a {module} field, but no {main}, {type} or {exports} field is present. This causes some of the modern tools which run in Node be unable to use the package (Vitest is an example).

Although it may seem irrational to use the browser package in Node, but it makes sense when we want to write tests. Many test tools such as Jest and Vitest run in Node.

Add a {set_exports} script to be run after {wasm-pack}, updating the generated {package.json} as follows:
- Add an {exports} field to enable new Node entry resolution feature
- Add {"type": "module"} to indicate that this is an ESM module
- Remove {module}, as it's no longer needed

{wasm-pack} may fix the issue in the future or new module entry resolution mechanisms may be introduced in the future. Until then, this script will enable the use of the package without getting browser environment related issues when run in Node.

Related {wasm-pack} PR:
https://github.com/rustwasm/wasm-pack/pull/1061

Closes #632.