### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tokio = { version = "1.15.0", features = ["full"] }
 tokio-stream = { version = "0.1.8", features = ["sync", "time"] }
 tokio-util = { version = "0.6.9", features = ["codec"] }
 bounded-integer = { version = "^0.5", features = ["types"] }
-url = "2.2"
+url = "~2.2"
 getrandom = { version = "0.2.7" }
 itertools = "0.10.3"
 miette = { version = "5", features = ["fancy"] }


### PR DESCRIPTION
Pin url for now as it has breaking changes for wasm32 in later versions