### PR TITLE
Fix bottom-up and top-down traverals in prover

### DIFF
--- a/ergotree-interpreter/src/sigma_protocol/proof_tree.rs
+++ b/ergotree-interpreter/src/sigma_protocol/proof_tree.rs
@@ -180,13 +180,13 @@ where
                     }))
                     .into()
                 }
-                UnprovenConjecture::CthresholdUnproven(ct) => UnprovenTree::UnprovenConjecture(
-                    UnprovenConjecture::CthresholdUnproven(CthresholdUnproven {
-                        children: ct.children.clone().try_mapped(|c| rewrite_bu(c, f))?,
-                        ..ct.clone()
-                    }),
-                )
-                .into(),
+                UnprovenConjecture::CthresholdUnproven(ct) => {
+                    UnprovenTree::UnprovenConjecture(UnprovenConjecture::CthresholdUnproven(
+                        ct.clone()
+                            .with_children(ct.clone().children.try_mapped(|c| rewrite_bu(c, f))?),
+                    ))
+                    .into()
+                }
             },
         },
         ProofTree::UncheckedTree(unch_tree) => match unch_tree {
@@ -278,13 +278,13 @@ where
                     }))
                     .into()
                 }
-                UnprovenConjecture::CthresholdUnproven(ct) => UnprovenTree::UnprovenConjecture(
-                    UnprovenConjecture::CthresholdUnproven(CthresholdUnproven {
-                        children: ct.children.clone().try_mapped(|c| rewrite_td(c, f))?,
-                        ..ct.clone()
-                    }),
-                )
-                .into(),
+                UnprovenConjecture::CthresholdUnproven(ct) => {
+                    UnprovenTree::UnprovenConjecture(UnprovenConjecture::CthresholdUnproven(
+                        ct.clone()
+                            .with_children(ct.clone().children.try_mapped(|c| rewrite_td(c, f))?),
+                    ))
+                    .into()
+                }
             },
         },
         ProofTree::UncheckedTree(unch_tree) => match unch_tree {

--- a/ergotree-interpreter/src/sigma_protocol/prover.rs
+++ b/ergotree-interpreter/src/sigma_protocol/prover.rs
@@ -1214,8 +1214,6 @@ mod tests {
     use super::*;
     use crate::sigma_protocol::private_input::DhTupleProverInput;
     use crate::sigma_protocol::private_input::DlogProverInput;
-    use crate::sigma_protocol::verifier::TestVerifier;
-    use crate::sigma_protocol::verifier::Verifier;
     use ergotree_ir::mir::atleast::Atleast;
     use ergotree_ir::mir::collection::Collection;
     use ergotree_ir::mir::constant::Constant;
@@ -1467,22 +1465,13 @@ mod tests {
 
         let message = vec![0u8; 100];
         let ctx: Rc<Context> = force_any_val::<Context>().into();
-        let res = prover
-            .prove(
-                &tree,
-                &Env::empty(),
-                ctx.clone(),
-                message.as_slice(),
-                &HintsBag::empty(),
-            )
-            .unwrap()
-            .proof;
-        let verifier = TestVerifier;
-        assert!(
-            verifier
-                .verify(&tree, &Env::empty(), ctx, res, message.as_slice())
-                .unwrap()
-                .result,
-        )
+        let res = prover.prove(
+            &tree,
+            &Env::empty(),
+            ctx,
+            message.as_slice(),
+            &HintsBag::empty(),
+        );
+        assert!(res.is_err());
     }
 }

--- a/ergotree-interpreter/src/sigma_protocol/prover.rs
+++ b/ergotree-interpreter/src/sigma_protocol/prover.rs
@@ -245,7 +245,7 @@ fn mark_real<P: Prover + ?Sized>(
     unproven_tree: UnprovenTree,
     hints_bag: &HintsBag,
 ) -> Result<UnprovenTree, ProverError> {
-    proof_tree::rewrite(unproven_tree.into(), &|tree| {
+    proof_tree::rewrite_bu(unproven_tree.into(), &|tree| {
         Ok(match tree {
             ProofTree::UnprovenTree(unp) => match unp {
                 UnprovenTree::UnprovenLeaf(unp_leaf) => {
@@ -374,7 +374,7 @@ fn polish_simulated<P: Prover + ?Sized>(
     _prover: &P,
     unproven_tree: UnprovenTree,
 ) -> Result<UnprovenTree, ProverError> {
-    proof_tree::rewrite(unproven_tree.into(), &|tree| match tree {
+    proof_tree::rewrite_td(unproven_tree.into(), &|tree| match tree {
         ProofTree::UnprovenTree(ut) => match ut {
             UnprovenTree::UnprovenLeaf(_) => Ok(None),
             UnprovenTree::UnprovenConjecture(conj) => match conj {
@@ -726,7 +726,7 @@ fn simulate_and_commit(
     unproven_tree: UnprovenTree,
     hints_bag: &HintsBag,
 ) -> Result<UnprovenTree, ProverError> {
-    proof_tree::rewrite(unproven_tree.into(), &|tree| {
+    proof_tree::rewrite_td(unproven_tree.into(), &|tree| {
         match tree {
             // Step 4 part 1: If the node is marked "real", jhen each of its simulated children gets a fresh uniformly
             // random challenge in {0,1}^t.
@@ -1033,7 +1033,7 @@ fn proving<P: Prover + ?Sized>(
     proof_tree: ProofTree,
     hints_bag: &HintsBag,
 ) -> Result<ProofTree, ProverError> {
-    proof_tree::rewrite(proof_tree, &|tree| {
+    proof_tree::rewrite_td(proof_tree, &|tree| {
         match &tree {
             ProofTree::UncheckedTree(unch) => match unch {
                 UncheckedTree::UncheckedLeaf(_) => Ok(None),


### PR DESCRIPTION
Close #643
Close #579

Apply @kettlebell fix https://gist.github.com/kettlebell/21f94906a89072afb97fbfe5ff78df33 to `rewrite` and rename it to `rewrite_bu`.
Rename original `rewrite` to `rewrite_td`.
Add `test_prove_inner_threshold` from https://github.com/ergoplatform/sigma-rust/issues/579#issuecomment-1259058014 to simulate fail on "wrong" traversal order (BU vs TD).
Make `CthresholdUnproven::with_polynomial` failable (check polynomial bytes size against children count and k).