### PR TITLE
Lazy default for Option.getOrElse/Coll.getOrElse

### DIFF
--- a/ergotree-interpreter/src/eval/coll_by_index.rs
+++ b/ergotree-interpreter/src/eval/coll_by_index.rs
@@ -1,3 +1,4 @@
+use ergotree_ir::ergo_tree::ErgoTreeVersion;
 use ergotree_ir::mir::coll_by_index::ByIndex;
 use ergotree_ir::mir::constant::TryExtractInto;
 use ergotree_ir::mir::value::CollKind;
@@ -23,12 +24,16 @@ impl Evaluable for ByIndex {
                 input_v
             ))),
         }?;
-        match self.default.clone() {
+        match self.default.as_ref() {
             Some(default) => {
-                let default_v = default.eval(env, ctx)?;
-                Ok(normalized_input_vals
-                    .get_val(index_v.try_extract_into::<i32>()? as usize)
-                    .unwrap_or(default_v))
+                let mut default_v = || default.eval(env, ctx);
+                let val =
+                    normalized_input_vals.get_val(index_v.try_extract_into::<i32>()? as usize);
+                if ctx.tree_version() >= ErgoTreeVersion::V3 {
+                    val.map(Ok).unwrap_or_else(default_v)
+                } else {
+                    Ok(val.unwrap_or(default_v()?))
+                }
             }
             None => normalized_input_vals
                 .get_val(index_v.clone().try_extract_into::<i32>()? as usize)
@@ -47,6 +52,10 @@ impl Evaluable for ByIndex {
 #[cfg(test)]
 mod tests {
     use ergotree_ir::chain::ergo_box::ErgoBox;
+    use ergotree_ir::mir::bin_op::ArithOp;
+    use ergotree_ir::mir::bin_op::BinOp;
+    use ergotree_ir::mir::bin_op::BinOpKind;
+    use ergotree_ir::mir::constant::Constant;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;
     use ergotree_ir::reference::Ref;
@@ -55,6 +64,7 @@ mod tests {
     use super::*;
     use crate::eval::tests::eval_out;
     use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::tests::try_eval_out_with_version;
     use ergotree_ir::chain::context::Context;
 
     #[test]
@@ -79,5 +89,34 @@ mod tests {
         .unwrap()
         .into();
         assert_eq!(eval_out_wo_ctx::<i64>(&expr), 5);
+    }
+
+    #[test]
+    fn eval_lazy() {
+        let expr: Expr = ByIndex::new(
+            Expr::Const(vec![1i64, 2i64].into()),
+            Expr::Const(1i32.into()),
+            Some(Box::new(Expr::BinOp(
+                BinOp {
+                    kind: BinOpKind::Arith(ArithOp::Divide),
+                    left: Box::new(Constant::from(1i64).into()),
+                    right: Box::new(Constant::from(0i64).into()),
+                }
+                .into(),
+            ))),
+        )
+        .unwrap()
+        .into();
+        let ctx = force_any_val::<Context>();
+        for tree_version in 0u8..ErgoTreeVersion::V3.into() {
+            assert!(try_eval_out_with_version::<Value>(&expr, &ctx, tree_version, 3).is_err());
+        }
+        for tree_version in ErgoTreeVersion::V3.into()..=ErgoTreeVersion::MAX_SCRIPT_VERSION.into()
+        {
+            assert_eq!(
+                try_eval_out_with_version::<i64>(&expr, &ctx, tree_version, 3).unwrap(),
+                2i64
+            );
+        }
     }
 }

--- a/ergotree-interpreter/src/eval/extract_reg_as.rs
+++ b/ergotree-interpreter/src/eval/extract_reg_as.rs
@@ -35,13 +35,13 @@ impl Evaluable for ExtractRegisterAs {
         })?;
         match reg_val_opt {
             Some(constant) if constant.tpe == *self.elem_tpe => {
-                Ok(Value::Opt(Box::new(Some(constant.v.into()))))
+                Ok(Value::Opt(Some(Box::new(constant.v.into()))))
             }
             Some(constant) => Err(EvalError::UnexpectedValue(format!(
                 "Expected register {id} to be of type {}, got {}",
                 self.elem_tpe, constant.tpe
             ))),
-            None => Ok(Value::Opt(Box::new(None))),
+            None => Ok(Value::Opt(None)),
         }
     }
 }

--- a/ergotree-interpreter/src/eval/get_var.rs
+++ b/ergotree-interpreter/src/eval/get_var.rs
@@ -10,7 +10,7 @@ use crate::eval::Evaluable;
 impl Evaluable for GetVar {
     fn eval<'ctx>(&self, _env: &mut Env, ctx: &Context<'ctx>) -> Result<Value<'ctx>, EvalError> {
         match ctx.extension.values.get(&self.var_id) {
-            None => Ok(Value::Opt(None.into())),
+            None => Ok(Value::Opt(None)),
             Some(v) if v.tpe == self.var_tpe => Ok((Some(v.v.clone())).into()),
             Some(v) => Err(TryExtractFromError(format!(
                 "GetVar: expected extension value id {} to have type {:?}, found {:?} in context extension map {}",

--- a/ergotree-interpreter/src/eval/option_get.rs
+++ b/ergotree-interpreter/src/eval/option_get.rs
@@ -15,9 +15,10 @@ impl Evaluable for OptionGet {
     ) -> Result<Value<'ctx>, EvalError> {
         let v = self.input.eval(env, ctx)?;
         match v {
-            Value::Opt(opt_v) => {
-                opt_v.ok_or_else(|| EvalError::NotFound("calling Option.get on None".to_string()))
-            }
+            Value::Opt(opt_v) => opt_v
+                .as_deref()
+                .ok_or_else(|| EvalError::NotFound("calling Option.get on None".to_string()))
+                .cloned(),
             _ => Err(EvalError::UnexpectedExpr(format!(
                 "Don't know how to eval OptM: {0:?}",
                 self

--- a/ergotree-interpreter/src/eval/option_get_or_else.rs
+++ b/ergotree-interpreter/src/eval/option_get_or_else.rs
@@ -15,7 +15,7 @@ impl Evaluable for OptionGetOrElse {
         let v = self.input.eval(env, ctx)?;
         let default_v = self.default.eval(env, ctx)?;
         match v {
-            Value::Opt(opt_v) => Ok(opt_v.unwrap_or(default_v)),
+            Value::Opt(opt_v) => Ok(opt_v.as_deref().cloned().unwrap_or(default_v)),
             _ => Err(EvalError::UnexpectedExpr(format!(
                 "Don't know how to eval OptM: {0:?}",
                 self

--- a/ergotree-interpreter/src/eval/savltree.rs
+++ b/ergotree-interpreter/src/eval/savltree.rs
@@ -42,11 +42,12 @@ pub(crate) static KEY_LENGTH_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, _args| {
 
 pub(crate) static VALUE_LENGTH_OPT_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, _args| {
     let avl_tree_data = obj.try_extract_into::<AvlTreeData>()?;
-    Ok(Value::Opt(Box::new(
+    Ok(Value::Opt(
         avl_tree_data
             .value_length_opt
-            .map(|v| Value::Int(*v as i32)),
-    )))
+            .map(|v| Value::Int(*v as i32))
+            .map(Box::new),
+    ))
 };
 
 pub(crate) static IS_INSERT_ALLOWED_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, _args| {
@@ -125,10 +126,10 @@ pub(crate) static GET_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, args| {
 
     match bv.perform_one_operation(&Operation::Lookup(Bytes::from(key))) {
         Ok(opt) => match opt {
-            Some(v) => Ok(Value::Opt(Box::new(Some(Value::Coll(
+            Some(v) => Ok(Value::Opt(Some(Box::new(Value::Coll(
                 CollKind::NativeColl(NativeColl::CollByte(v.iter().map(|&b| b as i8).collect())),
             ))))),
-            _ => Ok(Value::Opt(Box::new(None))),
+            _ => Ok(Value::Opt(None)),
         },
         Err(_) => Err(EvalError::AvlTree(format!(
             "Tree proof is incorrect {:?}",
@@ -176,13 +177,13 @@ pub(crate) static GET_MANY_EVAL_FN: EvalFn =
             .map(|key| {
                 if let Ok(r) = bv.perform_one_operation(&Operation::Lookup(Bytes::from(key))) {
                     if let Some(v) = r {
-                        Ok(Value::Opt(Box::new(Some(Value::Coll(
+                        Ok(Value::Opt(Some(Box::new(Value::Coll(
                             CollKind::NativeColl(NativeColl::CollByte(
                                 v.iter().map(|&b| b as i8).collect(),
                             )),
                         )))))
                     } else {
-                        Ok(Value::Opt(Box::new(None)))
+                        Ok(Value::Opt(None))
                     }
                 } else {
                     Err(EvalError::AvlTree(format!(
@@ -254,7 +255,7 @@ pub(crate) static INSERT_EVAL_FN: EvalFn =
         if let Some(new_digest) = bv.digest() {
             let digest = ADDigest::scorex_parse_bytes(&new_digest)?;
             avl_tree_data.digest = digest;
-            Ok(Value::Opt(Box::new(Some(Value::AvlTree(
+            Ok(Value::Opt(Some(Box::new(Value::AvlTree(
                 avl_tree_data.into(),
             )))))
         } else {
@@ -314,7 +315,7 @@ pub(crate) static REMOVE_EVAL_FN: EvalFn =
         if let Some(new_digest) = bv.digest() {
             let digest = ADDigest::scorex_parse_bytes(&new_digest)?;
             avl_tree_data.digest = digest;
-            Ok(Value::Opt(Box::new(Some(Value::AvlTree(
+            Ok(Value::Opt(Some(Box::new(Value::AvlTree(
                 avl_tree_data.into(),
             )))))
         } else {
@@ -424,7 +425,7 @@ pub(crate) static UPDATE_EVAL_FN: EvalFn =
         if let Some(new_digest) = bv.digest() {
             let digest = ADDigest::scorex_parse_bytes(&new_digest)?;
             avl_tree_data.digest = digest;
-            Ok(Value::Opt(Box::new(Some(Value::AvlTree(
+            Ok(Value::Opt(Some(Box::new(Value::AvlTree(
                 avl_tree_data.into(),
             )))))
         } else {
@@ -511,7 +512,8 @@ mod tests {
         let res_not_found = eval_out_wo_ctx::<Value>(&expr_not_found);
 
         if let Value::Opt(opt) = res_found {
-            if let Some(Value::Coll(CollKind::NativeColl(NativeColl::CollByte(b)))) = *opt {
+            if let Some(Value::Coll(CollKind::NativeColl(NativeColl::CollByte(b)))) = opt.as_deref()
+            {
                 assert!(lookup_found.unwrap().eq(&b.as_vec_u8()));
             } else {
                 unreachable!();
@@ -592,7 +594,7 @@ mod tests {
         if let Value::Coll(CollKind::WrappedColl { items, .. }) = res {
             for (item, expected) in items.iter().zip(lookups) {
                 if let Value::Opt(opt) = item.clone() {
-                    match *opt {
+                    match opt.as_deref() {
                         None => assert!(expected.is_none()),
                         Some(Value::Coll(CollKind::NativeColl(NativeColl::CollByte(b)))) => {
                             assert_eq!(&b[..], &expected.unwrap().to_vec().as_vec_i8()[..]);
@@ -685,7 +687,7 @@ mod tests {
 
         let res = eval_out_wo_ctx::<Value>(&expr);
         if let Value::Opt(opt) = res {
-            if let Some(Value::AvlTree(avl)) = *opt {
+            if let Some(Value::AvlTree(avl)) = opt.as_deref() {
                 assert_eq!(avl.digest, final_digest);
             } else {
                 unreachable!();
@@ -773,7 +775,7 @@ mod tests {
 
             let res = eval_out_wo_ctx::<Value>(&expr);
             if let Value::Opt(opt) = res {
-                assert_eq!(*opt, value_length_opt);
+                assert_eq!(opt.as_deref().cloned(), value_length_opt);
             } else {
                 unreachable!();
             }
@@ -966,7 +968,7 @@ mod tests {
 
         let res = eval_out_wo_ctx::<Value>(&expr);
         if let Value::Opt(opt) = res {
-            if let Some(Value::AvlTree(avl)) = *opt {
+            if let Some(Value::AvlTree(avl)) = opt.as_deref() {
                 assert_eq!(avl.digest, final_digest);
             } else {
                 unreachable!();
@@ -1043,7 +1045,7 @@ mod tests {
 
         let res = eval_out_wo_ctx::<Value>(&expr);
         if let Value::Opt(opt) = res {
-            if let Some(Value::AvlTree(avl)) = *opt {
+            if let Some(Value::AvlTree(avl)) = opt.as_deref() {
                 assert_eq!(avl.digest, final_digest);
             } else {
                 unreachable!();

--- a/ergotree-interpreter/src/eval/sbox.rs
+++ b/ergotree-interpreter/src/eval/sbox.rs
@@ -57,13 +57,13 @@ pub(crate) static GET_REG_EVAL_FN: EvalFn = |mc, _env, ctx, obj, args| {
     };
     match reg_val_opt {
         Some(constant) if constant.tpe == **expected_type => {
-            Ok(Value::Opt(Box::new(Some(constant.v.into()))))
+            Ok(Value::Opt(Some(Box::new(constant.v.into()))))
         }
         Some(constant) => Err(EvalError::UnexpectedValue(format!(
             "Expected register {reg_id} to be of type {}, got {}",
             expected_type, constant.tpe
         ))),
-        None => Ok(Value::Opt(Box::new(None))),
+        None => Ok(Value::Opt(None)),
     }
 };
 

--- a/ergotree-interpreter/src/eval/sglobal.rs
+++ b/ergotree-interpreter/src/eval/sglobal.rs
@@ -178,7 +178,7 @@ pub(crate) static SGLOBAL_SOME_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, args| {
         .first()
         .cloned()
         .ok_or_else(|| EvalError::NotFound("some: missing value arg".to_string()))?;
-    Ok(Value::Opt(Box::new(Some(value))))
+    Ok(Value::Opt(Some(Box::new(value))))
 };
 
 pub(crate) static SGLOBAL_NONE_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, _args| {
@@ -188,7 +188,7 @@ pub(crate) static SGLOBAL_NONE_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, _args| {
             obj
         )));
     }
-    Ok(Value::Opt(Box::new(None)))
+    Ok(Value::Opt(None))
 };
 
 #[allow(clippy::unwrap_used)]

--- a/ergotree-interpreter/src/eval/soption.rs
+++ b/ergotree-interpreter/src/eval/soption.rs
@@ -45,7 +45,7 @@ pub fn map_eval<'ctx>(
         res
     };
     let normalized_input_val: Option<Value> = match input_v {
-        Value::Opt(opt) => Ok(*opt),
+        Value::Opt(opt) => Ok(opt.as_deref().cloned()),
         _ => Err(EvalError::UnexpectedValue(format!(
             "expected map input to be Value::Opt, got: {0:?}",
             input_v
@@ -53,8 +53,8 @@ pub fn map_eval<'ctx>(
     }?;
 
     match normalized_input_val {
-        Some(t) => Ok(Value::Opt(Box::new(lambda_call(t)?.into()))),
-        _ => Ok(Value::Opt(Box::new(None))),
+        Some(t) => Ok(Value::Opt(Box::new(lambda_call(t)?).into())),
+        _ => Ok(Value::Opt(None)),
     }
 }
 
@@ -93,7 +93,7 @@ pub fn filter_eval<'ctx>(
         res
     };
     let normalized_input_val: Option<Value> = match input_v {
-        Value::Opt(opt) => Ok(*opt),
+        Value::Opt(opt) => Ok(opt.as_deref().cloned()),
         _ => Err(EvalError::UnexpectedValue(format!(
             "expected filter input to be Value::Opt, got: {0:?}",
             input_v
@@ -103,15 +103,15 @@ pub fn filter_eval<'ctx>(
     match normalized_input_val {
         Some(val) => match predicate_call(val.clone())? {
             Value::Boolean(predicate_res) => match predicate_res {
-                true => Ok(Value::Opt(Box::new(Some(val)))),
-                false => Ok(Value::Opt(Box::new(None))),
+                true => Ok(Value::Opt(Some(Box::new(val)))),
+                false => Ok(Value::Opt(None)),
             },
             _ => Err(EvalError::UnexpectedValue(format!(
                 "expected filter predicate result to be boolean, got: {0:?}",
                 lambda.body.tpe()
             ))),
         },
-        None => Ok(Value::Opt(Box::new(None))),
+        None => Ok(Value::Opt(None)),
     }
 }
 
@@ -178,7 +178,7 @@ mod tests {
         let res = eval_out_wo_ctx::<Value>(&expr);
         assert_eq!(
             res,
-            Value::Opt(Box::new(Option::Some(Value::Boolean(true))))
+            Value::Opt(Option::Some(Box::new(Value::Boolean(true))))
         );
     }
 
@@ -224,7 +224,7 @@ mod tests {
         .into();
 
         let res = eval_out_wo_ctx::<Value>(&expr);
-        assert_eq!(res, Value::Opt(Box::new(None)));
+        assert_eq!(res, Value::Opt(None));
     }
 
     #[test]
@@ -262,7 +262,7 @@ mod tests {
         .into();
 
         let res = eval_out_wo_ctx::<Value>(&expr);
-        assert_eq!(res, Value::Opt(Box::new(Option::Some(Value::Long(1)))));
+        assert_eq!(res, Value::Opt(Option::Some(Box::new(Value::Long(1)))));
     }
 
     #[test]
@@ -300,7 +300,7 @@ mod tests {
         .into();
 
         let res = eval_out_wo_ctx::<Value>(&expr);
-        assert_eq!(res, Value::Opt(Box::new(Option::None)));
+        assert_eq!(res, Value::Opt(Option::None));
     }
 
     #[test]
@@ -339,7 +339,7 @@ mod tests {
         .into();
 
         let res = eval_out_wo_ctx::<Value>(&expr);
-        assert_eq!(res, Value::Opt(Box::new(Option::None)));
+        assert_eq!(res, Value::Opt(Option::None));
     }
 
     #[test]

--- a/ergotree-interpreter/src/eval/tree_lookup.rs
+++ b/ergotree-interpreter/src/eval/tree_lookup.rs
@@ -51,8 +51,8 @@ impl Evaluable for TreeLookup {
             normalized_key_val.as_vec_u8(),
         ))) {
             Ok(opt) => match opt {
-                Some(v) => Ok(Value::Opt(Box::new(Some(v.to_vec().into())))),
-                _ => Ok(Value::Opt(Box::new(None))),
+                Some(v) => Ok(Value::Opt(Some(Box::new(v.to_vec().into())))),
+                _ => Ok(Value::Opt(None)),
             },
             Err(_) => Err(EvalError::AvlTree(format!(
                 "Tree proof is incorrect {:?}",
@@ -131,7 +131,8 @@ mod tests {
         let res_not_found: Value = eval_out_wo_ctx(&expr_not_found);
 
         if let Value::Opt(opt) = res_found {
-            if let Some(Value::Coll(CollKind::NativeColl(NativeColl::CollByte(b)))) = *opt {
+            if let Some(Value::Coll(CollKind::NativeColl(NativeColl::CollByte(b)))) = opt.as_deref()
+            {
                 assert!(lookup_found.unwrap().eq(&b.as_vec_u8()));
             } else {
                 unreachable!();

--- a/ergotree-ir/src/mir/constant.rs
+++ b/ergotree-ir/src/mir/constant.rs
@@ -851,7 +851,7 @@ impl TryExtractFrom<Literal> for AvlTreeData {
 impl<T: TryExtractFrom<Literal>> TryExtractFrom<Literal> for Option<T> {
     fn try_extract_from(v: Literal) -> Result<Self, TryExtractFromError> {
         match v {
-            Literal::Opt(opt) => opt.as_deref().cloned().map(T::try_extract_from).transpose(),
+            Literal::Opt(opt) => opt.map(|boxed| *boxed).map(T::try_extract_from).transpose(),
             _ => Err(TryExtractFromError(format!(
                 "expected Option, found {:?}",
                 v

--- a/ergotree-ir/src/mir/constant.rs
+++ b/ergotree-ir/src/mir/constant.rs
@@ -83,7 +83,7 @@ pub enum Literal {
     /// Collection
     Coll(CollKind<Literal>),
     /// Option type
-    Opt(Box<Option<Literal>>),
+    Opt(Option<Box<Literal>>),
     /// Tuple (arbitrary type values)
     Tup(TupleItems<Literal>),
 }
@@ -148,7 +148,7 @@ impl core::fmt::Display for Literal {
                 write!(f, ")")
             }
             Literal::Opt(boxed_opt) => {
-                if let Some(v) = &**boxed_opt {
+                if let Some(v) = boxed_opt {
                     write!(f, "Some(")?;
                     v.fmt(f)?;
                     write!(f, ")")
@@ -293,7 +293,7 @@ impl<T: LiftIntoSType + StoreWrapped + Into<Literal>> From<Vec<T>> for Literal {
 
 impl<T: LiftIntoSType + Into<Literal>> From<Option<T>> for Literal {
     fn from(opt: Option<T>) -> Self {
-        Literal::Opt(Box::new(opt.map(|e| e.into())))
+        Literal::Opt(opt.map(|e| e.into()).map(Box::new))
     }
 }
 
@@ -338,11 +338,11 @@ impl<'ctx> TryFrom<Value<'ctx>> for Constant {
                 };
                 Ok(Constant { v, tpe })
             }
-            Value::Opt(lit) => match *lit {
+            Value::Opt(lit) => match lit {
                 Some(v) => {
-                    let c = Constant::try_from(v)?;
+                    let c = Constant::try_from((*v).clone())?;
                     Ok(Constant {
-                        v: Literal::Opt(Box::new(Some(c.v))),
+                        v: Literal::Opt(Some(Box::new(c.v))),
                         tpe: c.tpe,
                     })
                 }
@@ -532,7 +532,7 @@ impl<T: LiftIntoSType + Into<Constant>> From<Option<T>> for Constant {
     fn from(opt: Option<T>) -> Self {
         Constant {
             tpe: SType::SOption(Arc::new(T::stype())),
-            v: Literal::Opt(Box::new(opt.map(|e| e.into().v))),
+            v: Literal::Opt(opt.map(|e| e.into().v).map(Box::new)),
         }
     }
 }
@@ -851,7 +851,7 @@ impl TryExtractFrom<Literal> for AvlTreeData {
 impl<T: TryExtractFrom<Literal>> TryExtractFrom<Literal> for Option<T> {
     fn try_extract_from(v: Literal) -> Result<Self, TryExtractFromError> {
         match v {
-            Literal::Opt(opt) => opt.map(T::try_extract_from).transpose(),
+            Literal::Opt(opt) => opt.as_deref().cloned().map(T::try_extract_from).transpose(),
             _ => Err(TryExtractFromError(format!(
                 "expected Option, found {:?}",
                 v

--- a/ergotree-ir/src/mir/value.rs
+++ b/ergotree-ir/src/mir/value.rs
@@ -327,7 +327,7 @@ impl From<Literal> for Value<'static> {
                 Value::Coll(converted_coll)
             }
             Literal::AvlTree(a) => Value::AvlTree(a),
-            Literal::Opt(lit) => Value::Opt(lit.as_deref().cloned().map(Value::from).map(Box::new)),
+            Literal::Opt(lit) => Value::Opt(lit.map(|boxed| *boxed).map(Value::from).map(Box::new)),
             Literal::Tup(t) => Value::Tup(t.mapped(Value::from)),
         }
     }
@@ -690,7 +690,7 @@ impl<'ctx, T: TryExtractFrom<Value<'ctx>> + StoreWrapped> TryExtractFrom<Vec<Val
 impl<'ctx, T: TryExtractFrom<Value<'ctx>>> TryExtractFrom<Value<'ctx>> for Option<T> {
     fn try_extract_from(v: Value<'ctx>) -> Result<Self, TryExtractFromError> {
         match v {
-            Value::Opt(opt) => opt.as_deref().cloned().map(T::try_extract_from).transpose(),
+            Value::Opt(opt) => opt.map(|boxed| *boxed).map(T::try_extract_from).transpose(),
             _ => Err(TryExtractFromError(format!(
                 "expected Option, found {:?}",
                 v

--- a/ergotree-ir/src/mir/value.rs
+++ b/ergotree-ir/src/mir/value.rs
@@ -205,7 +205,7 @@ pub enum Value<'ctx> {
     /// Global which is used to define global methods
     Global,
     /// Optional value
-    Opt(Box<Option<Value<'ctx>>>),
+    Opt(Option<Box<Value<'ctx>>>),
     /// lambda
     Lambda(Lambda),
 }
@@ -246,7 +246,7 @@ impl<'ctx> Value<'ctx> {
             Value::PreHeader(h) => Value::PreHeader(h.clone()),
             Value::Global => Value::Global,
             Value::CBox(c) => Value::CBox(c.to_static()),
-            Value::Opt(opt) => Value::Opt(Box::new(Option::as_ref(opt).map(|o| o.to_static()))),
+            Value::Opt(opt) => Value::Opt(Option::as_ref(opt).map(|o| o.to_static()).map(Box::new)),
             Value::Lambda(l) => Value::Lambda(l.clone()),
         }
     }
@@ -299,7 +299,7 @@ impl<'ctx> From<Vec<u8>> for Value<'ctx> {
 
 impl<'ctx, T: Into<Value<'ctx>>> From<Option<T>> for Value<'ctx> {
     fn from(opt: Option<T>) -> Self {
-        Value::Opt(Box::new(opt.map(|v| v.into())))
+        Value::Opt(opt.map(|v| v.into()).map(Box::new))
     }
 }
 
@@ -327,7 +327,7 @@ impl From<Literal> for Value<'static> {
                 Value::Coll(converted_coll)
             }
             Literal::AvlTree(a) => Value::AvlTree(a),
-            Literal::Opt(lit) => Value::Opt(Box::new(lit.into_iter().next().map(Value::from))),
+            Literal::Opt(lit) => Value::Opt(lit.as_deref().cloned().map(Value::from).map(Box::new)),
             Literal::Tup(t) => Value::Tup(t.mapped(Value::from)),
         }
     }
@@ -357,7 +357,7 @@ impl core::fmt::Display for Value<'_> {
                 write!(f, ")")
             }
             Value::Opt(boxed_opt) => {
-                if let Some(v) = &**boxed_opt {
+                if let Some(v) = boxed_opt {
                     write!(f, "Some(")?;
                     v.fmt(f)?;
                     write!(f, ")")
@@ -690,7 +690,7 @@ impl<'ctx, T: TryExtractFrom<Value<'ctx>> + StoreWrapped> TryExtractFrom<Vec<Val
 impl<'ctx, T: TryExtractFrom<Value<'ctx>>> TryExtractFrom<Value<'ctx>> for Option<T> {
     fn try_extract_from(v: Value<'ctx>) -> Result<Self, TryExtractFromError> {
         match v {
-            Value::Opt(opt) => opt.map(T::try_extract_from).transpose(),
+            Value::Opt(opt) => opt.as_deref().cloned().map(T::try_extract_from).transpose(),
             _ => Err(TryExtractFromError(format!(
                 "expected Option, found {:?}",
                 v


### PR DESCRIPTION
Add lazy default for getOrElse and Coll.get, also transpose Box<Option<T>> so Option<Box<T>> to make pattern-matching simpler and avoid allocating for None
For #787 