### PR TITLE
Add criterion benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ proptest-derive = "0.5.1"
 pretty_assertions = "1.3"
 wasm-bindgen-test = "0.3.37"
 expect-test = "1.4.1"
+criterion = { version = "0.5.1", features = ["default", "cargo_bench_support"] }
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/ergo-lib/Cargo.toml
+++ b/ergo-lib/Cargo.toml
@@ -77,7 +77,12 @@ sigma-test-util = { workspace = true }
 pretty_assertions = { workspace = true }
 bs58 = { workspace = true }
 expect-test = { workspace = true }
+criterion = { workspace = true }
 
+[[bench]]
+name = "tx_context"
+harness = false
+required-features = ["arbitrary"]
 
 # docs.rs-specific configuration
 [package.metadata.docs.rs]

--- a/ergo-lib/benches/tx_context.rs
+++ b/ergo-lib/benches/tx_context.rs
@@ -1,0 +1,139 @@
+use criterion::{criterion_group, criterion_main, BatchSize};
+
+use criterion::{BenchmarkId, Criterion, SamplingMode};
+use ergo_lib::chain::ergo_box::box_builder::ErgoBoxCandidateBuilder;
+use ergo_lib::{
+    chain::transaction::{unsigned::UnsignedTransaction, UnsignedInput},
+    wallet::{secret_key::SecretKey, signing::TransactionContext, Wallet},
+};
+use ergotree_ir::chain::ergo_box::box_value::BoxValue;
+use ergotree_ir::chain::tx_id::TxId;
+use ergotree_ir::mir::expr::Expr;
+use ergotree_ir::{
+    chain::{context_extension::ContextExtension, ergo_box::ErgoBox},
+    ergo_tree::{ErgoTree, ErgoTreeHeader},
+    mir::constant::Constant,
+};
+use sigma_test_util::force_any_val;
+
+pub fn bench_tx_context(c: &mut Criterion) {
+    let mut group = c.benchmark_group("TransactionContext::new scaling with inputs");
+    group.sample_size(10);
+    let true_tree = ErgoTree::new(ErgoTreeHeader::v0(true), &Expr::Const(true.into())).unwrap();
+
+    for range in (1..=100).step_by(10) {
+        let inputs = (0..range)
+            .map(|i| {
+                ErgoBox::from_box_candidate(
+                    &ErgoBoxCandidateBuilder::new(BoxValue::SAFE_USER_MIN, true_tree.clone(), 1000)
+                        .build()
+                        .unwrap(),
+                    TxId::zero(),
+                    i as u16,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<ErgoBox>>();
+        let input_ids = inputs
+            .iter()
+            .map(|input| UnsignedInput::new(input.box_id(), ContextExtension::empty()))
+            .collect();
+        let unsigned_tx = UnsignedTransaction::new_from_vec(
+            input_ids,
+            vec![],
+            vec![
+                ErgoBoxCandidateBuilder::new(BoxValue::SAFE_USER_MIN, true_tree.clone(), 1000)
+                    .build()
+                    .unwrap(),
+            ],
+        )
+        .unwrap();
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{range:4}")),
+            &unsigned_tx,
+            |b, tx| {
+                b.iter_batched(
+                    || (tx.clone(), inputs.clone(), vec![]),
+                    |(tx, inputs, data_inputs)| {
+                        TransactionContext::new(tx, inputs, data_inputs).unwrap()
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
+    group.finish();
+}
+
+pub fn bench_tx_sign_wallet(c: &mut Criterion) {
+    let mut sign_group = c.benchmark_group("sign ProveDlog inputs");
+    sign_group
+        .sample_size(10)
+        .sampling_mode(SamplingMode::Flat)
+        .warm_up_time(std::time::Duration::from_millis(50));
+
+    const MAX_INPUTS: usize = 100;
+    let secrets = vec![SecretKey::random_dlog(); MAX_INPUTS];
+    let inputs = (0..MAX_INPUTS)
+        .map(|i| {
+            ErgoBox::from_box_candidate(
+                &ErgoBoxCandidateBuilder::new(
+                    BoxValue::SAFE_USER_MIN,
+                    secrets[i].get_address_from_public_image().script().unwrap(),
+                    1000,
+                )
+                .build()
+                .unwrap(),
+                TxId::zero(),
+                i as u16,
+            )
+            .unwrap()
+        })
+        .collect::<Vec<ErgoBox>>();
+    let wallet = Wallet::from_secrets(secrets);
+
+    for range in (1..=MAX_INPUTS).step_by(20) {
+        let input_ids = inputs
+            .iter()
+            .take(range)
+            .map(|input| UnsignedInput::new(input.box_id(), ContextExtension::empty()))
+            .collect();
+        let unsigned_tx = UnsignedTransaction::new_from_vec(
+            input_ids,
+            vec![],
+            vec![ErgoBoxCandidateBuilder::new(
+                BoxValue::SAFE_USER_MIN,
+                ErgoTree::new(
+                    ErgoTreeHeader::new(0).unwrap(),
+                    &Constant::from(true).into(),
+                )
+                .unwrap(),
+                1000,
+            )
+            .build()
+            .unwrap()],
+        )
+        .unwrap();
+        let tx_context =
+            TransactionContext::new(unsigned_tx, inputs[0..range].to_owned(), vec![]).unwrap();
+        sign_group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{range:4}")),
+            &tx_context,
+            |b, tx_context| {
+                b.iter_batched(
+                    || (tx_context.clone(), force_any_val()),
+                    |(tx_context, state_context)| {
+                        wallet
+                            .sign_transaction(tx_context, &state_context, None)
+                            .unwrap()
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
+    sign_group.finish();
+}
+
+criterion_group!(benches, bench_tx_context, bench_tx_sign_wallet);
+criterion_main!(benches);

--- a/ergo-lib/src/chain/ergo_box/box_builder.rs
+++ b/ergo-lib/src/chain/ergo_box/box_builder.rs
@@ -3,7 +3,7 @@
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
-use core::convert::{TryFrom, TryInto};
+use core::convert::TryFrom;
 use hashbrown::HashMap;
 
 use ergotree_ir::chain::address::AddressEncoderError;
@@ -28,7 +28,7 @@ pub enum ErgoBoxCandidateBuilderError {
         /// box value that caused this error
         error_value: BoxValue,
         /// minimum box value for that box size
-        min_box_value: BoxValue,
+        min_box_value: i64,
         /// box size in bytes
         box_size_bytes: usize,
     },
@@ -259,10 +259,8 @@ impl ErgoBoxCandidateBuilder {
 
         // Won't be overflowing an i64, so unwrap is safe.
         #[allow(clippy::unwrap_used)]
-        let min_box_value: BoxValue = (box_size_bytes as i64 * self.min_value_per_byte as i64)
-            .try_into()
-            .unwrap();
-        if self.value >= min_box_value {
+        let min_box_value: i64 = box_size_bytes as i64 * self.min_value_per_byte as i64;
+        if self.value.as_i64() >= min_box_value {
             Ok(b)
         } else {
             Err(ErgoBoxCandidateBuilderError::BoxValueTooLow {

--- a/ergotree-interpreter/Cargo.toml
+++ b/ergotree-interpreter/Cargo.toml
@@ -39,6 +39,7 @@ gf2_192 = { version = "^0.28.0", path = "../gf2_192" }
 miette = { workspace = true, optional = true }
 hashbrown = { workspace = true }
 core2 = { workspace = true }
+sigma-test-util = { workspace = true, optional = true }
 [features]
 json = [
     "serde",
@@ -57,6 +58,7 @@ arbitrary = [
     "ergotree-ir/arbitrary",
     "ergo-chain-types/arbitrary",
     "gf2_192/arbitrary",
+    "sigma-test-util",
 ]
 
 [dev-dependencies]
@@ -65,3 +67,9 @@ ergoscript-compiler = { workspace = true }
 proptest = { workspace = true }
 sigma-test-util = { workspace = true }
 expect-test = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "eval_benches"
+harness = false
+required-features = ["arbitrary"]

--- a/ergotree-interpreter/benches/eval_benches.rs
+++ b/ergotree-interpreter/benches/eval_benches.rs
@@ -1,0 +1,206 @@
+use std::str::FromStr;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use ergo_chain_types::ec_point::{exponentiate, generator};
+use ergotree_interpreter::eval::test_util::eval_out_wo_ctx;
+use ergotree_ir::{
+    bigint256::BigInt256,
+    ergo_tree::{ErgoTree, ErgoTreeHeader},
+    mir::{
+        bin_op::{BinOp, BinOpKind, RelationOp},
+        calc_blake2b256::CalcBlake2b256,
+        calc_sha256::CalcSha256,
+        coll_append::Append,
+        coll_filter::Filter,
+        constant::Constant,
+        exponentiate::Exponentiate,
+        expr::Expr,
+        func_value::{FuncArg, FuncValue},
+        method_call::MethodCall,
+        sigma_and::SigmaAnd,
+        subst_const::SubstConstants,
+        val_use::ValUse,
+        value::Value,
+    },
+    serialization::SigmaSerializable,
+    sigma_protocol::sigma_boolean::{SigmaBoolean, SigmaProp},
+    types::{scoll::FLATMAP_METHOD, stype::SType, stype_param::STypeVar},
+};
+
+fn bench_blake2b256(c: &mut Criterion) {
+    let mut group = c.benchmark_group("blake2b256");
+    for size in (1..1024).step_by(200) {
+        let arr = vec![0u8; size];
+        let expr: Expr = CalcBlake2b256 {
+            input: Box::new(Constant::from(arr).into()),
+        }
+        .into();
+        group.bench_function(BenchmarkId::from_parameter(format!("{size:4}")), |b| {
+            b.iter(|| eval_out_wo_ctx::<Vec<i8>>(&expr))
+        });
+    }
+}
+
+fn bench_sha256(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sha256");
+    for size in (1..1024).step_by(200) {
+        let arr = vec![0u8; size];
+        let expr: Expr = CalcSha256 {
+            input: Box::new(Constant::from(arr).into()),
+        }
+        .into();
+        group.bench_function(BenchmarkId::from_parameter(format!("{size:4}")), |b| {
+            b.iter(|| eval_out_wo_ctx::<Vec<i8>>(&expr))
+        });
+    }
+}
+
+fn bench_append(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Coll.append");
+    for size in (1..1024).step_by(200) {
+        let arr = vec![0u8; size];
+        let expr: Expr = Append::new(
+            Constant::from(arr.clone()).into(),
+            Constant::from(arr).into(),
+        )
+        .unwrap()
+        .into();
+        group.bench_function(BenchmarkId::from_parameter(format!("{size:4}")), |b| {
+            b.iter(|| eval_out_wo_ctx::<Value<'_>>(&expr));
+        });
+    }
+}
+
+fn bench_substitute_constants(c: &mut Criterion) {
+    let mut group = c.benchmark_group("substituteConstants");
+    for size in (1..=101).step_by(10) {
+        let tree_expr: Expr =
+            SigmaAnd::new(vec![Constant::from(SigmaBoolean::from(true)).into(); size])
+                .unwrap()
+                .into();
+        let tree_bytes = ErgoTree::new(ErgoTreeHeader::v1(true), &tree_expr)
+            .unwrap()
+            .sigma_serialize_bytes()
+            .unwrap();
+        let subst_expr = SubstConstants::new(
+            tree_bytes.into(),
+            Constant::from((0..size as i32).collect::<Vec<_>>()).into(),
+            Constant::from(vec![SigmaProp::new(false.into()); size]).into(),
+        )
+        .unwrap()
+        .into();
+        group.bench_function(BenchmarkId::from_parameter(format!("{size:3}")), |b| {
+            b.iter(|| eval_out_wo_ctx::<Value<'_>>(&subst_expr))
+        });
+    }
+}
+
+fn bench_exponentiate(c: &mut Criterion) {
+    c.bench_function("exponentiate(generator, a)", |b| {
+        let a = BigInt256::from_str("1000").unwrap();
+        let expr: Expr = Exponentiate::new(generator().into(), a.into())
+            .unwrap()
+            .into();
+        b.iter(|| eval_out_wo_ctx::<Value<'_>>(&expr))
+    });
+    c.bench_function("exponentiate(point, a)", |b| {
+        let a = BigInt256::from_str("1000").unwrap();
+        let expr: Expr =
+            Exponentiate::new((exponentiate(&generator(), &2u32.into())).into(), a.into())
+                .unwrap()
+                .into();
+        b.iter(|| eval_out_wo_ctx::<Value<'_>>(&expr))
+    });
+}
+
+fn bench_filter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("filter");
+    // v % 2 == 0
+    let filter_lambda = BinOp {
+        kind: BinOpKind::Relation(RelationOp::Eq),
+        left: Box::new(
+            BinOp {
+                kind: BinOpKind::Arith(ergotree_ir::mir::bin_op::ArithOp::Modulo),
+                left: Box::new(
+                    ValUse {
+                        val_id: 1.into(),
+                        tpe: SType::SInt,
+                    }
+                    .into(),
+                ),
+                right: Box::new(Constant::from(2i32).into()),
+            }
+            .into(),
+        ),
+        right: Box::new(Constant::from(0i32).into()),
+    };
+    for size in (1..=1001i32).step_by(100) {
+        let arr: Expr = Constant::from((0..size).collect::<Vec<_>>()).into();
+        let expr: Expr = Filter::new(
+            arr,
+            FuncValue::new(
+                vec![FuncArg {
+                    idx: 1.into(),
+                    tpe: SType::SInt,
+                }],
+                filter_lambda.clone().into(),
+            )
+            .into(),
+        )
+        .unwrap()
+        .into();
+        group.bench_function(BenchmarkId::from_parameter(format!("{size:4}")), |b| {
+            b.iter(|| eval_out_wo_ctx::<Value<'_>>(&expr))
+        });
+    }
+}
+
+fn bench_flatmap(c: &mut Criterion) {
+    let mut group = c.benchmark_group("flatMap");
+    // flatten Coll[Coll[Byte]] into Coll[Byte]
+    let flatmap_lambda: Expr = ValUse {
+        val_id: 1.into(),
+        tpe: SType::SColl(SType::SByte.into()),
+    }
+    .into();
+    for size in (1..=1001).step_by(100) {
+        let obj: Expr = Constant::from(vec![vec![0u8; 100]; size]).into();
+        let mc: Expr = MethodCall::new(
+            obj,
+            FLATMAP_METHOD.clone().with_concrete_types(
+                &[
+                    (STypeVar::iv(), SType::SColl(SType::SByte.into())),
+                    (STypeVar::ov(), SType::SByte),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            vec![FuncValue::new(
+                vec![FuncArg {
+                    idx: 1.into(),
+                    tpe: SType::SColl(SType::SByte.into()),
+                }],
+                flatmap_lambda.clone(),
+            )
+            .into()],
+        )
+        .unwrap()
+        .into();
+        group.bench_function(BenchmarkId::from_parameter(format!("{size:4}")), |b| {
+            b.iter(|| assert_eq!(eval_out_wo_ctx::<Vec<i8>>(&mc).len(), 100 * size))
+        });
+    }
+}
+
+criterion_group!(
+    eval_benches,
+    bench_blake2b256,
+    bench_sha256,
+    bench_append,
+    bench_substitute_constants,
+    bench_exponentiate,
+    bench_filter,
+    bench_flatmap
+);
+
+criterion_main!(eval_benches);

--- a/ergotree-interpreter/src/contracts.rs
+++ b/ergotree-interpreter/src/contracts.rs
@@ -3,7 +3,7 @@
 mod tests {
     use core::convert::TryInto;
 
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
     use ergotree_ir::chain::address::AddressEncoder;
     use ergotree_ir::chain::address::NetworkPrefix;
     use ergotree_ir::sigma_protocol::sigma_boolean::SigmaProp;

--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -410,9 +410,12 @@ pub(crate) mod tests {
     use expect_test::expect;
     use sigma_test_util::force_any_val;
 
+    thread_local! {
+        static TEST_CTX: Context<'static> = force_any_val::<Context>();
+    }
+
     pub fn eval_out_wo_ctx<T: TryExtractFrom<Value<'static>> + 'static>(expr: &Expr) -> T {
-        let ctx = force_any_val::<Context>();
-        eval_out(expr, &ctx)
+        TEST_CTX.with(|ctx| eval_out(expr, ctx))
     }
 
     pub fn eval_out<T: TryExtractFrom<Value<'static>> + 'static>(
@@ -472,8 +475,7 @@ pub(crate) mod tests {
     pub fn try_eval_out_wo_ctx<T: TryExtractFrom<Value<'static>> + 'static>(
         expr: &Expr,
     ) -> Result<T, EvalError> {
-        let ctx = force_any_val::<Context>();
-        try_eval_out(expr, &ctx)
+        TEST_CTX.with(|ctx| try_eval_out(expr, ctx))
     }
 
     #[test]

--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -387,27 +387,20 @@ fn smethod_eval_fn(method: &SMethod) -> Result<EvalFn, EvalError> {
     })
 }
 
-#[cfg(test)]
-#[cfg(feature = "arbitrary")]
+#[doc(hidden)]
+#[allow(missing_docs)]
 #[allow(clippy::unwrap_used)]
 #[allow(clippy::todo)]
-pub(crate) mod tests {
+#[cfg(feature = "arbitrary")]
+pub mod test_util {
 
     use super::env::Env;
     use super::*;
-    use ergotree_ir::mir::bin_op::BinOp;
-    use ergotree_ir::mir::bin_op::BinOpKind;
-    use ergotree_ir::mir::bin_op::RelationOp;
-    use ergotree_ir::mir::block::BlockValue;
     use ergotree_ir::mir::constant::TryExtractFrom;
     use ergotree_ir::mir::constant::TryExtractInto;
-    use ergotree_ir::mir::val_def::ValDef;
-    use ergotree_ir::mir::val_use::ValUse;
     use ergotree_ir::serialization::sigma_byte_reader::from_bytes;
     use ergotree_ir::serialization::sigma_byte_reader::SigmaByteRead;
     use ergotree_ir::serialization::SigmaSerializable;
-    use ergotree_ir::types::stype::SType;
-    use expect_test::expect;
     use sigma_test_util::force_any_val;
 
     thread_local! {
@@ -477,6 +470,28 @@ pub(crate) mod tests {
     ) -> Result<T, EvalError> {
         TEST_CTX.with(|ctx| try_eval_out(expr, ctx))
     }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod test {
+    use ergotree_ir::{
+        chain::context::Context,
+        ergo_tree::ErgoTree,
+        mir::{
+            bin_op::{BinOp, BinOpKind, RelationOp},
+            block::BlockValue,
+            expr::Expr,
+            val_def::ValDef,
+            val_use::ValUse,
+        },
+        sigma_protocol::sigma_boolean::SigmaBoolean,
+        types::stype::SType,
+    };
+    use expect_test::expect;
+    use sigma_test_util::force_any_val;
+
+    use crate::eval::reduce_to_crypto;
 
     #[test]
     fn diag_on_reduced_to_false() {

--- a/ergotree-interpreter/src/eval/and.rs
+++ b/ergotree-interpreter/src/eval/and.rs
@@ -23,7 +23,7 @@ impl Evaluable for And {
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod tests {
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
 
     use super::*;

--- a/ergotree-interpreter/src/eval/apply.rs
+++ b/ergotree-interpreter/src/eval/apply.rs
@@ -68,7 +68,7 @@ mod tests {
     use ergotree_ir::mir::val_use::ValUse;
     use ergotree_ir::types::stype::SType;
 
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
 
     use super::*;
 

--- a/ergotree-interpreter/src/eval/atleast.rs
+++ b/ergotree-interpreter/src/eval/atleast.rs
@@ -63,7 +63,7 @@ impl Evaluable for Atleast {
 mod tests {
     use alloc::sync::Arc;
 
-    use crate::eval::tests::try_eval_out_wo_ctx;
+    use crate::eval::test_util::try_eval_out_wo_ctx;
     use ergotree_ir::mir::constant::Constant;
     use ergotree_ir::mir::constant::Literal;
     use ergotree_ir::mir::value::CollKind;
@@ -71,7 +71,7 @@ mod tests {
     use ergotree_ir::sigma_protocol::sigma_boolean::SigmaConjecture;
     use ergotree_ir::types::stype::SType;
 
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
 
     use super::*;

--- a/ergotree-interpreter/src/eval/bin_op.rs
+++ b/ergotree-interpreter/src/eval/bin_op.rs
@@ -349,8 +349,8 @@ impl Evaluable for BinOp {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
-    use crate::eval::tests::try_eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
+    use crate::eval::test_util::try_eval_out_wo_ctx;
     use alloc::boxed::Box;
     use ergotree_ir::mir::constant::Constant;
     use ergotree_ir::mir::expr::Expr;

--- a/ergotree-interpreter/src/eval/bit_inversion.rs
+++ b/ergotree-interpreter/src/eval/bit_inversion.rs
@@ -32,7 +32,7 @@ impl Evaluable for BitInversion {
 mod tests {
 
     use super::*;
-    use crate::eval::tests::try_eval_out_wo_ctx;
+    use crate::eval::test_util::try_eval_out_wo_ctx;
     use ergotree_ir::bigint256::BigInt256;
     use ergotree_ir::mir::constant::Constant;
     use ergotree_ir::mir::constant::TryExtractFrom;

--- a/ergotree-interpreter/src/eval/bool_to_sigma.rs
+++ b/ergotree-interpreter/src/eval/bool_to_sigma.rs
@@ -25,7 +25,7 @@ impl Evaluable for BoolToSigmaProp {
 #[allow(clippy::panic)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
     use ergotree_ir::mir::expr::Expr;
     use proptest::prelude::*;
 

--- a/ergotree-interpreter/src/eval/byte_array_to_bigint.rs
+++ b/ergotree-interpreter/src/eval/byte_array_to_bigint.rs
@@ -38,7 +38,7 @@ impl Evaluable for ByteArrayToBigInt {
 mod tests {
 
     use super::*;
-    use crate::eval::tests::try_eval_out_wo_ctx;
+    use crate::eval::test_util::try_eval_out_wo_ctx;
     use alloc::boxed::Box;
     use num_bigint::{BigInt, Sign, ToBigInt};
     use num_traits::{Bounded, Num, Pow};

--- a/ergotree-interpreter/src/eval/byte_array_to_long.rs
+++ b/ergotree-interpreter/src/eval/byte_array_to_long.rs
@@ -40,7 +40,7 @@ mod tests {
     use alloc::boxed::Box;
 
     use super::*;
-    use crate::eval::tests::try_eval_out_wo_ctx;
+    use crate::eval::test_util::try_eval_out_wo_ctx;
 
     fn eval_node(val: Vec<i8>) -> Result<i64, EvalError> {
         let expr = ByteArrayToLong {

--- a/ergotree-interpreter/src/eval/calc_blake2b256.rs
+++ b/ergotree-interpreter/src/eval/calc_blake2b256.rs
@@ -37,7 +37,7 @@ impl Evaluable for CalcBlake2b256 {
 #[allow(clippy::panic)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use proptest::prelude::*;

--- a/ergotree-interpreter/src/eval/calc_sha256.rs
+++ b/ergotree-interpreter/src/eval/calc_sha256.rs
@@ -35,7 +35,7 @@ impl Evaluable for CalcSha256 {
 #[allow(clippy::panic)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use proptest::prelude::*;

--- a/ergotree-interpreter/src/eval/coll_append.rs
+++ b/ergotree-interpreter/src/eval/coll_append.rs
@@ -67,7 +67,7 @@ impl Evaluable for Append {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
     use ergotree_ir::mir::collection::Collection;
     use ergotree_ir::mir::constant::Constant;
     use ergotree_ir::mir::expr::Expr;

--- a/ergotree-interpreter/src/eval/coll_by_index.rs
+++ b/ergotree-interpreter/src/eval/coll_by_index.rs
@@ -62,9 +62,9 @@ mod tests {
     use sigma_test_util::force_any_val;
 
     use super::*;
-    use crate::eval::tests::eval_out;
-    use crate::eval::tests::eval_out_wo_ctx;
-    use crate::eval::tests::try_eval_out_with_version;
+    use crate::eval::test_util::eval_out;
+    use crate::eval::test_util::eval_out_wo_ctx;
+    use crate::eval::test_util::try_eval_out_with_version;
     use ergotree_ir::chain::context::Context;
 
     #[test]

--- a/ergotree-interpreter/src/eval/coll_exists.rs
+++ b/ergotree-interpreter/src/eval/coll_exists.rs
@@ -71,7 +71,7 @@ impl Evaluable for Exists {
 #[cfg(test)]
 mod tests {
 
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
 
     use super::*;
 

--- a/ergotree-interpreter/src/eval/coll_filter.rs
+++ b/ergotree-interpreter/src/eval/coll_filter.rs
@@ -89,7 +89,7 @@ impl Evaluable for Filter {
 #[cfg(feature = "arbitrary")]
 mod tests {
 
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
 
     use super::*;

--- a/ergotree-interpreter/src/eval/coll_fold.rs
+++ b/ergotree-interpreter/src/eval/coll_fold.rs
@@ -71,7 +71,7 @@ impl Evaluable for Fold {
 mod tests {
     use core::convert::TryInto;
 
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::bin_op::ArithOp;
     use ergotree_ir::mir::bin_op::BinOp;

--- a/ergotree-interpreter/src/eval/coll_forall.rs
+++ b/ergotree-interpreter/src/eval/coll_forall.rs
@@ -71,7 +71,7 @@ impl Evaluable for ForAll {
 #[cfg(test)]
 mod tests {
 
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
 
     use super::*;
 

--- a/ergotree-interpreter/src/eval/coll_map.rs
+++ b/ergotree-interpreter/src/eval/coll_map.rs
@@ -87,8 +87,8 @@ impl Evaluable for Map {
 #[cfg(feature = "arbitrary")]
 mod tests {
 
-    use crate::eval::tests::eval_out;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out;
+    use crate::eval::test_util::eval_out_wo_ctx;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::chain::context::TxIoVec;
     use ergotree_ir::ergo_tree::ErgoTree;

--- a/ergotree-interpreter/src/eval/coll_size.rs
+++ b/ergotree-interpreter/src/eval/coll_size.rs
@@ -27,7 +27,7 @@ impl Evaluable for SizeOf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;

--- a/ergotree-interpreter/src/eval/coll_slice.rs
+++ b/ergotree-interpreter/src/eval/coll_slice.rs
@@ -46,7 +46,7 @@ mod tests {
     use ergotree_ir::types::stype::SType;
 
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
 
     #[test]
     fn slice() {

--- a/ergotree-interpreter/src/eval/collection.rs
+++ b/ergotree-interpreter/src/eval/collection.rs
@@ -49,7 +49,7 @@ impl Evaluable for Collection {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
     use ergotree_ir::mir::expr::Expr;
     use proptest::prelude::*;
 

--- a/ergotree-interpreter/src/eval/create_avl_tree.rs
+++ b/ergotree-interpreter/src/eval/create_avl_tree.rs
@@ -48,7 +48,7 @@ fn map_eval_err<T: core::fmt::Debug>(e: T) -> EvalError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
 
     use ergo_avltree_rust::authenticated_tree_ops::AuthenticatedTreeOps;
     use ergo_avltree_rust::batch_avl_prover::BatchAVLProver;

--- a/ergotree-interpreter/src/eval/decode_point.rs
+++ b/ergotree-interpreter/src/eval/decode_point.rs
@@ -32,7 +32,7 @@ impl Evaluable for DecodePoint {
 #[allow(clippy::unwrap_used)]
 #[allow(clippy::panic)]
 mod tests {
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
 
     use super::*;
 

--- a/ergotree-interpreter/src/eval/deserialize_context.rs
+++ b/ergotree-interpreter/src/eval/deserialize_context.rs
@@ -14,7 +14,7 @@ mod tests {
     use sigma_test_util::force_any_val;
 
     use crate::eval::reduce_to_crypto;
-    use crate::eval::tests::try_eval_with_deserialize;
+    use crate::eval::test_util::try_eval_with_deserialize;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::chain::context_extension::ContextExtension;
 

--- a/ergotree-interpreter/src/eval/deserialize_register.rs
+++ b/ergotree-interpreter/src/eval/deserialize_register.rs
@@ -17,8 +17,8 @@ mod tests {
     use ergotree_ir::types::stype::SType;
     use sigma_test_util::force_any_val;
 
-    use crate::eval::tests::try_eval_out;
-    use crate::eval::tests::try_eval_with_deserialize;
+    use crate::eval::test_util::try_eval_out;
+    use crate::eval::test_util::try_eval_with_deserialize;
     use crate::eval::EvalError;
     use ergotree_ir::chain::context::Context;
 

--- a/ergotree-interpreter/src/eval/downcast.rs
+++ b/ergotree-interpreter/src/eval/downcast.rs
@@ -136,7 +136,7 @@ mod tests {
     use ergotree_ir::mir::{constant::Constant, expr::Expr};
     use sigma_test_util::force_any_val;
 
-    use crate::eval::tests::{eval_out_wo_ctx, try_eval_out_with_version, try_eval_out_wo_ctx};
+    use crate::eval::test_util::{eval_out_wo_ctx, try_eval_out_with_version, try_eval_out_wo_ctx};
 
     use super::*;
     use proptest::prelude::*;

--- a/ergotree-interpreter/src/eval/error.rs
+++ b/ergotree-interpreter/src/eval/error.rs
@@ -245,7 +245,7 @@ mod tests {
 
     use crate::eval::error::SpannedEvalError;
     use crate::eval::error::SpannedWithSourceEvalError;
-    use crate::eval::tests::try_eval_out;
+    use crate::eval::test_util::try_eval_out;
     use ergotree_ir::chain::context::Context;
 
     fn check(expr: Expr, expected_tree: expect_test::Expect) {

--- a/ergotree-interpreter/src/eval/exponentiate.rs
+++ b/ergotree-interpreter/src/eval/exponentiate.rs
@@ -37,7 +37,7 @@ pub(crate) fn exponentiate(
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use crate::sigma_protocol::private_input::DlogProverInput;
     use ergotree_ir::chain::context::Context;
 

--- a/ergotree-interpreter/src/eval/extract_amount.rs
+++ b/ergotree-interpreter/src/eval/extract_amount.rs
@@ -28,7 +28,7 @@ impl Evaluable for ExtractAmount {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;

--- a/ergotree-interpreter/src/eval/extract_bytes.rs
+++ b/ergotree-interpreter/src/eval/extract_bytes.rs
@@ -29,7 +29,7 @@ impl Evaluable for ExtractBytes {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;

--- a/ergotree-interpreter/src/eval/extract_bytes_with_no_ref.rs
+++ b/ergotree-interpreter/src/eval/extract_bytes_with_no_ref.rs
@@ -28,7 +28,7 @@ impl Evaluable for ExtractBytesWithNoRef {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;

--- a/ergotree-interpreter/src/eval/extract_creation_info.rs
+++ b/ergotree-interpreter/src/eval/extract_creation_info.rs
@@ -27,7 +27,7 @@ impl Evaluable for ExtractCreationInfo {
 #[cfg(test)]
 #[cfg(feature = "arbitrary")]
 mod tests {
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use crate::eval::Context;
 
     use ergotree_ir::mir::expr::Expr;

--- a/ergotree-interpreter/src/eval/extract_id.rs
+++ b/ergotree-interpreter/src/eval/extract_id.rs
@@ -32,7 +32,7 @@ impl Evaluable for ExtractId {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;

--- a/ergotree-interpreter/src/eval/extract_reg_as.rs
+++ b/ergotree-interpreter/src/eval/extract_reg_as.rs
@@ -51,7 +51,7 @@ impl Evaluable for ExtractRegisterAs {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
-    use crate::eval::tests::{eval_out, try_eval_out};
+    use crate::eval::test_util::{eval_out, try_eval_out};
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;

--- a/ergotree-interpreter/src/eval/extract_script_bytes.rs
+++ b/ergotree-interpreter/src/eval/extract_script_bytes.rs
@@ -28,7 +28,7 @@ impl Evaluable for ExtractScriptBytes {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;

--- a/ergotree-interpreter/src/eval/get_var.rs
+++ b/ergotree-interpreter/src/eval/get_var.rs
@@ -25,9 +25,9 @@ impl Evaluable for GetVar {
 #[cfg(feature = "arbitrary")]
 pub mod tests {
     use super::*;
-    use crate::eval::tests::{eval_out, try_eval_out};
-
+    use crate::eval::test_util::{eval_out, try_eval_out};
     use ergotree_ir::chain::context::arbitrary::DummyContextExtensionProvider;
+    use ergotree_ir::chain::context::Context;
     use ergotree_ir::chain::context_extension::ContextExtension;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::types::stype::SType;

--- a/ergotree-interpreter/src/eval/global_vars.rs
+++ b/ergotree-interpreter/src/eval/global_vars.rs
@@ -37,7 +37,7 @@ impl Evaluable for GlobalVars {
 #[cfg(feature = "arbitrary")]
 mod tests {
 
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergo_chain_types::EcPoint;
     use ergoscript_compiler::compiler::compile_expr;
     use ergoscript_compiler::script_env::ScriptEnv;

--- a/ergotree-interpreter/src/eval/if_op.rs
+++ b/ergotree-interpreter/src/eval/if_op.rs
@@ -25,7 +25,7 @@ impl Evaluable for If {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
     use alloc::boxed::Box;
     use ergotree_ir::mir::bin_op::ArithOp;
     use ergotree_ir::mir::bin_op::BinOp;

--- a/ergotree-interpreter/src/eval/logical_not.rs
+++ b/ergotree-interpreter/src/eval/logical_not.rs
@@ -23,7 +23,7 @@ impl Evaluable for LogicalNot {
 mod tests {
 
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
     use ergotree_ir::mir::expr::Expr;
 
     fn check(input: bool) -> bool {

--- a/ergotree-interpreter/src/eval/long_to_byte_array.rs
+++ b/ergotree-interpreter/src/eval/long_to_byte_array.rs
@@ -29,7 +29,7 @@ mod tests {
     use alloc::{boxed::Box, vec::Vec};
 
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
 
     fn eval_node(val: i64) -> Vec<i8> {
         let expr = LongToByteArray {

--- a/ergotree-interpreter/src/eval/multiply_group.rs
+++ b/ergotree-interpreter/src/eval/multiply_group.rs
@@ -33,7 +33,7 @@ impl Evaluable for MultiplyGroup {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
 
     use ergo_chain_types::EcPoint;

--- a/ergotree-interpreter/src/eval/negation.rs
+++ b/ergotree-interpreter/src/eval/negation.rs
@@ -44,7 +44,7 @@ impl Evaluable for Negation {
 mod tests {
 
     use super::*;
-    use crate::eval::tests::try_eval_out_wo_ctx;
+    use crate::eval::test_util::try_eval_out_wo_ctx;
     use ergotree_ir::bigint256::BigInt256;
     use ergotree_ir::mir::constant::Constant;
     use ergotree_ir::mir::constant::TryExtractFrom;

--- a/ergotree-interpreter/src/eval/option_get.rs
+++ b/ergotree-interpreter/src/eval/option_get.rs
@@ -31,7 +31,7 @@ impl Evaluable for OptionGet {
 #[cfg(test)]
 mod tests {
     use super::OptionGet;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::extract_reg_as::ExtractRegisterAs;

--- a/ergotree-interpreter/src/eval/option_get_or_else.rs
+++ b/ergotree-interpreter/src/eval/option_get_or_else.rs
@@ -32,7 +32,7 @@ impl Evaluable for OptionGetOrElse {
 #[cfg(test)]
 mod tests {
     use super::OptionGetOrElse;
-    use crate::eval::tests::{eval_out, try_eval_out_with_version};
+    use crate::eval::test_util::{eval_out, try_eval_out_with_version};
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::ergo_tree::ErgoTreeVersion;
     use ergotree_ir::mir::bin_op::{ArithOp, BinOp, BinOpKind};

--- a/ergotree-interpreter/src/eval/option_is_defined.rs
+++ b/ergotree-interpreter/src/eval/option_is_defined.rs
@@ -28,7 +28,7 @@ impl Evaluable for OptionIsDefined {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::OptionIsDefined;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::extract_reg_as::ExtractRegisterAs;

--- a/ergotree-interpreter/src/eval/or.rs
+++ b/ergotree-interpreter/src/eval/or.rs
@@ -24,7 +24,7 @@ impl Evaluable for Or {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use proptest::collection;

--- a/ergotree-interpreter/src/eval/property_call.rs
+++ b/ergotree-interpreter/src/eval/property_call.rs
@@ -23,7 +23,7 @@ impl Evaluable for PropertyCall {
 #[cfg(feature = "arbitrary")]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::chain::ergo_box::ErgoBox;
     use ergotree_ir::mir::expr::Expr;

--- a/ergotree-interpreter/src/eval/savltree.rs
+++ b/ergotree-interpreter/src/eval/savltree.rs
@@ -456,7 +456,7 @@ mod tests {
     };
     use proptest::prelude::*;
 
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
 
     use super::*;
     use sigma_util::{AsVecI8, AsVecU8};

--- a/ergotree-interpreter/src/eval/sbox.rs
+++ b/ergotree-interpreter/src/eval/sbox.rs
@@ -91,7 +91,7 @@ mod tests {
     use ergotree_ir::types::stype_param::STypeVar;
     use sigma_test_util::force_any_val;
 
-    use crate::eval::tests::{eval_out, try_eval_out_with_version};
+    use crate::eval::test_util::{eval_out, try_eval_out_with_version};
     use crate::eval::EvalError;
     use ergotree_ir::chain::context::Context;
 

--- a/ergotree-interpreter/src/eval/scoll.rs
+++ b/ergotree-interpreter/src/eval/scoll.rs
@@ -427,7 +427,7 @@ mod tests {
     use ergotree_ir::types::stype::SType;
     use ergotree_ir::types::stype_param::STypeVar;
 
-    use crate::eval::tests::{eval_out_wo_ctx, try_eval_out_wo_ctx};
+    use crate::eval::test_util::{eval_out_wo_ctx, try_eval_out_wo_ctx};
 
     #[test]
     fn eval_index_of() {

--- a/ergotree-interpreter/src/eval/scontext.rs
+++ b/ergotree-interpreter/src/eval/scontext.rs
@@ -124,7 +124,7 @@ pub(crate) static GET_VAR_FROM_INPUT_EVAL_FN: EvalFn = |mc, _env, ctx, _obj, arg
 #[cfg(feature = "arbitrary")]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergo_chain_types::{Header, PreHeader};
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::chain::ergo_box::ErgoBox;

--- a/ergotree-interpreter/src/eval/sglobal.rs
+++ b/ergotree-interpreter/src/eval/sglobal.rs
@@ -268,7 +268,7 @@ mod tests {
     use num_traits::Num;
     use proptest::proptest;
 
-    use crate::eval::tests::{eval_out, eval_out_wo_ctx, try_eval_out_with_version};
+    use crate::eval::test_util::{eval_out, eval_out_wo_ctx, try_eval_out_with_version};
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::types::sglobal::{
         self, DECODE_NBITS_METHOD, DESERIALIZE_METHOD, ENCODE_NBITS_METHOD, SERIALIZE_METHOD,

--- a/ergotree-interpreter/src/eval/sgroup_elem.rs
+++ b/ergotree-interpreter/src/eval/sgroup_elem.rs
@@ -78,8 +78,8 @@ mod tests {
     use proptest::prelude::*;
     use proptest::proptest;
 
-    use crate::eval::tests::eval_out_wo_ctx;
-    use crate::eval::tests::try_eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
+    use crate::eval::test_util::try_eval_out_wo_ctx;
     use crate::sigma_protocol::private_input::DlogProverInput;
     use ergo_chain_types::EcPoint;
     use ergotree_ir::serialization::SigmaSerializable;

--- a/ergotree-interpreter/src/eval/sheader.rs
+++ b/ergotree-interpreter/src/eval/sheader.rs
@@ -130,7 +130,7 @@ mod tests {
     use sigma_test_util::force_any_val;
     use sigma_util::AsVecU8;
 
-    use crate::eval::tests::{eval_out, try_eval_out_wo_ctx};
+    use crate::eval::test_util::{eval_out, try_eval_out_wo_ctx};
 
     // Index in Context.headers array
     const HEADER_INDEX: usize = 0;

--- a/ergotree-interpreter/src/eval/sigma_and.rs
+++ b/ergotree-interpreter/src/eval/sigma_and.rs
@@ -35,7 +35,7 @@ mod tests {
     use ergotree_ir::sigma_protocol::sigma_boolean::SigmaBoolean;
     use ergotree_ir::sigma_protocol::sigma_boolean::SigmaConjecture;
 
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
 
     use super::*;

--- a/ergotree-interpreter/src/eval/sigma_or.rs
+++ b/ergotree-interpreter/src/eval/sigma_or.rs
@@ -35,7 +35,7 @@ mod tests {
     use ergotree_ir::sigma_protocol::sigma_boolean::SigmaBoolean;
     use ergotree_ir::sigma_protocol::sigma_boolean::SigmaConjecture;
 
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
 
     use super::*;

--- a/ergotree-interpreter/src/eval/sigma_prop_bytes.rs
+++ b/ergotree-interpreter/src/eval/sigma_prop_bytes.rs
@@ -29,7 +29,7 @@ impl Evaluable for SigmaPropBytes {
 #[allow(clippy::panic)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
     use ergotree_ir::mir::constant::Constant;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::sigma_protocol::sigma_boolean::SigmaProp;

--- a/ergotree-interpreter/src/eval/snumeric.rs
+++ b/ergotree-interpreter/src/eval/snumeric.rs
@@ -205,7 +205,7 @@ mod test {
     use num_traits::CheckedRem;
     use proptest::prelude::*;
 
-    use crate::eval::{tests::try_eval_out_wo_ctx, EvalError};
+    use crate::eval::{test_util::try_eval_out_wo_ctx, EvalError};
 
     fn eval_modular_op(
         desc: &SMethodDesc,

--- a/ergotree-interpreter/src/eval/soption.rs
+++ b/ergotree-interpreter/src/eval/soption.rs
@@ -132,7 +132,7 @@ mod tests {
     use ergotree_ir::types::stype::SType;
     use ergotree_ir::types::stype_param::STypeVar;
 
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
     use ergotree_ir::mir::value::Value;
 
     #[test]

--- a/ergotree-interpreter/src/eval/spreheader.rs
+++ b/ergotree-interpreter/src/eval/spreheader.rs
@@ -54,7 +54,7 @@ mod tests {
     use sigma_test_util::force_any_val;
     use sigma_util::AsVecU8;
 
-    use crate::eval::tests::{eval_out, try_eval_out_wo_ctx};
+    use crate::eval::test_util::{eval_out, try_eval_out_wo_ctx};
     use ergotree_ir::chain::context::Context;
 
     fn create_get_preheader_property_expr(method: SMethod) -> Expr {

--- a/ergotree-interpreter/src/eval/subst_const.rs
+++ b/ergotree-interpreter/src/eval/subst_const.rs
@@ -106,7 +106,7 @@ mod tests {
     };
     use proptest::prelude::*;
 
-    use crate::eval::tests::try_eval_out_wo_ctx;
+    use crate::eval::test_util::try_eval_out_wo_ctx;
 
     use super::*;
     proptest! {

--- a/ergotree-interpreter/src/eval/tree_lookup.rs
+++ b/ergotree-interpreter/src/eval/tree_lookup.rs
@@ -71,7 +71,7 @@ fn map_eval_err<T: core::fmt::Debug>(e: T) -> EvalError {
 mod tests {
 
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
 
     use ergo_avltree_rust::authenticated_tree_ops::AuthenticatedTreeOps;
     use ergo_avltree_rust::batch_avl_prover::BatchAVLProver;

--- a/ergotree-interpreter/src/eval/tuple.rs
+++ b/ergotree-interpreter/src/eval/tuple.rs
@@ -21,7 +21,7 @@ impl Evaluable for Tuple {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out_wo_ctx;
+    use crate::eval::test_util::eval_out_wo_ctx;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;
 

--- a/ergotree-interpreter/src/eval/upcast.rs
+++ b/ergotree-interpreter/src/eval/upcast.rs
@@ -97,7 +97,7 @@ mod tests {
     use ergotree_ir::mir::constant::Constant;
     use sigma_test_util::force_any_val;
 
-    use crate::eval::tests::{eval_out_wo_ctx, try_eval_out_with_version};
+    use crate::eval::test_util::{eval_out_wo_ctx, try_eval_out_with_version};
 
     use super::*;
     use proptest::prelude::*;

--- a/ergotree-interpreter/src/eval/xor.rs
+++ b/ergotree-interpreter/src/eval/xor.rs
@@ -44,7 +44,7 @@ impl Evaluable for Xor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::tests::{eval_out, eval_out_wo_ctx};
+    use crate::eval::test_util::{eval_out, eval_out_wo_ctx};
     use alloc::boxed::Box;
     use alloc::vec::Vec;
     use ergotree_ir::chain::context::Context;

--- a/ergotree-interpreter/src/eval/xor_of.rs
+++ b/ergotree-interpreter/src/eval/xor_of.rs
@@ -24,7 +24,7 @@ impl Evaluable for XorOf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::tests::eval_out;
+    use crate::eval::test_util::eval_out;
     use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use proptest::collection;


### PR DESCRIPTION
This PR adds criterion benchmarks for some expensive interpreter nodes that could be targets of optimization efforts in the future. It also includes benchmarks for signing transactions with P2PK inputs, and TransactionContext creation benchmarks I previously wrote (these were used to reduce TransactionContext::new complexity from O(n^2) to O(n) in previous optimization attempts, so they are worthwhile to add here)

Closes #739
