### PR TITLE
Speed up some tests, make transaction validation tests less flaky

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -78,7 +78,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter --manifest-path bindings/ergo-lib-python/Cargo.toml
-          sccache: "true"
+          sccache: "false"
           manylinux: musllinux_1_2
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/bindings/ergo-lib-ios/Sources/ErgoLib/NodeConf.swift
+++ b/bindings/ergo-lib-ios/Sources/ErgoLib/NodeConf.swift
@@ -1,5 +1,11 @@
-import Foundation
 import ErgoLibC
+import Foundation
+
+enum NodeConfError: Error {
+    case InvalidScheme
+    case MissingHost
+    case MissingPort
+}
 
 class NodeConf {
     internal var pointer: NodeConfPtr
@@ -15,6 +21,16 @@ class NodeConf {
         }
         try checkError(error)
         self.pointer = ptr!
+    }
+
+    convenience init(withUrl url: URL) throws {
+        guard url.scheme == "http" || url.scheme == "https" else {
+            throw NodeConfError.InvalidScheme
+        }
+        guard url.host != nil else { throw NodeConfError.MissingHost }
+        guard url.port != nil else { throw NodeConfError.MissingPort }
+        let addr = url.host()! + ":" + String(url.port!)
+        try self.init(withAddrString: addr)
     }
 
     deinit {

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/Common.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/Common.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 @testable import ErgoLib
 @testable import ErgoLibC
 
@@ -34,16 +35,17 @@ func getSeeds() -> [URL] {
         "http://62.171.190.193:9030",
         "http://173.212.220.9:9030",
         "http://176.9.65.58:9130",
-        "http://213.152.106.56:9030"
+        "http://213.152.106.56:9030",
     ].map { URL(string: $0)! }
 }
 
 func getNipopowProof(url: URL, headerId: BlockId) async throws -> NipopowProof? {
-    let nodeConf = try NodeConf(withAddrString: url.absoluteString)
+    let nodeConf = try NodeConf(withUrl: url)
     let restNodeApi = try RestNodeApi()
     let nodeInfo = try await restNodeApi.getInfoAsync(nodeConf: nodeConf)
     if nodeInfo.isAtLeastVersion40100() {
-        let proof = try await restNodeApi.getNipopowProofByHeaderIdAsync(nodeConf: nodeConf, minChainLength: UInt32(7), suffixLen: UInt32(6), headerId: headerId)
+        let proof = try await restNodeApi.getNipopowProofByHeaderIdAsync(
+            nodeConf: nodeConf, minChainLength: UInt32(7), suffixLen: UInt32(6), headerId: headerId)
         return proof
     } else {
         return nil

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/RestNodeApiTests.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/RestNodeApiTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import ErgoLib
 @testable import ErgoLibC
 
@@ -13,18 +14,18 @@ final class RestNodeApiTests: XCTestCase {
             minChainLength: UInt32(3),
             suffixLen: UInt32(2),
             headerId: blockHeaders.get(index: UInt(0))!.getBlockId(),
-            closure: { (res: Result<NipopowProof, Error>) -> () in
+            closure: { (res: Result<NipopowProof, Error>) -> Void in
                 switch res {
-                    case .success(_):
-                        break
-                    case .failure(let error):
-                        XCTFail(error.localizedDescription)
+                case .success(_):
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 expectation.fulfill()
             })
         waitForExpectations(timeout: 5, handler: nil)
     }
-    
+
     func testGetNipopowProofByHeaderAbort() throws {
         let nodeConf = try NodeConf(withAddrString: "213.239.193.208:9053")
         let restNodeApi = try RestNodeApi()
@@ -34,12 +35,12 @@ final class RestNodeApiTests: XCTestCase {
             minChainLength: UInt32(3),
             suffixLen: UInt32(2),
             headerId: blockHeaders.get(index: UInt(0))!.getBlockId(),
-            closure: { (res: Result<NipopowProof, Error>) -> () in
+            closure: { (res: Result<NipopowProof, Error>) -> Void in
                 XCTFail("this should not be called")
             })
         handle.abort()
     }
-    
+
     func testGetNipopowProofByHeaderIdAsync() async throws {
         let nodeConf = try NodeConf(withAddrString: "213.239.193.208:9053")
         let restNodeApi = try RestNodeApi()
@@ -51,7 +52,7 @@ final class RestNodeApiTests: XCTestCase {
             headerId: blockHeaders.get(index: UInt(0))!.getBlockId()
         )
         XCTAssertNoThrow(try proof.toJSON()!)
-        
+
         // test of re-using of tokio runtime
         let proofNew = try await restNodeApi.getNipopowProofByHeaderIdAsync(
             nodeConf: nodeConf,
@@ -61,7 +62,7 @@ final class RestNodeApiTests: XCTestCase {
         )
         XCTAssertNoThrow(try proofNew.toJSON()!)
     }
-    
+
     func testPeerDiscoveryNonAsync() throws {
         let expectation = self.expectation(description: "peerDiscovery")
         let restNodeApi = try RestNodeApi()
@@ -69,19 +70,19 @@ final class RestNodeApiTests: XCTestCase {
             seeds: getSeeds(),
             maxParallelReqs: UInt16(30),
             timeoutSec: UInt32(3),
-            closure: { (res: Result<CStringCollection, Error>) -> () in
+            closure: { (res: Result<CStringCollection, Error>) -> Void in
                 switch res {
-                    case .success(let peers):
-                        XCTAssert(peers.getLength() > 0)
-                        break
-                    case .failure(let error):
-                        XCTFail(error.localizedDescription)
+                case .success(let peers):
+                    XCTAssert(peers.getLength() > 0)
+                    break
+                case .failure(let error):
+                    XCTFail(error.localizedDescription)
                 }
                 expectation.fulfill()
             })
         waitForExpectations(timeout: 60, handler: nil)
     }
-    
+
     func testPeerDiscoveryAsync() async throws {
         let restNodeApi = try RestNodeApi()
         let peers = try await restNodeApi.peerDiscoveryAsync(
@@ -91,7 +92,7 @@ final class RestNodeApiTests: XCTestCase {
         )
 
         XCTAssert(!peers.isEmpty)
-        
+
         // test of re-using of tokio runtime
         let peersNew = try await restNodeApi.peerDiscoveryAsync(
             seeds: getSeeds(),
@@ -100,34 +101,41 @@ final class RestNodeApiTests: XCTestCase {
         )
         XCTAssert(!peersNew.isEmpty)
     }
-    
+
     func testSPVWorkflow() async throws {
-        let headerId = try BlockId(withString: "d1366f762e46b7885496aaab0c42ec2950b0422d48aec3b91f45d4d0cdeb41e5")
-        let txId = try TxId(withString: "258ddfc09b94b8313bca724de44a0d74010cab26de379be845713cc129546b78")
-        let proofs = try await withThrowingTaskGroup(of: [NipopowProof].self) { group -> [NipopowProof] in
+        let headerId = try BlockId(
+            withString: "d1366f762e46b7885496aaab0c42ec2950b0422d48aec3b91f45d4d0cdeb41e5")
+        let txId = try TxId(
+            withString: "258ddfc09b94b8313bca724de44a0d74010cab26de379be845713cc129546b78")
+        let proofs = try await withThrowingTaskGroup(of: [NipopowProof].self) {
+            group -> [NipopowProof] in
             group.addTask {
-                let proof = try await getNipopowProof(url: URL(string: "159.65.11.55:9053")!, headerId: headerId)!
+                let proof = try await getNipopowProof(
+                    url: URL(string: "http://159.65.11.55:9053")!, headerId: headerId)!
                 return [proof]
             }
             group.addTask {
-                let proof = try await getNipopowProof(url: URL(string: "213.239.193.208:9053")!, headerId: headerId)!
+                let proof = try await getNipopowProof(
+                    url: URL(string: "http://213.239.193.208:9053")!, headerId: headerId)!
                 return [proof]
             }
             return try await group.reduce(into: [NipopowProof]()) { $0 += $1 }
         }
-        
-        let genesisBlockId = try BlockId(withString: "b0244dfc267baca974a4caee06120321562784303a8a688976ae56170e4d175b")
+
+        let genesisBlockId = try BlockId(
+            withString: "b0244dfc267baca974a4caee06120321562784303a8a688976ae56170e4d175b")
         let verifier = NipopowVerifier(withGenesisBlockId: genesisBlockId)
         try verifier.process(newProof: proofs[0])
         try verifier.process(newProof: proofs[1])
         let bestProof = verifier.bestProof()
         XCTAssertEqual(try bestProof.suffixHead().getHeader().getBlockId(), headerId)
-        
+
         // Now verify with 3rd node
         let nodeConf = try NodeConf(withAddrString: "213.239.193.208:9053")
         let restNodeApi = try RestNodeApi()
         let header = try await restNodeApi.getHeaderAsync(nodeConf: nodeConf, blockId: headerId)
-        let merkleProof = try await restNodeApi.getBlocksHeaderIdProofForTxIdAsync(nodeConf: nodeConf, blockId: headerId, txId: txId)
+        let merkleProof = try await restNodeApi.getBlocksHeaderIdProofForTxIdAsync(
+            nodeConf: nodeConf, blockId: headerId, txId: txId)
         XCTAssert(try merkleProof.valid(expected_root: header.getTransactionsRoot()))
     }
 }

--- a/ergo-chain-generation/src/chain_generation.rs
+++ b/ergo-chain-generation/src/chain_generation.rs
@@ -383,7 +383,7 @@ mod tests {
     #[test]
     fn test_nipopow_lowest_common_ancestor_diverging_autolykos_v1() {
         let popow_algos = NipopowAlgos::default();
-        for size in [10, 100, 200] {
+        for size in [10, 50, 100] {
             let stream = block_stream(None);
             let chain_0: Vec<_> = stream.take(size).collect();
             let branch_point = chain_0[size / 2].clone();
@@ -428,7 +428,7 @@ mod tests {
         let k = 30;
         let popow_algos = NipopowAlgos::default();
 
-        let short_chain = generate_popowheader_chain(1000, None);
+        let short_chain = generate_popowheader_chain(100, None);
         let branch_point = short_chain[short_chain.len() - 1].clone();
         let mut long_chain = short_chain.clone();
         long_chain.extend(std::iter::once(

--- a/ergo-chain-generation/src/fake_pow_scheme.rs
+++ b/ergo-chain-generation/src/fake_pow_scheme.rs
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn test_nipopow_lowest_common_ancestor_diverging() {
         let popow_algos = NipopowAlgos::default();
-        for size in [10, 100, 200] {
+        for size in [10, 50, 100] {
             let stream = block_stream(None);
             let chain_0: Vec<_> = stream.take(size).collect();
             let branch_point = chain_0[size / 2].clone();
@@ -250,7 +250,7 @@ mod tests {
         let k = 30;
         let popow_algos = NipopowAlgos::default();
 
-        let short_chain = generate_popowheader_chain(1000, None);
+        let short_chain = generate_popowheader_chain(100, None);
         let branch_point = short_chain[short_chain.len() - 1].clone();
         let mut long_chain = short_chain.clone();
         long_chain.extend(std::iter::once(

--- a/ergo-lib/src/wallet/deterministic.rs
+++ b/ergo-lib/src/wallet/deterministic.rs
@@ -114,6 +114,7 @@ mod test {
     }
 
     proptest! {
+        #![proptest_config(ProptestConfig::with_cases(32))]
         // Produce signatures for different messages and test for nonce re-use
         #[test]
         fn test_sign_deterministic((sk, boxes) in gen_boxes()) {

--- a/ergo-lib/src/wallet/tx_context.rs
+++ b/ergo-lib/src/wallet/tx_context.rs
@@ -352,7 +352,7 @@ mod test {
                         .into_iter()
                         .map(move |tokens| {
                             let box_params = ArbBoxParameters {
-                                value_range: (1000000..100000000).into(),
+                                value_range: (10000000..100000000).into(),
                                 ergo_tree: Just(proposition.clone()).boxed(),
                                 creation_height: Just(creation_height).boxed(),
                                 tokens: Just(tokens).boxed(),
@@ -570,6 +570,8 @@ mod test {
     }
 
     proptest! {
+
+    #![proptest_config(ProptestConfig::with_cases(32))]
     #[test]
     // Test that a valid transaction is valid
     fn test_valid_transaction((boxes, tx) in valid_transaction_generator()) {

--- a/ergo-merkle-tree/src/batchmerkleproof.rs
+++ b/ergo-merkle-tree/src/batchmerkleproof.rs
@@ -6,6 +6,7 @@ use ergo_chain_types::Digest32;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(proptest_derive::Arbitrary))]
 pub struct BatchMerkleProofIndex {
+    #[cfg_attr(feature = "arbitrary", proptest(strategy = "1..u32::MAX as usize"))]
     pub index: usize,
     pub hash: Digest32,
 }
@@ -196,12 +197,12 @@ impl ScorexSerializable for BatchMerkleProof {
 #[cfg(feature = "arbitrary")]
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod test {
-    use crate::batchmerkleproof::{BatchMerkleProof, BatchMerkleProofIndex};
+    use crate::batchmerkleproof::BatchMerkleProof;
     use proptest::prelude::*;
     use sigma_ser::ScorexSerializable;
     proptest! {
         #[test]
-        fn test_batchmerkleproof_serialization_roundtrip(proof in any::<BatchMerkleProof>().prop_filter("Indices > u32::max not allowed", |proof| proof.indices.len() < u32::MAX as usize && proof.indices.iter().all(|BatchMerkleProofIndex {index, ..}| *index < u32::MAX as usize))) {
+        fn test_batchmerkleproof_serialization_roundtrip(proof in any::<BatchMerkleProof>().prop_filter("Indices > u32::max not allowed", |proof| proof.indices.len() < u32::MAX as usize)) {
             let serialized_bytes = proof.scorex_serialize_bytes().unwrap();
             assert_eq!(BatchMerkleProof::scorex_parse_bytes(&serialized_bytes).unwrap(), proof);
             assert_eq!(serialized_bytes.len(), (8 + proof.proofs.len() * 33 + proof.indices.len() * 36));

--- a/ergo-merkle-tree/src/merkletree.rs
+++ b/ergo-merkle-tree/src/merkletree.rs
@@ -353,15 +353,16 @@ mod arbitrary {
     use proptest::prelude::*;
     proptest! {
         #[test]
-        fn merkle_tree_test_arbitrary_proof(data in vec(uniform32(0u8..), 0..1000)) {
+        fn merkle_tree_test_arbitrary_proof(data in vec(uniform32(0u8..), 0..100)) {
             let nodes: Vec<MerkleNode> = data.into_iter().map(MerkleNode::from_bytes).collect();
             let tree = MerkleTree::new(&*nodes);
             for (i, node) in nodes.iter().enumerate() {
+                let proof = tree.proof_by_index(i).unwrap();
                 assert_eq!(
-                    tree.proof_by_index(i).unwrap().get_leaf_data(),
+                    proof.get_leaf_data(),
                     node.get_leaf_data().unwrap()
                 );
-                assert!(tree.proof_by_index(i).unwrap().valid(tree.root_hash().as_ref()));
+                assert!(proof.valid(tree.root_hash().as_ref()));
             }
         }
         #[test]


### PR DESCRIPTION
This PR speeds up some tests by lowering constraints (number of cases, size of structures to generate, etc). 

The default cargo test command can run tests in parallel, but only within the same crate. So for a cargo workspace running tests in parallel the time taken would (roughly) be the sum of the times of the longest running tests in each crate. 

This brings time for tests in release mode down from 1m 15s to 56s, and time to generate coverage (slower to run tests and no parallelism) from 27m to ~18m. 

Also fixes python builds for musl and swift tests broken by changed URL behavior