### PR TITLE
Use avltree fork to fix empty hash

### DIFF
--- a/ergotree-interpreter/Cargo.toml
+++ b/ergotree-interpreter/Cargo.toml
@@ -34,8 +34,8 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
-scorex_crypto_avltree = "0.1.0"
-gf2_192 = { version = "^0.26.0", path = "../gf2_192" }
+ergo_avltree_rust = "0.1.0"
+gf2_192 = { version = "^0.24.1", path = "../gf2_192" }
 miette = { workspace = true }
 hashbrown = "0.14.1"
 

--- a/ergotree-interpreter/Cargo.toml
+++ b/ergotree-interpreter/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 ergo_avltree_rust = "0.1.0"
-gf2_192 = { version = "^0.24.1", path = "../gf2_192" }
+gf2_192 = { version = "^0.26.0", path = "../gf2_192" }
 miette = { workspace = true }
 hashbrown = "0.14.1"
 

--- a/ergotree-interpreter/src/eval/create_avl_tree.rs
+++ b/ergotree-interpreter/src/eval/create_avl_tree.rs
@@ -44,14 +44,14 @@ mod tests {
     use super::*;
     use crate::eval::tests::eval_out_wo_ctx;
 
+    use ergo_avltree_rust::authenticated_tree_ops::AuthenticatedTreeOps;
+    use ergo_avltree_rust::batch_avl_prover::BatchAVLProver;
+    use ergo_avltree_rust::batch_node::{AVLTree, Node, NodeHeader};
     use ergo_chain_types::ADDigest;
     use ergotree_ir::mir::{
         avl_tree_data::{AvlTreeData, AvlTreeFlags},
         expr::Expr,
     };
-    use ergo_avltree_rust::authenticated_tree_ops::AuthenticatedTreeOps;
-    use ergo_avltree_rust::batch_avl_prover::BatchAVLProver;
-    use ergo_avltree_rust::batch_node::{AVLTree, Node, NodeHeader};
     use sigma_ser::ScorexSerializable;
 
     #[test]

--- a/ergotree-interpreter/src/eval/create_avl_tree.rs
+++ b/ergotree-interpreter/src/eval/create_avl_tree.rs
@@ -49,9 +49,9 @@ mod tests {
         avl_tree_data::{AvlTreeData, AvlTreeFlags},
         expr::Expr,
     };
-    use scorex_crypto_avltree::authenticated_tree_ops::AuthenticatedTreeOps;
-    use scorex_crypto_avltree::batch_avl_prover::BatchAVLProver;
-    use scorex_crypto_avltree::batch_node::{AVLTree, Node, NodeHeader};
+    use ergo_avltree_rust::authenticated_tree_ops::AuthenticatedTreeOps;
+    use ergo_avltree_rust::batch_avl_prover::BatchAVLProver;
+    use ergo_avltree_rust::batch_node::{AVLTree, Node, NodeHeader};
     use sigma_ser::ScorexSerializable;
 
     #[test]

--- a/ergotree-interpreter/src/eval/savltree.rs
+++ b/ergotree-interpreter/src/eval/savltree.rs
@@ -6,13 +6,13 @@ use ergotree_ir::mir::avl_tree_data::AvlTreeData;
 use ergotree_ir::mir::avl_tree_data::AvlTreeFlags;
 use ergotree_ir::mir::constant::TryExtractInto;
 use ergotree_ir::mir::value::{CollKind, NativeColl, Value};
-use scorex_crypto_avltree::authenticated_tree_ops::AuthenticatedTreeOps;
-use scorex_crypto_avltree::batch_avl_verifier::BatchAVLVerifier;
-use scorex_crypto_avltree::batch_node::AVLTree;
-use scorex_crypto_avltree::batch_node::Node;
-use scorex_crypto_avltree::batch_node::NodeHeader;
-use scorex_crypto_avltree::operation::KeyValue;
-use scorex_crypto_avltree::operation::Operation;
+use ergo_avltree_rust::authenticated_tree_ops::AuthenticatedTreeOps;
+use ergo_avltree_rust::batch_avl_verifier::BatchAVLVerifier;
+use ergo_avltree_rust::batch_node::AVLTree;
+use ergo_avltree_rust::batch_node::Node;
+use ergo_avltree_rust::batch_node::NodeHeader;
+use ergo_avltree_rust::operation::KeyValue;
+use ergo_avltree_rust::operation::Operation;
 use sigma_ser::ScorexSerializable;
 
 use super::EvalError;
@@ -446,7 +446,7 @@ mod tests {
         types::{savltree, stuple::STuple, stype::SType},
     };
     use proptest::prelude::*;
-    use scorex_crypto_avltree::batch_avl_prover::BatchAVLProver;
+    use ergo_avltree_rust::batch_avl_prover::BatchAVLProver;
 
     use crate::eval::tests::eval_out_wo_ctx;
 
@@ -603,7 +603,7 @@ mod tests {
 
     #[test]
     fn eval_avl_insert() {
-        // This example taken from `scorex_crypto_avltree` README
+        // This example taken from `ergo_avltree_rust` README
         let mut prover = BatchAVLProver::new(
             AVLTree::new(
                 |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),

--- a/ergotree-interpreter/src/eval/savltree.rs
+++ b/ergotree-interpreter/src/eval/savltree.rs
@@ -1,11 +1,6 @@
 use std::convert::TryFrom;
 
 use bytes::Bytes;
-use ergo_chain_types::ADDigest;
-use ergotree_ir::mir::avl_tree_data::AvlTreeData;
-use ergotree_ir::mir::avl_tree_data::AvlTreeFlags;
-use ergotree_ir::mir::constant::TryExtractInto;
-use ergotree_ir::mir::value::{CollKind, NativeColl, Value};
 use ergo_avltree_rust::authenticated_tree_ops::AuthenticatedTreeOps;
 use ergo_avltree_rust::batch_avl_verifier::BatchAVLVerifier;
 use ergo_avltree_rust::batch_node::AVLTree;
@@ -13,6 +8,11 @@ use ergo_avltree_rust::batch_node::Node;
 use ergo_avltree_rust::batch_node::NodeHeader;
 use ergo_avltree_rust::operation::KeyValue;
 use ergo_avltree_rust::operation::Operation;
+use ergo_chain_types::ADDigest;
+use ergotree_ir::mir::avl_tree_data::AvlTreeData;
+use ergotree_ir::mir::avl_tree_data::AvlTreeFlags;
+use ergotree_ir::mir::constant::TryExtractInto;
+use ergotree_ir::mir::value::{CollKind, NativeColl, Value};
 use sigma_ser::ScorexSerializable;
 
 use super::EvalError;
@@ -435,6 +435,7 @@ fn map_eval_err<T: std::fmt::Debug>(e: T) -> EvalError {
 mod tests {
     use std::convert::TryFrom;
 
+    use ergo_avltree_rust::batch_avl_prover::BatchAVLProver;
     use ergotree_ir::{
         mir::{
             avl_tree_data::{AvlTreeData, AvlTreeFlags},
@@ -446,7 +447,6 @@ mod tests {
         types::{savltree, stuple::STuple, stype::SType},
     };
     use proptest::prelude::*;
-    use ergo_avltree_rust::batch_avl_prover::BatchAVLProver;
 
     use crate::eval::tests::eval_out_wo_ctx;
 

--- a/ergotree-interpreter/src/eval/tree_lookup.rs
+++ b/ergotree-interpreter/src/eval/tree_lookup.rs
@@ -6,11 +6,11 @@ use crate::eval::env::Env;
 use crate::eval::EvalContext;
 use crate::eval::EvalError;
 use crate::eval::Evaluable;
+use ergo_avltree_rust::batch_avl_verifier::BatchAVLVerifier;
+use ergo_avltree_rust::batch_node::{AVLTree, Node, NodeHeader};
+use ergo_avltree_rust::operation::Operation;
 use ergotree_ir::mir::avl_tree_data::AvlTreeData;
 use ergotree_ir::mir::constant::TryExtractInto;
-use scorex_crypto_avltree::batch_avl_verifier::BatchAVLVerifier;
-use scorex_crypto_avltree::batch_node::{AVLTree, Node, NodeHeader};
-use scorex_crypto_avltree::operation::Operation;
 use sigma_util::AsVecU8;
 
 impl Evaluable for TreeLookup {
@@ -67,15 +67,15 @@ mod tests {
     use super::*;
     use crate::eval::tests::eval_out_wo_ctx;
 
+    use ergo_avltree_rust::authenticated_tree_ops::AuthenticatedTreeOps;
+    use ergo_avltree_rust::batch_avl_prover::BatchAVLProver;
+    use ergo_avltree_rust::operation::KeyValue;
     use ergo_chain_types::ADDigest;
     use ergotree_ir::mir::{
         avl_tree_data::{AvlTreeData, AvlTreeFlags},
         expr::Expr,
         value::{CollKind, NativeColl},
     };
-    use scorex_crypto_avltree::authenticated_tree_ops::AuthenticatedTreeOps;
-    use scorex_crypto_avltree::batch_avl_prover::BatchAVLProver;
-    use scorex_crypto_avltree::operation::KeyValue;
     use sigma_ser::ScorexSerializable;
     use sigma_util::AsVecI8;
 


### PR DESCRIPTION
Use fork of avltree library: https://github.com/ergoplatform/ergo_avltree_rust

It contains fix for empty avltree hash not matching scala implementation

closes #731 