### PR TITLE
Swift: avoid undefined behavior when creating SecretKey from array that is too short

### DIFF
--- a/bindings/ergo-lib-ios/Sources/ErgoLib/ExtSecretKey.swift
+++ b/bindings/ergo-lib-ios/Sources/ErgoLib/ExtSecretKey.swift
@@ -1,11 +1,22 @@
 import Foundation
 import ErgoLibC
 
+enum ExtSecretKeyError: Error {
+    case SecretKeyLengthError
+    case ChainCodeLengthError
+    case SeedLengthError
+}
 class ExtSecretKey {
     internal var pointer: ExtSecretKeyPtr
 
     /// Create ExtSecretKey from secret key bytes, chain code and derivation path
     init(secretKeyBytes: [UInt8], chainCodeBytes: [UInt8], derivationPath: DerivationPath) throws {
+        if secretKeyBytes.count != 32 {
+            throw ExtSecretKeyError.SecretKeyLengthError
+        }
+        if chainCodeBytes.count != 32 {
+            throw ExtSecretKeyError.ChainCodeLengthError
+        }
         var ptr: ExtSecretKeyPtr?
         let error = ergo_lib_ext_secret_key_new(secretKeyBytes, chainCodeBytes, derivationPath.pointer, &ptr)
         try checkError(error)
@@ -14,6 +25,9 @@ class ExtSecretKey {
 
     /// Derive root extended secret key from seed bytes
     init(seedBytes: [UInt8]) throws {
+        if seedBytes.count != 32 {
+            throw ExtSecretKeyError.SeedLengthError
+        }
         var ptr: ExtSecretKeyPtr?
         let error = ergo_lib_ext_secret_key_derive_master(seedBytes, &ptr)
         try checkError(error)

--- a/bindings/ergo-lib-ios/Sources/ErgoLib/SecretKey.swift
+++ b/bindings/ergo-lib-ios/Sources/ErgoLib/SecretKey.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ErgoLibC
 
+struct SecretKeyError: Error {}
 /// Secret key for the prover
 class SecretKey {
     internal var pointer: SecretKeyPtr
@@ -15,6 +16,9 @@ class SecretKey {
     /// Parse dlog secret key from bytes (SEC-1-encoded scalar)
     init(fromBytes : [UInt8]) throws {
         var ptr: SecretKeyPtr?
+        if fromBytes.count != 32 {
+            throw SecretKeyError()
+        }
         let error = ergo_lib_secret_key_from_bytes(fromBytes, &ptr)
         try checkError(error)
         self.pointer = ptr!

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/SecretKeyTests.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/SecretKeyTests.swift
@@ -3,11 +3,20 @@ import XCTest
 @testable import ErgoLib
 @testable import ErgoLibC
 
-final class SecreteKeyTests: XCTestCase {
+final class SecretKeyTests: XCTestCase {
     func testSecretKey() throws {
         let key = SecretKey()
         let bytes = key.toBytes()
         let newKey = try SecretKey(fromBytes: bytes)
         XCTAssertEqual(bytes, newKey.toBytes())
+    }
+    // Test that SecretKey constructor fails for arrays that are too short
+    func testInvalidSecretKey() {
+        let bytes = [UInt8](repeating: UInt8(0), count: 30)
+        XCTAssertThrowsError(try SecretKey(fromBytes: bytes))
+    }
+    func testInvalidExtSecretKey() {
+            let bytes = [UInt8](repeating: UInt8(0), count: 30)
+            XCTAssertThrowsError(try ExtSecretKey(seedBytes: bytes))
     }
 }


### PR DESCRIPTION
Fixes the issue discussed in https://github.com/ergoplatform/sigma-rust/pull/742#discussion_r1589983388