### PR TITLE
Unparseable register value should not prevent parsing ErgoBox from JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ on:
       - opened
       - synchronize
 
-env:
-  RUSTV: '1.63'
-
 jobs:
   build_wo_default_features:
     name: Build without default features
@@ -21,7 +18,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUSTV }}
           override: true
       - name: Build ergotree-ir
         uses: actions-rs/cargo@v1
@@ -47,7 +43,6 @@ jobs:
           fetch-depth: 0
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUSTV }}
           override: true
       - name: cargo fetch
         uses: actions-rs/cargo@v1
@@ -71,7 +66,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUSTV }}
           override: true
       - name: rust-tarpaulin code coverage check
         uses: actions-rs/tarpaulin@master
@@ -95,7 +89,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUSTV }}
           components: clippy
           override: true
       - name: Check with Clippy
@@ -132,7 +125,6 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUSTV }}
           override: true
 
       - name: install deps
@@ -194,7 +186,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUSTV }}
           components: rustfmt
           override: true
       - name: Check formatting
@@ -210,7 +201,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUSTV }}
           override: true
       - name: cargo fetch
         uses: actions-rs/cargo@v1
@@ -258,7 +248,6 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUSTV }}
           override: true
 
       - name: build and run tests
@@ -276,7 +265,6 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.RUSTV }}
           override: true
 
       - name: install deps

--- a/bindings/ergo-lib-c-core/src/ergo_box.rs
+++ b/bindings/ergo-lib-c-core/src/ergo_box.rs
@@ -135,7 +135,11 @@ pub unsafe fn ergo_box_candidate_register_value(
 ) -> Result<bool, Error> {
     let candidate = const_ptr_as_ref(ergo_box_candidate_ptr, "ergo_box_candidate_ptr")?;
     let constant_out = mut_ptr_as_mut(constant_out, "constant_out")?;
-    if let Some(c) = candidate.0.additional_registers.get(register_id.into()) {
+    if let Some(c) = candidate
+        .0
+        .additional_registers
+        .get_constant(register_id.into())
+    {
         *constant_out = Box::into_raw(Box::new(Constant(c.clone())));
         Ok(true)
     } else {
@@ -286,7 +290,11 @@ pub unsafe fn ergo_box_register_value(
 ) -> Result<bool, Error> {
     let ergo_box = const_ptr_as_ref(ergo_box_ptr, "ergo_box_ptr")?;
     let constant_out = mut_ptr_as_mut(constant_out, "constant_out")?;
-    if let Some(c) = ergo_box.0.additional_registers.get(register_id.into()) {
+    if let Some(c) = ergo_box
+        .0
+        .additional_registers
+        .get_constant(register_id.into())
+    {
         *constant_out = Box::into_raw(Box::new(Constant(c.clone())));
         Ok(true)
     } else {

--- a/bindings/ergo-lib-wasm/Cargo.toml
+++ b/bindings/ergo-lib-wasm/Cargo.toml
@@ -50,18 +50,18 @@ version = "1.9.1"
 features = [ "json" ]
 
 [dependencies.wasm-bindgen]
-version = "0.2.79"
+version = "0.2.83"
 features = []
 
 [dependencies.wasm-bindgen-futures]
-version = "0.4.28"
+version = "0.4.33"
 
 [dependencies.bounded-vec]
 version = "^0.7.0"
 features = ["serde"]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.29"
+wasm-bindgen-test = "0.3.33"
 ergo-lib = { version = "^0.21.0", path = "../../ergo-lib", features = ["arbitrary"] }
 
 [dev-dependencies.proptest]

--- a/bindings/ergo-lib-wasm/Cargo.toml
+++ b/bindings/ergo-lib-wasm/Cargo.toml
@@ -74,5 +74,5 @@ default-features = false
 features = ["std"]
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-Os", "--enable-mutable-globals"]
-# wasm-opt = false
+# wasm-opt = ["-Os", "--enable-mutable-globals"]
+wasm-opt = false

--- a/bindings/ergo-lib-wasm/Cargo.toml
+++ b/bindings/ergo-lib-wasm/Cargo.toml
@@ -74,5 +74,5 @@ default-features = false
 features = ["std"]
 
 [package.metadata.wasm-pack.profile.release]
-# wasm-opt = ["-Os", "--enable-mutable-globals"]
-wasm-opt = false
+wasm-opt = ["-Os", "--enable-mutable-globals"]
+# wasm-opt = false

--- a/bindings/ergo-lib-wasm/src/ergo_box.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_box.rs
@@ -83,7 +83,7 @@ impl ErgoBoxCandidate {
             .into())
     }
 
-    /// Returns value (ErgoTree constant) stored in the register or None if the register is empty
+    /// Returns value (ErgoTree constant) stored in the register or None if the register is empty or cannot be parsed
     pub fn register_value(&self, register_id: NonMandatoryRegisterId) -> Option<Constant> {
         self.0
             .additional_registers
@@ -195,7 +195,7 @@ impl ErgoBox {
         self.0.value.into()
     }
 
-    /// Returns value (ErgoTree constant) stored in the register or None if the register is empty
+    /// Returns value (ErgoTree constant) stored in the register or None if the register is empty or cannot be parsed
     pub fn register_value(&self, register_id: NonMandatoryRegisterId) -> Option<Constant> {
         self.0
             .additional_registers

--- a/bindings/ergo-lib-wasm/src/ergo_box.rs
+++ b/bindings/ergo-lib-wasm/src/ergo_box.rs
@@ -87,7 +87,7 @@ impl ErgoBoxCandidate {
     pub fn register_value(&self, register_id: NonMandatoryRegisterId) -> Option<Constant> {
         self.0
             .additional_registers
-            .get(register_id.into())
+            .get_constant(register_id.into())
             .cloned()
             .map(Constant::from)
     }
@@ -199,7 +199,7 @@ impl ErgoBox {
     pub fn register_value(&self, register_id: NonMandatoryRegisterId) -> Option<Constant> {
         self.0
             .additional_registers
-            .get(register_id.into())
+            .get_constant(register_id.into())
             .cloned()
             .map(Constant::from)
     }

--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+
+### Changed
+- uparseable register value should not prevent parsing `ErgoBox` from JSON [#647](https://github.com/ergoplatform/sigma-rust/pull/647);
+- rename `NonMandatoryRegisters:get` to `NonMandatoryRegisters::get_constant` and return `None` if the register value is unparseable [#647](https://github.com/ergoplatform/sigma-rust/pull/647);
+- add `NonMandatoryRegisters:get` returning new `RegisterValue` holding either a `Constant` or unparseable bytes [#647](https://github.com/ergoplatform/sigma-rust/pull/647);
+
+
 ## [0.21.0] - 2022-10-27
 
 ### Changed

--- a/ergo-lib/src/chain/ergo_box/box_builder.rs
+++ b/ergo-lib/src/chain/ergo_box/box_builder.rs
@@ -348,7 +348,7 @@ mod tests {
         builder.set_register_value(R4, reg_value.clone());
         assert_eq!(builder.register_value(&R4).unwrap(), &reg_value);
         let b = builder.build().unwrap();
-        assert_eq!(b.additional_registers.get(R4).unwrap(), &reg_value);
+        assert_eq!(b.additional_registers.get_constant(R4).unwrap(), &reg_value);
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
         builder.delete_register_value(&R4);
         assert!(builder.register_value(&R4).is_none());
         let b = builder.build().unwrap();
-        assert!(b.additional_registers.get(R4).is_none());
+        assert!(b.additional_registers.get_constant(R4).is_none());
     }
 
     #[test]
@@ -382,7 +382,7 @@ mod tests {
         assert_eq!(
             out_box
                 .additional_registers
-                .get(NonMandatoryRegisterId::R4)
+                .get_constant(NonMandatoryRegisterId::R4)
                 .unwrap()
                 .base16_str()
                 .unwrap(),
@@ -392,7 +392,7 @@ mod tests {
         assert_eq!(
             out_box
                 .additional_registers
-                .get(NonMandatoryRegisterId::R5)
+                .get_constant(NonMandatoryRegisterId::R5)
                 .unwrap()
                 .base16_str()
                 .unwrap(),
@@ -402,7 +402,7 @@ mod tests {
         assert_eq!(
             out_box
                 .additional_registers
-                .get(NonMandatoryRegisterId::R6)
+                .get_constant(NonMandatoryRegisterId::R6)
                 .unwrap()
                 .base16_str()
                 .unwrap(),

--- a/ergotree-ir/src/chain/ergo_box.rs
+++ b/ergotree-ir/src/chain/ergo_box.rs
@@ -146,7 +146,7 @@ impl ErgoBox {
         Ok(Digest32::from(*hash).into())
     }
 
-    /// Get register value
+    /// Get register value, or None if register is empty or cannot be parsed
     pub fn get_register(&self, id: RegisterId) -> Option<Constant> {
         match id {
             RegisterId::MandatoryRegisterId(id) => match id {

--- a/ergotree-ir/src/chain/ergo_box.rs
+++ b/ergotree-ir/src/chain/ergo_box.rs
@@ -157,7 +157,9 @@ impl ErgoBox {
                 MandatoryRegisterId::R2 => Some(self.tokens_raw().into()),
                 MandatoryRegisterId::R3 => Some(self.creation_info().into()),
             },
-            RegisterId::NonMandatoryRegisterId(id) => self.additional_registers.get(id).cloned(),
+            RegisterId::NonMandatoryRegisterId(id) => {
+                self.additional_registers.get_constant(id).cloned()
+            }
         }
     }
 

--- a/ergotree-ir/src/chain/ergo_box/register.rs
+++ b/ergotree-ir/src/chain/ergo_box/register.rs
@@ -203,9 +203,9 @@ impl NonMandatoryRegisters {
         self.0.is_empty()
     }
 
-    /// Return true if register value is parsed as a Constant
-    pub fn is_parseable(&self, reg_id: NonMandatoryRegisterId) -> Option<bool> {
-        self.0.get(reg_id as usize).map(|v| v.is_parseable())
+    /// Get register value (returns None, if there is no value for the given register id)
+    pub fn get(&self, reg_id: NonMandatoryRegisterId) -> Option<&RegisterValue> {
+        self.0.get(reg_id as usize)
     }
 
     /// Get register value as a Constant (returns None, if there is no value for the given register id or if it's an unparseable)
@@ -214,22 +214,19 @@ impl NonMandatoryRegisters {
             .get(reg_id as usize - NonMandatoryRegisterId::START_INDEX)
             .and_then(|rv| rv.as_option_constant())
     }
-
-    /// Get register value as bytes (returns None, if there is no value for the given register id)
-    pub fn get_bytes(&self, reg_id: NonMandatoryRegisterId) -> Option<Vec<u8>> {
-        self.0
-            .get(reg_id as usize - NonMandatoryRegisterId::START_INDEX)
-            .map(|rv| rv.sigma_serialize_bytes())
-    }
 }
 
+/// Register value (either Constant or bytes if it's unparseable)
 #[derive(PartialEq, Eq, Debug, Clone, From)]
-pub(crate) enum RegisterValue {
+pub enum RegisterValue {
+    /// Constant value
     Parsed(Constant),
+    /// Unparseable bytes
     Unparseable(Vec<u8>),
 }
 
 impl RegisterValue {
+    /// Return a Constant if it's parsed, otherwise None
     pub fn as_option_constant(&self) -> Option<&Constant> {
         match self {
             RegisterValue::Parsed(c) => Some(c),
@@ -242,13 +239,6 @@ impl RegisterValue {
         match self {
             RegisterValue::Parsed(c) => c.sigma_serialize_bytes().unwrap(),
             RegisterValue::Unparseable(bytes) => bytes.clone(),
-        }
-    }
-
-    fn is_parseable(&self) -> bool {
-        match self {
-            RegisterValue::Parsed(_) => true,
-            RegisterValue::Unparseable(_) => false,
         }
     }
 }

--- a/ergotree-ir/src/serialization/serializable.rs
+++ b/ergotree-ir/src/serialization/serializable.rs
@@ -50,10 +50,10 @@ pub enum SigmaParsingError {
     #[error("invalid op code: {0}")]
     InvalidOpCode(u8),
     /// Lacking support for the op
-    #[error("not implemented op error")]
+    #[error("not implemented op error: {0}")]
     NotImplementedOpCode(String),
     /// Failed to parse type
-    #[error("type parsing error")]
+    #[error("type parsing error, invalid type code: {0}")]
     InvalidTypeCode(u8),
     /// Failed to decode VLQ
     #[error("vlq encode error: {0}")]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.63"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,1 @@
-[toolchain]
-channel = "1.63"
+1.63


### PR DESCRIPTION
Introduce RegisterValue to hold either Constant or unparseable bytes

- rename `NonMandatoryRegisters:get` to `NonMandatoryRegisters::get_constant` and return `None` if the register value is unparseable;
- add `NonMandatoryRegisters:get` returning new `RegisterValue` holding either a `Constant` or unparseable bytes;
