### PR TITLE
expose constant value and type in c bindings

### DIFF
--- a/bindings/ergo-lib-c-core/src/constant.rs
+++ b/bindings/ergo-lib-c-core/src/constant.rs
@@ -42,6 +42,20 @@ pub unsafe fn constant_to_base16_str(constant_ptr: ConstConstantPtr) -> Result<S
     Ok(s)
 }
 
+/// Returns the debug representation of the type of the constant as string or return an error if serialization failed
+pub unsafe fn constant_type_to_dbg_str(constant_ptr: ConstConstantPtr) -> Result<String, Error> {
+    let constant = const_ptr_as_ref(constant_ptr, "constant_ptr")?;
+    let s = format!("{:?}", constant.0.tpe);
+    Ok(s)
+}
+
+/// Returns the debug representation of the value of the constant as string or return an error if serialization failed
+pub unsafe fn constant_value_to_dbg_str(constant_ptr: ConstConstantPtr) -> Result<String, Error> {
+    let constant = const_ptr_as_ref(constant_ptr, "constant_ptr")?;
+    let s = format!("{:?}", constant.0.v);
+    Ok(s)
+}
+
 /// Create from i32 value
 pub unsafe fn constant_from_i32(value: i32, constant_out: *mut ConstantPtr) -> Result<(), Error> {
     let constant_out = mut_ptr_as_mut(constant_out, "constant_out")?;

--- a/bindings/ergo-lib-c/src/constant.rs
+++ b/bindings/ergo-lib-c/src/constant.rs
@@ -41,6 +41,42 @@ pub unsafe extern "C" fn ergo_lib_constant_to_base16(
     Error::c_api_from(res)
 }
 
+/// Returns the debug representation of the type of the constant as string
+/// or return an error if serialization failed
+#[no_mangle]
+pub unsafe extern "C" fn ergo_lib_constant_type_to_dbg_str(
+    constant_ptr: ConstConstantPtr,
+    _bytes_str: *mut *const c_char,
+) -> ErrorPtr {
+    #[allow(clippy::unwrap_used)]
+    let res = match constant_type_to_dbg_str(constant_ptr) {
+        Ok(s) => {
+            *_bytes_str = CString::new(s).unwrap().into_raw();
+            Ok(())
+        }
+        Err(e) => Err(e),
+    };
+    Error::c_api_from(res)
+}
+
+/// Returns the debug representation of the value of the constant as string
+/// or return an error if serialization failed
+#[no_mangle]
+pub unsafe extern "C" fn ergo_lib_constant_value_to_dbg_str(
+    constant_ptr: ConstConstantPtr,
+    _bytes_str: *mut *const c_char,
+) -> ErrorPtr {
+    #[allow(clippy::unwrap_used)]
+    let res = match constant_value_to_dbg_str(constant_ptr) {
+        Ok(s) => {
+            *_bytes_str = CString::new(s).unwrap().into_raw();
+            Ok(())
+        }
+        Err(e) => Err(e),
+    };
+    Error::c_api_from(res)
+}
+
 /// Create from i32 value
 #[no_mangle]
 pub unsafe extern "C" fn ergo_lib_constant_from_i32(value: i32, constant_out: *mut ConstantPtr) {


### PR DESCRIPTION
Makes the value and type of a Constant available as debug string in the bindings for C