### PR TITLE
update wasm-pack build command to use --dev profile for *-alpha builds;

### DIFF
--- a/bindings/ergo-lib-wasm/package.json
+++ b/bindings/ergo-lib-wasm/package.json
@@ -5,13 +5,13 @@
     "scripts": {
         "build": "webpack",
         "serve": "cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --target browser && webpack-dev-server",
-        "test": "cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --target nodejs && mocha --require @babel/register --require @babel/polyfill 'tests/test*.js'",
+        "test": "cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --target nodejs --dev && mocha --require @babel/register --require @babel/polyfill 'tests/test*.js'",
         "test-browser": "rm -rf ./pkg && npm run build-browser && mv ./pkg-browser ./pkg && ./node_modules/.bin/karma start",
         "doc": "jsdoc -c jsdoc.json pkg/ergo_wallet_wasm.js README.md -d docs",
         "build-nodejs": "rm -rf ./pkg-nodejs && cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --target nodejs --out-dir pkg-nodejs && cd pkg-nodejs && node ../scripts/publish_helper -nodejs",
-        "build-nodejs-alpha": "rm -rf ./pkg-nodejs && cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --target nodejs --out-dir pkg-nodejs && cd pkg-nodejs && node ../scripts/publish_helper -nodejs && npm version minor && node ../scripts/set_alpha_version -nodejs $(git rev-parse --short HEAD)",
+        "build-nodejs-alpha": "rm -rf ./pkg-nodejs && cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --dev --target nodejs --out-dir pkg-nodejs && cd pkg-nodejs && node ../scripts/publish_helper -nodejs && npm version minor && node ../scripts/set_alpha_version -nodejs $(git rev-parse --short HEAD)",
         "build-browser": "rm -rf ./pkg-browser && cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --target browser --out-dir pkg-browser --features rest && cd pkg-browser && node ../scripts/publish_helper -browser && node ../scripts/set_exports",
-        "build-browser-alpha": "rm -rf ./pkg-browser && cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --target browser --out-dir pkg-browser --features rest && cd pkg-browser && node ../scripts/publish_helper -browser && node ../scripts/set_exports && npm version minor && node ../scripts/set_alpha_version -browser $(git rev-parse --short HEAD)",
+        "build-browser-alpha": "rm -rf ./pkg-browser && cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --dev --target browser --out-dir pkg-browser --features rest && cd pkg-browser && node ../scripts/publish_helper -browser && node ../scripts/set_exports && npm version minor && node ../scripts/set_alpha_version -browser $(git rev-parse --short HEAD)",
         "publish-nodejs": "npm run build-nodejs &&  cd pkg-nodejs && npm publish",
         "publish-browser": "npm run build-browser && cd pkg-browser && npm publish"
     },


### PR DESCRIPTION
Should disable wasm-opt phase for alhpa JS builds. 
wasm-opt cleans out debug symbols and makes stacktrace for console_error_panic_hook crypted and unusable.
Discovered while digging into #698 