### PR TITLE
Global.serialize, tree-based versioning for methods

### DIFF
--- a/bindings/ergo-lib-wasm/Cargo.toml
+++ b/bindings/ergo-lib-wasm/Cargo.toml
@@ -41,7 +41,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 derive_more = { workspace = true }
 num-traits = { workspace = true }
 serde_with = { workspace = true }
-bounded-vec = { workspace = true, features=["serde"] }
+bounded-vec = { workspace = true, features = ["serde"] }
 wasm-bindgen = { version = "0.2.87", features = [] }
 wasm-bindgen-futures = { version = "0.4.37" }
 

--- a/ergo-lib/src/wallet/signing.rs
+++ b/ergo-lib/src/wallet/signing.rs
@@ -110,6 +110,7 @@ pub fn make_context<'ctx, T: ErgoTransaction>(
         pre_header: state_ctx.pre_header.clone(),
         extension,
         headers: state_ctx.headers.clone(),
+        tree_version: Default::default(),
     })
 }
 // Updates a Context, changing its self box and context extension to transaction.inputs[i]

--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -379,6 +379,9 @@ pub(crate) mod tests {
     use ergotree_ir::mir::constant::TryExtractInto;
     use ergotree_ir::mir::val_def::ValDef;
     use ergotree_ir::mir::val_use::ValUse;
+    use ergotree_ir::serialization::sigma_byte_reader::from_bytes;
+    use ergotree_ir::serialization::sigma_byte_reader::SigmaByteRead;
+    use ergotree_ir::serialization::SigmaSerializable;
     use ergotree_ir::types::stype::SType;
     use expect_test::expect;
     use sigma_test_util::force_any_val;
@@ -425,10 +428,15 @@ pub(crate) mod tests {
     pub fn try_eval_out_with_version<'ctx, T: TryExtractFrom<Value<'static>> + 'static>(
         expr: &Expr,
         ctx: &'ctx Context<'ctx>,
-        version: u8,
+        tree_version: u8,
+        activated_version: u8,
     ) -> Result<T, EvalError> {
         let mut ctx = ctx.clone();
-        ctx.pre_header.version = version + 1;
+        ctx.pre_header.version = activated_version + 1;
+        ctx.tree_version.set(tree_version.into());
+        // roundtrip expr to test methodcall versioning
+        from_bytes(&expr.sigma_serialize_bytes()?)
+            .with_tree_version(ctx.tree_version(), Expr::sigma_parse)?;
         let mut env = Env::empty();
         expr.eval(&mut env, &ctx).and_then(|v| {
             v.to_static()

--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -345,6 +345,7 @@ fn smethod_eval_fn(method: &SMethod) -> Result<EvalFn, EvalError> {
             sglobal::FROM_BIGENDIAN_BYTES_METHOD_ID => {
                 self::sglobal::SGLOBAL_FROM_BIGENDIAN_BYTES_EVAL_FN
             }
+            sglobal::SERIALIZE_METHOD_ID => self::sglobal::SERIALIZE_EVAL_FN,
             method_id => {
                 return Err(EvalError::NotFound(format!(
                     "Eval fn: method {:?} with method id {:?} not found in SGlobal",

--- a/ergotree-interpreter/src/eval/downcast.rs
+++ b/ergotree-interpreter/src/eval/downcast.rs
@@ -18,7 +18,7 @@ fn downcast_to_bigint<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a
         Value::Short(v) => Ok(BigInt256::from(v).into()),
         Value::Int(v) => Ok(BigInt256::from(v).into()),
         Value::Long(v) => Ok(BigInt256::from(v).into()),
-        Value::BigInt(_) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => Ok(in_v),
+        Value::BigInt(_) if ctx.tree_version() >= ErgoTreeVersion::V3 => Ok(in_v),
         _ => Err(EvalError::UnexpectedValue(format!(
             "Downcast: cannot downcast {0:?} to BigInt",
             in_v
@@ -32,7 +32,7 @@ fn downcast_to_long<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a>,
         Value::Short(v) => Ok((v as i64).into()),
         Value::Int(v) => Ok((v as i64).into()),
         Value::Long(_) => Ok(in_v),
-        Value::BigInt(v) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => {
+        Value::BigInt(v) if ctx.tree_version() >= ErgoTreeVersion::V3 => {
             v.to_i64().map(Value::from).ok_or_else(|| {
                 EvalError::UnexpectedValue(
                     "Downcast: overflow converting BigInt to Long".to_string(),
@@ -57,7 +57,7 @@ fn downcast_to_int<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a>, 
                 "Downcast: Int overflow".to_string(),
             )),
         },
-        Value::BigInt(v) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => {
+        Value::BigInt(v) if ctx.tree_version() >= ErgoTreeVersion::V3 => {
             v.to_i32().map(Value::from).ok_or_else(|| {
                 EvalError::UnexpectedValue(
                     "Downcast: overflow converting BigInt to Int".to_string(),
@@ -86,7 +86,7 @@ fn downcast_to_short<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a>
                 "Downcast: Short overflow".to_string(),
             )),
         },
-        Value::BigInt(v) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => {
+        Value::BigInt(v) if ctx.tree_version() >= ErgoTreeVersion::V3 => {
             v.to_i16().map(Value::from).ok_or_else(|| {
                 EvalError::UnexpectedValue(
                     "Downcast: overflow converting BigInt to Short".to_string(),
@@ -121,7 +121,7 @@ fn downcast_to_byte<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a>,
                 "Downcast: Byte overflow".to_string(),
             )),
         },
-        Value::BigInt(v) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => {
+        Value::BigInt(v) if ctx.tree_version() >= ErgoTreeVersion::V3 => {
             v.to_i8().map(Value::from).ok_or_else(|| {
                 EvalError::UnexpectedValue(
                     "Downcast: overflow converting BigInt to Byte".to_string(),
@@ -203,7 +203,7 @@ mod tests {
             );
             let ctx = force_any_val::<Context>();
             (0..ErgoTreeVersion::V3.into())
-                .for_each(|version| assert!(try_eval_out_with_version::<BigInt256>(&downcast(v_bigint, SType::SBigInt), &ctx, version, version).is_err()));
+                .for_each(|version| assert!(try_eval_out_with_version::<BigInt256>(&downcast(v_bigint, SType::SBigInt), &ctx, version, 1).is_err()));
             (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
                 |version| {
                     assert_eq!(
@@ -244,7 +244,7 @@ mod tests {
             );
             let ctx = force_any_val::<Context>();
             (0..ErgoTreeVersion::V3.into())
-                .for_each(|version| assert!(try_eval_out_with_version::<i64>(&downcast(c_bigint.clone(), SType::SLong), &ctx, version, version).is_err()));
+                .for_each(|version| assert!(try_eval_out_with_version::<i64>(&downcast(c_bigint.clone(), SType::SLong), &ctx, version, 1).is_err()));
             (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
                 |version| {
                     let res = try_eval_out_with_version::<i64>(
@@ -298,7 +298,7 @@ mod tests {
             .is_err());
             let ctx = force_any_val::<Context>();
             (0..ErgoTreeVersion::V3.into())
-                .for_each(|version| assert!(try_eval_out_with_version::<i32>(&downcast(v_bigint, SType::SInt), &ctx, version, version).is_err()));
+                .for_each(|version| assert!(try_eval_out_with_version::<i32>(&downcast(v_bigint, SType::SInt), &ctx, version, 1).is_err()));
             (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
                 |version| {
                     let res = try_eval_out_with_version::<i32>(
@@ -353,7 +353,7 @@ mod tests {
             assert!(try_eval_out_wo_ctx::<i16>(&downcast(c_long_oob, SType::SShort)).is_err());
             let ctx = force_any_val::<Context>();
             (0..ErgoTreeVersion::V3.into())
-                .for_each(|version| assert!(try_eval_out_with_version::<i16>(&downcast(v_bigint, SType::SShort), &ctx, version, version).is_err()));
+                .for_each(|version| assert!(try_eval_out_with_version::<i16>(&downcast(v_bigint, SType::SShort), &ctx, version, 1).is_err()));
             (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
                 |version| {
                     let res = try_eval_out_with_version::<i16>(
@@ -419,7 +419,7 @@ mod tests {
             assert!(try_eval_out_wo_ctx::<i8>(&downcast(c_long_oob, SType::SByte)).is_err());
             let ctx = force_any_val::<Context>();
             (0..ErgoTreeVersion::V3.into())
-                .for_each(|version| assert!(try_eval_out_with_version::<i8>(&downcast(v_bigint, SType::SByte), &ctx, version, version).is_err()));
+                .for_each(|version| assert!(try_eval_out_with_version::<i8>(&downcast(v_bigint, SType::SByte), &ctx, version, 1).is_err()));
             (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
                 |version| {
                     let res = try_eval_out_with_version::<i8>(

--- a/ergotree-interpreter/src/eval/downcast.rs
+++ b/ergotree-interpreter/src/eval/downcast.rs
@@ -18,11 +18,7 @@ fn downcast_to_bigint<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a
         Value::Short(v) => Ok(BigInt256::from(v).into()),
         Value::Int(v) => Ok(BigInt256::from(v).into()),
         Value::Long(v) => Ok(BigInt256::from(v).into()),
-        Value::BigInt(_)
-            if ctx.activated_script_version() >= ErgoTreeVersion::V6_SOFT_FORK_VERSION =>
-        {
-            Ok(in_v)
-        }
+        Value::BigInt(_) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => Ok(in_v),
         _ => Err(EvalError::UnexpectedValue(format!(
             "Downcast: cannot downcast {0:?} to BigInt",
             in_v
@@ -36,9 +32,7 @@ fn downcast_to_long<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a>,
         Value::Short(v) => Ok((v as i64).into()),
         Value::Int(v) => Ok((v as i64).into()),
         Value::Long(_) => Ok(in_v),
-        Value::BigInt(v)
-            if ctx.activated_script_version() >= ErgoTreeVersion::V6_SOFT_FORK_VERSION =>
-        {
+        Value::BigInt(v) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => {
             v.to_i64().map(Value::from).ok_or_else(|| {
                 EvalError::UnexpectedValue(
                     "Downcast: overflow converting BigInt to Long".to_string(),
@@ -63,9 +57,7 @@ fn downcast_to_int<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a>, 
                 "Downcast: Int overflow".to_string(),
             )),
         },
-        Value::BigInt(v)
-            if ctx.activated_script_version() >= ErgoTreeVersion::V6_SOFT_FORK_VERSION =>
-        {
+        Value::BigInt(v) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => {
             v.to_i32().map(Value::from).ok_or_else(|| {
                 EvalError::UnexpectedValue(
                     "Downcast: overflow converting BigInt to Int".to_string(),
@@ -94,9 +86,7 @@ fn downcast_to_short<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a>
                 "Downcast: Short overflow".to_string(),
             )),
         },
-        Value::BigInt(v)
-            if ctx.activated_script_version() >= ErgoTreeVersion::V6_SOFT_FORK_VERSION =>
-        {
+        Value::BigInt(v) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => {
             v.to_i16().map(Value::from).ok_or_else(|| {
                 EvalError::UnexpectedValue(
                     "Downcast: overflow converting BigInt to Short".to_string(),
@@ -131,9 +121,7 @@ fn downcast_to_byte<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a>,
                 "Downcast: Byte overflow".to_string(),
             )),
         },
-        Value::BigInt(v)
-            if ctx.activated_script_version() >= ErgoTreeVersion::V6_SOFT_FORK_VERSION =>
-        {
+        Value::BigInt(v) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => {
             v.to_i8().map(Value::from).ok_or_else(|| {
                 EvalError::UnexpectedValue(
                     "Downcast: overflow converting BigInt to Byte".to_string(),
@@ -214,14 +202,15 @@ mod tests {
                 v_long.into()
             );
             let ctx = force_any_val::<Context>();
-            (0..ErgoTreeVersion::V6_SOFT_FORK_VERSION)
-                .for_each(|version| assert!(try_eval_out_with_version::<BigInt256>(&downcast(v_bigint, SType::SBigInt), &ctx, version).is_err()));
-            (ErgoTreeVersion::V6_SOFT_FORK_VERSION..=ErgoTreeVersion::MAX_SCRIPT_VERSION).for_each(
+            (0..ErgoTreeVersion::V3.into())
+                .for_each(|version| assert!(try_eval_out_with_version::<BigInt256>(&downcast(v_bigint, SType::SBigInt), &ctx, version, version).is_err()));
+            (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
                 |version| {
                     assert_eq!(
                         try_eval_out_with_version::<BigInt256>(
                             &downcast(v_bigint, SType::SBigInt),
                             &ctx,
+                            version,
                             version
                         ).unwrap(),
                         v_bigint.clone()
@@ -254,13 +243,14 @@ mod tests {
                 v_long
             );
             let ctx = force_any_val::<Context>();
-            (0..ErgoTreeVersion::V6_SOFT_FORK_VERSION)
-                .for_each(|version| assert!(try_eval_out_with_version::<i64>(&downcast(c_bigint.clone(), SType::SLong), &ctx, version).is_err()));
-            (ErgoTreeVersion::V6_SOFT_FORK_VERSION..=ErgoTreeVersion::MAX_SCRIPT_VERSION).for_each(
+            (0..ErgoTreeVersion::V3.into())
+                .for_each(|version| assert!(try_eval_out_with_version::<i64>(&downcast(c_bigint.clone(), SType::SLong), &ctx, version, version).is_err()));
+            (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
                 |version| {
                     let res = try_eval_out_with_version::<i64>(
                         &downcast(c_bigint.clone(), SType::SLong),
                         &ctx,
+                        version,
                         version
                     );
                     if v_bigint < BigInt256::from(i64::MIN) || v_bigint > BigInt256::from(i64::MAX) {
@@ -307,13 +297,14 @@ mod tests {
             )
             .is_err());
             let ctx = force_any_val::<Context>();
-            (0..ErgoTreeVersion::V6_SOFT_FORK_VERSION)
-                .for_each(|version| assert!(try_eval_out_with_version::<i32>(&downcast(v_bigint, SType::SInt), &ctx, version).is_err()));
-            (ErgoTreeVersion::V6_SOFT_FORK_VERSION..=ErgoTreeVersion::MAX_SCRIPT_VERSION).for_each(
+            (0..ErgoTreeVersion::V3.into())
+                .for_each(|version| assert!(try_eval_out_with_version::<i32>(&downcast(v_bigint, SType::SInt), &ctx, version, version).is_err()));
+            (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
                 |version| {
                     let res = try_eval_out_with_version::<i32>(
                         &downcast(v_bigint, SType::SInt),
                         &ctx,
+                        version,
                         version
                     );
                     if v_bigint < BigInt256::from(i32::MIN) || v_bigint > BigInt256::from(i32::MAX) {
@@ -361,13 +352,14 @@ mod tests {
             );
             assert!(try_eval_out_wo_ctx::<i16>(&downcast(c_long_oob, SType::SShort)).is_err());
             let ctx = force_any_val::<Context>();
-            (0..ErgoTreeVersion::V6_SOFT_FORK_VERSION)
-                .for_each(|version| assert!(try_eval_out_with_version::<i16>(&downcast(v_bigint, SType::SShort), &ctx, version).is_err()));
-            (ErgoTreeVersion::V6_SOFT_FORK_VERSION..=ErgoTreeVersion::MAX_SCRIPT_VERSION).for_each(
+            (0..ErgoTreeVersion::V3.into())
+                .for_each(|version| assert!(try_eval_out_with_version::<i16>(&downcast(v_bigint, SType::SShort), &ctx, version, version).is_err()));
+            (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
                 |version| {
                     let res = try_eval_out_with_version::<i16>(
                         &downcast(v_bigint, SType::SShort),
                         &ctx,
+                        version,
                         version
                     );
                     if v_bigint < BigInt256::from(i16::MIN) || v_bigint > BigInt256::from(i16::MAX) {
@@ -426,13 +418,14 @@ mod tests {
             );
             assert!(try_eval_out_wo_ctx::<i8>(&downcast(c_long_oob, SType::SByte)).is_err());
             let ctx = force_any_val::<Context>();
-            (0..ErgoTreeVersion::V6_SOFT_FORK_VERSION)
-                .for_each(|version| assert!(try_eval_out_with_version::<i8>(&downcast(v_bigint, SType::SByte), &ctx, version).is_err()));
-            (ErgoTreeVersion::V6_SOFT_FORK_VERSION..=ErgoTreeVersion::MAX_SCRIPT_VERSION).for_each(
+            (0..ErgoTreeVersion::V3.into())
+                .for_each(|version| assert!(try_eval_out_with_version::<i8>(&downcast(v_bigint, SType::SByte), &ctx, version, version).is_err()));
+            (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
                 |version| {
                     let res = try_eval_out_with_version::<i8>(
                         &downcast(v_bigint, SType::SByte),
                         &ctx,
+                        version,
                         version
                     );
                     if v_bigint < BigInt256::from(i16::MIN) || v_bigint > BigInt256::from(i16::MAX) {

--- a/ergotree-interpreter/src/eval/error.rs
+++ b/ergotree-interpreter/src/eval/error.rs
@@ -2,6 +2,7 @@ use alloc::boxed::Box;
 use alloc::string::String;
 use core::fmt::Debug;
 use core::fmt::Display;
+use ergotree_ir::ergo_tree::ErgoTreeVersion;
 use ergotree_ir::mir::expr::SubstDeserializeError;
 
 use bounded_vec::BoundedVecOutOfBounds;
@@ -76,12 +77,12 @@ pub enum EvalError {
     #[error("eval error: {0:?}")]
     Spanned(SpannedEvalError),
     /// Script version error
-    #[error("Method requires at least version {required_version}, but activated version is {activated_version}")]
+    #[error("Method requires at least version {required_version:?}, but activated version is {activated_version:?}")]
     ScriptVersionError {
         /// Opcode/method call requires this version
-        required_version: u8,
+        required_version: ErgoTreeVersion,
         /// Currently activated script version on network
-        activated_version: u8,
+        activated_version: ErgoTreeVersion,
     },
     /// Deserialize substitution error, see [`ergotree_ir::mir::expr::Expr::substitute_deserialize`]
     #[error("DeserializeRegister/DeserializeContext error: {0}")]

--- a/ergotree-interpreter/src/eval/sbox.rs
+++ b/ergotree-interpreter/src/eval/sbox.rs
@@ -18,9 +18,9 @@ pub(crate) static VALUE_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, _args| {
 };
 
 pub(crate) static GET_REG_EVAL_FN: EvalFn = |mc, _env, ctx, obj, args| {
-    if ctx.activated_script_version() < ErgoTreeVersion::V6_SOFT_FORK_VERSION {
+    if ctx.activated_script_version() < ErgoTreeVersion::V3 {
         return Err(EvalError::ScriptVersionError {
-            required_version: ErgoTreeVersion::V6_SOFT_FORK_VERSION,
+            required_version: ErgoTreeVersion::V3,
             activated_version: ctx.activated_script_version(),
         });
     }
@@ -128,13 +128,13 @@ mod tests {
         .unwrap()
         .into();
         let ctx = force_any_val::<Context>();
-        (0..ErgoTreeVersion::V6_SOFT_FORK_VERSION).for_each(|version| {
-            assert!(try_eval_out_with_version::<i64>(&expr, &ctx, version).is_err())
+        (0..ErgoTreeVersion::V3.into()).for_each(|version| {
+            assert!(try_eval_out_with_version::<i64>(&expr, &ctx, version, version).is_err())
         });
-        (ErgoTreeVersion::V6_SOFT_FORK_VERSION..=ErgoTreeVersion::MAX_SCRIPT_VERSION).for_each(
+        (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
             |version| {
                 assert_eq!(
-                    try_eval_out_with_version::<Option<i64>>(&expr, &ctx, version)
+                    try_eval_out_with_version::<Option<i64>>(&expr, &ctx, version, version)
                         .unwrap()
                         .unwrap(),
                     ctx.self_box.value.as_i64()
@@ -156,23 +156,26 @@ mod tests {
         .unwrap()
         .into();
         let ctx = force_any_val::<Context>();
-        (0..ErgoTreeVersion::V6_SOFT_FORK_VERSION).for_each(|version| {
-            let res = try_eval_out_with_version::<Option<i64>>(&expr, &ctx, version);
+        (0..ErgoTreeVersion::V3.into()).for_each(|version| {
+            let res = try_eval_out_with_version::<Option<i64>>(&expr, &ctx, version, version);
             match res {
                 Err(EvalError::Spanned(err))
                     if matches!(
                         *err.error,
                         EvalError::ScriptVersionError {
-                            required_version: ErgoTreeVersion::V6_SOFT_FORK_VERSION,
+                            required_version: ErgoTreeVersion::V3,
                             activated_version: _
                         }
                     ) => {}
                 _ => panic!("Expected script version error"),
             }
         });
-        (ErgoTreeVersion::V6_SOFT_FORK_VERSION..=ErgoTreeVersion::MAX_SCRIPT_VERSION).for_each(
+        (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(
             |version| {
-                assert!(try_eval_out_with_version::<Option<i64>>(&expr, &ctx, version).is_err())
+                assert!(
+                    try_eval_out_with_version::<Option<i64>>(&expr, &ctx, version, version)
+                        .is_err()
+                )
             },
         );
     }

--- a/ergotree-interpreter/src/eval/sbox.rs
+++ b/ergotree-interpreter/src/eval/sbox.rs
@@ -18,10 +18,10 @@ pub(crate) static VALUE_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, _args| {
 };
 
 pub(crate) static GET_REG_EVAL_FN: EvalFn = |mc, _env, ctx, obj, args| {
-    if ctx.activated_script_version() < ErgoTreeVersion::V3 {
+    if ctx.tree_version() < ErgoTreeVersion::V3 {
         return Err(EvalError::ScriptVersionError {
             required_version: ErgoTreeVersion::V3,
-            activated_version: ctx.activated_script_version(),
+            activated_version: ctx.tree_version(),
         });
     }
     #[allow(clippy::unwrap_used)]

--- a/ergotree-interpreter/src/eval/sglobal.rs
+++ b/ergotree-interpreter/src/eval/sglobal.rs
@@ -2,7 +2,13 @@ use alloc::{string::ToString, sync::Arc};
 
 use crate::eval::EvalError;
 
-use ergotree_ir::mir::value::{CollKind, NativeColl, Value};
+use ergotree_ir::{
+    mir::{
+        constant::Constant,
+        value::{CollKind, NativeColl, Value},
+    },
+    serialization::{data::DataSerializer, sigma_byte_writer::SigmaByteWriter},
+};
 
 use super::EvalFn;
 use crate::eval::Vec;
@@ -141,22 +147,65 @@ pub(crate) static SGLOBAL_FROM_BIGENDIAN_BYTES_EVAL_FN: EvalFn = |mc, _env, _ctx
     }
 };
 
+pub(crate) static SERIALIZE_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, args| {
+    if obj != Value::Global {
+        return Err(EvalError::UnexpectedValue(format!(
+            "sglobal.groupGenerator expected obj to be Value::Global, got {:?}",
+            obj
+        )));
+    }
+    let arg: Constant = args
+        .first()
+        .ok_or_else(|| EvalError::NotFound("serialize: missing first arg".into()))?
+        .to_static()
+        .try_into()
+        .map_err(EvalError::UnexpectedValue)?;
+
+    let mut buf = vec![];
+    let mut writer = SigmaByteWriter::new(&mut buf, None);
+    DataSerializer::sigma_serialize(&arg.v, &mut writer)?;
+    Ok(Value::from(buf))
+};
+
 #[allow(clippy::unwrap_used)]
 #[cfg(test)]
 #[cfg(feature = "arbitrary")]
 mod tests {
     use ergo_chain_types::EcPoint;
     use ergotree_ir::bigint256::BigInt256;
+    use ergotree_ir::mir::constant::Constant;
     use ergotree_ir::mir::expr::Expr;
+    use ergotree_ir::mir::long_to_byte_array::LongToByteArray;
     use ergotree_ir::mir::method_call::MethodCall;
     use ergotree_ir::mir::property_call::PropertyCall;
+    use ergotree_ir::mir::sigma_prop_bytes::SigmaPropBytes;
+    use ergotree_ir::mir::unary_op::OneArgOpTryBuild;
+    use ergotree_ir::sigma_protocol::sigma_boolean::SigmaProp;
+    use ergotree_ir::types::sgroup_elem::GET_ENCODED_METHOD;
+    use ergotree_ir::types::stype_param::STypeVar;
+    use proptest::proptest;
 
     use crate::eval::tests::{eval_out, eval_out_wo_ctx};
     use ergotree_ir::chain::context::Context;
-    use ergotree_ir::types::sglobal;
+    use ergotree_ir::types::sglobal::{self, SERIALIZE_METHOD};
     use ergotree_ir::types::stype::SType;
-    use ergotree_ir::types::stype_param::STypeVar;
     use sigma_test_util::force_any_val;
+
+    fn serialize(val: impl Into<Constant>) -> Vec<u8> {
+        let constant = val.into();
+        let serialize_node = MethodCall::new(
+            Expr::Global,
+            SERIALIZE_METHOD.clone().with_concrete_types(
+                &[(STypeVar::t(), constant.tpe.clone())]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            ),
+            vec![constant.into()],
+        )
+        .unwrap();
+        eval_out_wo_ctx(&serialize_node.into())
+    }
 
     #[test]
     fn eval_group_generator() {
@@ -310,6 +359,69 @@ mod tests {
             .unwrap()
             .into();
             assert_eq!(eval_out_wo_ctx::<BigInt256>(&expr), BigInt256::from(v_long));
+        }
+    }
+
+    #[test]
+    fn serialize_byte() {
+        assert_eq!(serialize(-128i8), vec![-128i8 as u8]);
+        assert_eq!(serialize(-1i8), vec![-1i8 as u8]);
+        assert_eq!(serialize(0i8), vec![0u8]);
+        assert_eq!(serialize(1i8), vec![1]);
+        assert_eq!(serialize(127i8), vec![127u8]);
+    }
+
+    #[test]
+    fn serialize_short() {
+        assert_eq!(serialize(i16::MIN), vec![0xff, 0xff, 0x03]);
+        assert_eq!(serialize(-1i16), vec![0x01]);
+        assert_eq!(serialize(0i16), vec![0x00]);
+        assert_eq!(serialize(1i16), vec![0x02]);
+        assert_eq!(serialize(i16::MAX), vec![0xfe, 0xff, 0x03]);
+    }
+
+    #[test]
+    fn serialize_byte_array() {
+        let arr = vec![0xc0, 0xff, 0xee];
+        let serialized = serialize(arr.clone());
+
+        assert_eq!(serialized[0], arr.len() as u8);
+        assert_eq!(&serialized[1..], &arr)
+    }
+
+    // test that serialize(long) != longToByteArray()
+    #[test]
+    fn serialize_long_ne_tobytearray() {
+        let num = -1000i64;
+        let long_to_byte_array = LongToByteArray::try_build(Constant::from(num).into()).unwrap();
+        let serialized = serialize(num);
+        assert!(serialized != eval_out_wo_ctx::<Vec<u8>>(&long_to_byte_array.into()))
+    }
+
+    // test equivalence between Global.serialize and ge.getEncoded
+    #[test]
+    fn serialize_group_element() {
+        let ec_point = EcPoint::from_base16_str(String::from(
+            "026930cb9972e01534918a6f6d6b8e35bc398f57140d13eb3623ea31fbd069939b",
+        ))
+        .unwrap();
+        let get_encoded = MethodCall::new(
+            Constant::from(ec_point.clone()).into(),
+            GET_ENCODED_METHOD.clone(),
+            vec![],
+        )
+        .unwrap();
+        assert_eq!(
+            eval_out_wo_ctx::<Vec<u8>>(&get_encoded.into()),
+            serialize(ec_point)
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn serialize_sigmaprop_eq_prop_bytes(sigma_prop: SigmaProp) {
+            let prop_bytes = SigmaPropBytes::try_build(Constant::from(sigma_prop.clone()).into()).unwrap();
+            assert_eq!(serialize(sigma_prop), &eval_out_wo_ctx::<Vec<u8>>(&prop_bytes.into())[2..])
         }
     }
 }

--- a/ergotree-interpreter/src/eval/sglobal.rs
+++ b/ergotree-interpreter/src/eval/sglobal.rs
@@ -173,6 +173,7 @@ pub(crate) static SERIALIZE_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, args| {
 mod tests {
     use ergo_chain_types::EcPoint;
     use ergotree_ir::bigint256::BigInt256;
+    use ergotree_ir::ergo_tree::ErgoTreeVersion;
     use ergotree_ir::mir::constant::Constant;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::long_to_byte_array::LongToByteArray;
@@ -185,7 +186,7 @@ mod tests {
     use ergotree_ir::types::stype_param::STypeVar;
     use proptest::proptest;
 
-    use crate::eval::tests::{eval_out, eval_out_wo_ctx};
+    use crate::eval::tests::{eval_out, eval_out_wo_ctx, try_eval_out_with_version};
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::types::sglobal::{self, SERIALIZE_METHOD};
     use ergotree_ir::types::stype::SType;
@@ -204,7 +205,13 @@ mod tests {
             vec![constant.into()],
         )
         .unwrap();
-        eval_out_wo_ctx(&serialize_node.into())
+        let ctx = force_any_val::<Context>();
+        assert!((0u8..ErgoTreeVersion::V3.into()).all(|version| {
+            try_eval_out_with_version::<Vec<u8>>(&serialize_node.clone().into(), &ctx, version, 3)
+                .is_err()
+        }));
+        try_eval_out_with_version(&serialize_node.into(), &ctx, ErgoTreeVersion::V3.into(), 3)
+            .unwrap()
     }
 
     #[test]

--- a/ergotree-interpreter/src/eval/upcast.rs
+++ b/ergotree-interpreter/src/eval/upcast.rs
@@ -15,11 +15,7 @@ fn upcast_to_bigint<'a>(in_v: Value<'a>, ctx: &Context) -> Result<Value<'a>, Eva
         Value::Short(v) => Ok(BigInt256::from(v).into()),
         Value::Int(v) => Ok(BigInt256::from(v).into()),
         Value::Long(v) => Ok(BigInt256::from(v).into()),
-        Value::BigInt(_)
-            if ctx.activated_script_version() >= ErgoTreeVersion::V6_SOFT_FORK_VERSION =>
-        {
-            Ok(in_v)
-        }
+        Value::BigInt(_) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => Ok(in_v),
         _ => Err(EvalError::UnexpectedValue(format!(
             "Upcast: cannot upcast {0:?} to BigInt",
             in_v
@@ -186,11 +182,11 @@ mod tests {
         fn from_bigint(v in any::<BigInt256>()) {
             let c: Constant = v.into();
             let ctx = force_any_val::<Context>();
-            (0..ErgoTreeVersion::V6_SOFT_FORK_VERSION).for_each(|version| {
-                assert!(try_eval_out_with_version::<BigInt256>(&Upcast::new(c.clone().into(), SType::SBigInt).unwrap().into(), &ctx, version).is_err());
+            (0..ErgoTreeVersion::V3.into()).for_each(|version| {
+                assert!(try_eval_out_with_version::<BigInt256>(&Upcast::new(c.clone().into(), SType::SBigInt).unwrap().into(), &ctx, version, version).is_err());
             });
-            (ErgoTreeVersion::V6_SOFT_FORK_VERSION..=ErgoTreeVersion::MAX_SCRIPT_VERSION).for_each(|version| {
-                assert_eq!(try_eval_out_with_version::<BigInt256>(&Upcast::new(c.clone().into(), SType::SBigInt).unwrap().into(), &ctx, version).unwrap(), v.clone());
+            (ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()).for_each(|version| {
+                assert_eq!(try_eval_out_with_version::<BigInt256>(&Upcast::new(c.clone().into(), SType::SBigInt).unwrap().into(), &ctx, version, version).unwrap(), v.clone());
             });
         }
     }

--- a/ergotree-interpreter/src/eval/upcast.rs
+++ b/ergotree-interpreter/src/eval/upcast.rs
@@ -15,7 +15,7 @@ fn upcast_to_bigint<'a>(in_v: Value<'a>, ctx: &Context) -> Result<Value<'a>, Eva
         Value::Short(v) => Ok(BigInt256::from(v).into()),
         Value::Int(v) => Ok(BigInt256::from(v).into()),
         Value::Long(v) => Ok(BigInt256::from(v).into()),
-        Value::BigInt(_) if ctx.activated_script_version() >= ErgoTreeVersion::V3 => Ok(in_v),
+        Value::BigInt(_) if ctx.tree_version() >= ErgoTreeVersion::V3 => Ok(in_v),
         _ => Err(EvalError::UnexpectedValue(format!(
             "Upcast: cannot upcast {0:?} to BigInt",
             in_v

--- a/ergotree-ir/src/chain/context.rs
+++ b/ergotree-ir/src/chain/context.rs
@@ -1,6 +1,8 @@
 //! Context(blockchain) for the interpreter
-use crate::chain::context_extension::ContextExtension;
+use core::cell::Cell;
+
 use crate::chain::ergo_box::ErgoBox;
+use crate::{chain::context_extension::ContextExtension, ergo_tree::ErgoTreeVersion};
 use bounded_vec::BoundedVec;
 use ergo_chain_types::{Header, PreHeader};
 
@@ -26,6 +28,8 @@ pub struct Context<'ctx> {
     pub headers: [Header; 10],
     /// prover-defined key-value pairs, that may be used inside a script
     pub extension: ContextExtension,
+    /// ergo tree version
+    pub tree_version: Cell<ErgoTreeVersion>,
 }
 
 impl<'ctx> Context<'ctx> {
@@ -37,8 +41,12 @@ impl<'ctx> Context<'ctx> {
         }
     }
     /// Activated script version corresponds to block version - 1
-    pub fn activated_script_version(&self) -> u8 {
-        self.pre_header.version.saturating_sub(1)
+    pub fn activated_script_version(&self) -> ErgoTreeVersion {
+        ErgoTreeVersion::from(self.pre_header.version.saturating_sub(1))
+    }
+    /// Version of ergotree being evaluated under context
+    pub fn tree_version(&self) -> ErgoTreeVersion {
+        self.tree_version.get()
     }
 }
 
@@ -95,6 +103,7 @@ mod arbitrary {
                             pre_header,
                             extension,
                             headers,
+                            tree_version: Default::default(),
                         }
                     },
                 )

--- a/ergotree-ir/src/ergo_tree/tree_header.rs
+++ b/ergotree-ir/src/ergo_tree/tree_header.rs
@@ -1,7 +1,7 @@
 //! ErgoTree header
 
 use alloc::string::{String, ToString};
-use derive_more::From;
+use derive_more::{From, Into};
 use thiserror::Error;
 
 use crate::serialization::sigma_byte_reader::SigmaByteRead;
@@ -103,8 +103,8 @@ impl ErgoTreeHeader {
     }
 
     /// Returns ErgoTree version
-    pub fn version(&self) -> &ErgoTreeVersion {
-        &self.version
+    pub fn version(&self) -> ErgoTreeVersion {
+        self.version
     }
 }
 
@@ -120,7 +120,7 @@ pub enum ErgoTreeHeaderError {
 }
 
 /// ErgoTree version 0..=7, should fit in 3 bits
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Debug, Clone, Copy, From, Into, Default)]
 pub struct ErgoTreeVersion(u8);
 
 impl ErgoTreeVersion {
@@ -128,9 +128,7 @@ impl ErgoTreeVersion {
     pub const VERSION_MASK: u8 = 0x07;
 
     /// Max version of ErgoTree supported by interpreter
-    pub const MAX_SCRIPT_VERSION: u8 = 3;
-    /// Version for v6.0 (Evolution)
-    pub const V6_SOFT_FORK_VERSION: u8 = 3;
+    pub const MAX_SCRIPT_VERSION: Self = Self::V3;
     /// Version 0
     pub const V0: Self = ErgoTreeVersion(0);
     /// Version 1 (size flag is mandatory)
@@ -138,7 +136,7 @@ impl ErgoTreeVersion {
     /// Version 2 (JIT)
     pub const V2: Self = ErgoTreeVersion(2);
     /// Version 3 (v6.0/Evolution)
-    pub const V3: Self = ErgoTreeVersion(Self::V6_SOFT_FORK_VERSION);
+    pub const V3: Self = ErgoTreeVersion(3);
 
     /// Returns a value of the version bits from the given header byte.
     pub fn parse_version(header_byte: u8) -> Self {

--- a/ergotree-ir/src/serialization.rs
+++ b/ergotree-ir/src/serialization.rs
@@ -3,7 +3,8 @@
 mod bin_op;
 mod constant;
 mod constant_placeholder;
-pub(crate) mod data;
+/// Serializer for literals & constants
+pub mod data;
 mod expr;
 mod global_vars;
 mod method_call;

--- a/ergotree-ir/src/serialization/data.rs
+++ b/ergotree-ir/src/serialization/data.rs
@@ -31,6 +31,7 @@ use core::convert::TryInto;
 pub struct DataSerializer {}
 
 impl DataSerializer {
+    /// Serialize Literal without typecode serialized
     pub fn sigma_serialize<W: SigmaByteWrite>(c: &Literal, w: &mut W) -> SigmaSerializeResult {
         // for reference see http://github.com/ScorexFoundation/sigmastate-interpreter/blob/25251c1313b0131835f92099f02cef8a5d932b5e/sigmastate/src/main/scala/sigmastate/serialization/DataSerializer.scala#L26-L26
         Ok(match c {
@@ -87,6 +88,7 @@ impl DataSerializer {
         })
     }
 
+    /// Parse sigma-serialized literal
     pub fn sigma_parse<R: SigmaByteRead>(
         tpe: &SType,
         r: &mut R,

--- a/ergotree-ir/src/types/savltree.rs
+++ b/ergotree-ir/src/types/savltree.rs
@@ -2,6 +2,7 @@ use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 
+use crate::ergo_tree::ErgoTreeVersion;
 use crate::serialization::types::TypeCode;
 
 use super::sfunc::SFunc;
@@ -80,7 +81,8 @@ lazy_static! {
             t_range: SType::SColl(Arc::new(SType::SByte)).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.digest
     pub static ref DIGEST_METHOD: SMethod =
@@ -96,7 +98,8 @@ lazy_static! {
             t_range: SType::SByte.into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.enabledOperations
     pub static ref ENABLED_OPERATIONS_METHOD: SMethod =
@@ -112,7 +115,8 @@ lazy_static! {
             t_range: SType::SInt.into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.keyLength
     pub static ref KEY_LENGTH_METHOD: SMethod =
@@ -128,7 +132,8 @@ lazy_static! {
             t_range: SType::SOption(Arc::new(SType::SInt)).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.valueLengthOpt
     pub static ref VALUE_LENGTH_OPT_METHOD: SMethod =
@@ -144,7 +149,8 @@ lazy_static! {
             t_range: SType::SBoolean.into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.isInsertAllowed
     pub static ref IS_INSERT_ALLOWED_METHOD: SMethod =
@@ -160,7 +166,8 @@ lazy_static! {
             t_range: SType::SBoolean.into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.isUpdateAllowed
     pub static ref IS_UPDATE_ALLOWED_METHOD: SMethod =
@@ -176,7 +183,8 @@ lazy_static! {
             t_range: SType::SBoolean.into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.isRemoveAllowed
     pub static ref IS_REMOVE_ALLOWED_METHOD: SMethod =
@@ -192,7 +200,8 @@ lazy_static! {
             t_range: SType::SAvlTree.into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.updateOperations
     pub static ref UPDATE_OPERATIONS_METHOD: SMethod =
@@ -211,7 +220,8 @@ lazy_static! {
             t_range: SType::SOption(SType::SColl(SType::SByte.into()).into()).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
 
     /// AvlTree.get
@@ -231,7 +241,8 @@ lazy_static! {
             t_range: SType::SColl(SType::SOption(SType::SColl(SType::SByte.into()).into()).into()).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
 
     /// AvlTree.getMany
@@ -260,7 +271,8 @@ lazy_static! {
             t_range: SType::SOption(Arc::new(SType::SAvlTree)).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.insert
     pub static ref INSERT_METHOD: SMethod =
@@ -283,7 +295,8 @@ lazy_static! {
             t_range: SType::SOption(Arc::new(SType::SAvlTree)).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.remove
     pub static ref REMOVE_METHOD: SMethod =
@@ -303,7 +316,8 @@ lazy_static! {
             t_range: SType::SBoolean.into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.contains
     pub static ref CONTAINS_METHOD: SMethod =
@@ -331,7 +345,8 @@ lazy_static! {
             t_range: SType::SOption(Arc::new(SType::SAvlTree)).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.update
     pub static ref UPDATE_METHOD: SMethod =
@@ -347,7 +362,8 @@ lazy_static! {
             t_range: SType::SAvlTree.into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// AvlTree.updateDigest
     pub static ref UPDATE_DIGEST_METHOD: SMethod =

--- a/ergotree-ir/src/types/sbox.rs
+++ b/ergotree-ir/src/types/sbox.rs
@@ -1,3 +1,4 @@
+use crate::ergo_tree::ErgoTreeVersion;
 use crate::serialization::types::TypeCode;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
@@ -46,6 +47,7 @@ lazy_static! {
             tpe_params: vec![],
         },
         explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Box.value
     pub static ref VALUE_METHOD: SMethod = SMethod::new(STypeCompanion::Box, VALUE_METHOD_DESC.clone(),);
@@ -60,7 +62,8 @@ lazy_static! {
             t_range: SType::SOption(Arc::new(STypeVar::t().into())).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![STypeVar::t()]
+        explicit_type_args: vec![STypeVar::t()],
+        min_version: ErgoTreeVersion::V0
     };
     /// Box.getReg
     pub static ref GET_REG_METHOD: SMethod =
@@ -81,6 +84,7 @@ lazy_static! {
             tpe_params: vec![],
         },
         explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Box.tokens
     pub static ref TOKENS_METHOD: SMethod =

--- a/ergotree-ir/src/types/scoll.rs
+++ b/ergotree-ir/src/types/scoll.rs
@@ -1,3 +1,4 @@
+use crate::ergo_tree::ErgoTreeVersion;
 use crate::serialization::types::TypeCode;
 use crate::types::stuple::STuple;
 use crate::types::stype_companion::STypeCompanion;
@@ -59,7 +60,8 @@ lazy_static! {
             t_range: SType::SInt.into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Coll.indexOf
     pub static ref INDEX_OF_METHOD: SMethod = SMethod::new(STypeCompanion::Coll, INDEX_OF_METHOD_DESC.clone());
@@ -79,7 +81,8 @@ lazy_static! {
                 ],
             SType::SColl(SType::STypeVar(STypeVar::ov()).into()),
         ),
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Coll.flatMap
     pub static ref FLATMAP_METHOD: SMethod = SMethod::new(STypeCompanion::Coll, FLATMAP_METHOD_DESC.clone());
@@ -98,7 +101,8 @@ lazy_static! {
                 STypeVar::t().into(), STypeVar::iv().into()
             )).into())
         ),
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Coll.zip
     pub static ref ZIP_METHOD: SMethod = SMethod::new(STypeCompanion::Coll, ZIP_METHOD_DESC.clone());
@@ -114,7 +118,8 @@ lazy_static! {
             ],
             SType::SColl(SType::SInt.into())
         ),
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Coll.indices
     pub static ref INDICES_METHOD: SMethod = SMethod::new(STypeCompanion::Coll, INDICES_METHOD_DESC.clone());
@@ -133,7 +138,8 @@ lazy_static! {
             ],
             SType::SColl(SType::STypeVar(STypeVar::t()).into())
         ),
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Coll.patch
     pub static ref PATCH_METHOD: SMethod = SMethod::new(STypeCompanion::Coll, PATCH_METHOD_DESC.clone());
@@ -152,7 +158,8 @@ lazy_static! {
             ],
             SType::SColl(SType::STypeVar(STypeVar::t()).into())
         ),
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Coll.updated
     pub static ref UPDATED_METHOD: SMethod = SMethod::new(STypeCompanion::Coll, UPDATED_METHOD_DESC.clone());
@@ -171,7 +178,8 @@ lazy_static! {
             ],
             SType::SColl(SType::STypeVar(STypeVar::t()).into())
         ),
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Coll.updateMany
     pub static ref UPDATE_MANY_METHOD: SMethod = SMethod::new(STypeCompanion::Coll, UPDATE_MANY_METHOD_DESC.clone());

--- a/ergotree-ir/src/types/sglobal.rs
+++ b/ergotree-ir/src/types/sglobal.rs
@@ -22,11 +22,13 @@ pub const GROUP_GENERATOR_METHOD_ID: MethodId = MethodId(1);
 pub const XOR_METHOD_ID: MethodId = MethodId(2);
 /// "fromBigEndianBytes" predefined function
 pub const FROM_BIGENDIAN_BYTES_METHOD_ID: MethodId = MethodId(5);
+/// serialize function added in v6.0
+pub const SERIALIZE_METHOD_ID: MethodId = MethodId(3);
 
 lazy_static! {
     /// Global method descriptors
     pub(crate) static ref METHOD_DESC: Vec<&'static SMethodDesc> =
-        vec![&GROUP_GENERATOR_METHOD_DESC, &XOR_METHOD_DESC, &FROM_BIGENDIAN_BYTES_METHOD_DESC];
+        vec![&GROUP_GENERATOR_METHOD_DESC, &XOR_METHOD_DESC, &SERIALIZE_METHOD_DESC, &FROM_BIGENDIAN_BYTES_METHOD_DESC];
 }
 
 lazy_static! {
@@ -71,11 +73,26 @@ lazy_static! {
         name: "fromBigEndianBytes",
         tpe: SFunc {
             t_dom: vec![SType::SGlobal, SType::SColl(SType::SByte.into())],
-            t_range:SType::STypeVar(STypeVar::t()).into(),
+            t_range: SType::STypeVar(STypeVar::t()).into(),
             tpe_params: vec![],
         },
         explicit_type_args: vec![STypeVar::t()]
     };
     /// GLOBAL.fromBigEndianBytes
     pub static ref FROM_BIGENDIAN_BYTES_METHOD: SMethod = SMethod::new(STypeCompanion::Global, FROM_BIGENDIAN_BYTES_METHOD_DESC.clone(),);
+    static ref SERIALIZE_METHOD_DESC: SMethodDesc = SMethodDesc {
+        method_id: SERIALIZE_METHOD_ID,
+        name: "serialize",
+        tpe: SFunc {
+            t_dom: vec![
+                SType::SGlobal,
+                STypeVar::t().into()
+            ],
+            t_range: SType::SColl(SType::SByte.into()).into(),
+            tpe_params: vec![],
+        },
+        explicit_type_args: vec![]
+    };
+     /// GLOBAL.serialize
+    pub static ref SERIALIZE_METHOD: SMethod = SMethod::new(STypeCompanion::Global, SERIALIZE_METHOD_DESC.clone(),);
 }

--- a/ergotree-ir/src/types/sglobal.rs
+++ b/ergotree-ir/src/types/sglobal.rs
@@ -1,3 +1,4 @@
+use crate::ergo_tree::ErgoTreeVersion;
 use crate::serialization::types::TypeCode;
 
 use super::sfunc::SFunc;
@@ -40,7 +41,8 @@ lazy_static! {
             t_range: SType::SGroupElement.into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
      /// GLOBAL.GroupGenerator
     pub static ref GROUP_GENERATOR_METHOD: SMethod = SMethod::new(STypeCompanion::Global, GROUP_GENERATOR_METHOD_DESC.clone(),);
@@ -60,7 +62,8 @@ lazy_static! {
             t_range: SType::SColl(SType::SByte.into()).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
      /// GLOBAL.xor
     pub static ref XOR_METHOD: SMethod = SMethod::new(STypeCompanion::Global, XOR_METHOD_DESC.clone(),);
@@ -76,7 +79,8 @@ lazy_static! {
             t_range: SType::STypeVar(STypeVar::t()).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![STypeVar::t()]
+        explicit_type_args: vec![STypeVar::t()],
+        min_version: ErgoTreeVersion::V3
     };
     /// GLOBAL.fromBigEndianBytes
     pub static ref FROM_BIGENDIAN_BYTES_METHOD: SMethod = SMethod::new(STypeCompanion::Global, FROM_BIGENDIAN_BYTES_METHOD_DESC.clone(),);
@@ -91,7 +95,8 @@ lazy_static! {
             t_range: SType::SColl(SType::SByte.into()).into(),
             tpe_params: vec![],
         },
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V3
     };
      /// GLOBAL.serialize
     pub static ref SERIALIZE_METHOD: SMethod = SMethod::new(STypeCompanion::Global, SERIALIZE_METHOD_DESC.clone(),);

--- a/ergotree-ir/src/types/sgroup_elem.rs
+++ b/ergotree-ir/src/types/sgroup_elem.rs
@@ -1,3 +1,4 @@
+use crate::ergo_tree::ErgoTreeVersion;
 use crate::serialization::types::TypeCode;
 use crate::types::stype_companion::STypeCompanion;
 use alloc::sync::Arc;
@@ -38,7 +39,8 @@ lazy_static! {
             vec![SType::SGroupElement],
             SType::SColl(Arc::new(SType::SByte)),
         ),
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// GroupElement.geEncoded
     pub static ref GET_ENCODED_METHOD: SMethod = SMethod::new(STypeCompanion::GroupElem, GET_ENCODED_METHOD_DESC.clone(),);
@@ -52,7 +54,8 @@ lazy_static! {
             vec![SType::SGroupElement],
             SType::SGroupElement,
         ),
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// GroupElement.negate
     pub static ref NEGATE_METHOD: SMethod = SMethod::new(STypeCompanion::GroupElem, NEGATE_METHOD_DESC.clone(),);

--- a/ergotree-ir/src/types/smethod.rs
+++ b/ergotree-ir/src/types/smethod.rs
@@ -1,6 +1,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
+use crate::ergo_tree::ErgoTreeVersion;
 use crate::serialization::sigma_byte_reader::SigmaByteRead;
 use crate::serialization::sigma_byte_writer::SigmaByteWrite;
 use crate::serialization::types::TypeCode;
@@ -17,7 +18,7 @@ use super::type_unify::TypeUnificationError;
 use crate::serialization::SigmaParsingError::UnknownMethodId;
 
 /// Method id unique among the methods of the same object
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
 pub struct MethodId(pub u8);
 
 impl MethodId {
@@ -71,7 +72,7 @@ impl SMethod {
 
     /// Returns method id
     pub fn method_id(&self) -> MethodId {
-        self.method_raw.method_id.clone()
+        self.method_raw.method_id
     }
 
     /// Return new SMethod with type variables substituted
@@ -105,6 +106,7 @@ pub struct SMethodDesc {
     pub(crate) tpe: SFunc,
     // Typevars that cannot be inferred from arguments. For example Box.getReg[T](4), T can not be inferred thus must be explicitly serialized
     pub(crate) explicit_type_args: Vec<STypeVar>,
+    pub(crate) min_version: ErgoTreeVersion,
 }
 
 impl SMethodDesc {
@@ -123,7 +125,8 @@ impl SMethodDesc {
                 t_range: res_tpe.into(),
                 tpe_params: vec![],
             },
-            explicit_type_args: vec![], // TODO: check if PropertyCalls need explicit type args as well
+            explicit_type_args: vec![],
+            min_version: ErgoTreeVersion::V0,
         }
     }
     pub(crate) fn as_method(&self, obj_type: STypeCompanion) -> SMethod {

--- a/ergotree-ir/src/types/soption.rs
+++ b/ergotree-ir/src/types/soption.rs
@@ -1,3 +1,4 @@
+use crate::ergo_tree::ErgoTreeVersion;
 use crate::serialization::types::TypeCode;
 
 use super::sfunc::SFunc;
@@ -44,7 +45,8 @@ lazy_static! {
                 ],
             SType::SOption(SType::STypeVar(STypeVar::ov()).into()),
         ),
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Option.map
     pub static ref MAP_METHOD: SMethod = SMethod::new(
@@ -66,7 +68,8 @@ lazy_static! {
                 ],
             SType::SOption(SType::STypeVar(STypeVar::iv()).into()),
         ),
-        explicit_type_args: vec![]
+        explicit_type_args: vec![],
+        min_version: ErgoTreeVersion::V0
     };
     /// Option.map
     pub static ref FILTER_METHOD: SMethod = SMethod::new(


### PR DESCRIPTION
Add Global.serialize method, version methodcalls using ErgoTree version. Also includes a fix for downcast/upcast behavior based on https://github.com/ergoplatform/sigmastate-interpreter/issues/1042