### PR TITLE
serialize sigmaboolean as base-16 string in ergo-lib-wasm bindings

### DIFF
--- a/ergo-lib/src/chain/transaction/reduced.rs
+++ b/ergo-lib/src/chain/transaction/reduced.rs
@@ -11,6 +11,8 @@ use ergotree_ir::serialization::SigmaSerializable;
 use ergotree_ir::serialization::SigmaSerializeResult;
 use ergotree_ir::sigma_protocol::sigma_boolean::SigmaBoolean;
 
+use super::unsigned::UnsignedTransaction;
+use super::TxIoVec;
 use crate::chain::ergo_state_context::ErgoStateContext;
 use crate::chain::transaction::Transaction;
 use crate::chain::transaction::UnsignedInput;
@@ -20,9 +22,6 @@ use crate::wallet::signing::TransactionContext;
 use crate::wallet::signing::TxSigningError;
 use crate::wallet::tx_context::TransactionContextError;
 
-use super::unsigned::UnsignedTransaction;
-use super::TxIoVec;
-
 /// Input box script reduced to SigmaBoolean
 /// see EIP-19 for more details -
 /// <https://github.com/ergoplatform/eips/blob/f280890a4163f2f2e988a0091c078e36912fc531/eip-0019.md>
@@ -30,7 +29,13 @@ use super::TxIoVec;
 #[cfg_attr(feature = "json", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReducedInput {
     /// value of SigmaProp type which represents a statement verifiable via sigma protocol.
-    #[cfg_attr(feature = "json", serde(rename = "sigmaProp"))]
+    #[cfg_attr(
+        feature = "json",
+        serde(
+            rename = "sigmaProp",
+            with = "ergotree_ir::chain::json::sigma_protocol"
+        )
+    )]
     pub sigma_prop: SigmaBoolean,
     /// estimated cost of expression evaluation
     pub cost: u64,

--- a/ergotree-ir/src/chain/json.rs
+++ b/ergotree-ir/src/chain/json.rs
@@ -14,7 +14,7 @@ use serde::Serializer;
 pub(crate) mod box_value;
 pub(crate) mod ergo_box;
 pub mod ergo_tree;
-pub(crate) mod sigma_protocol;
+pub mod sigma_protocol;
 pub(crate) mod token;
 
 /// Serialize bytes ([u8]) as base16 encoded string

--- a/ergotree-ir/src/chain/json/sigma_protocol.rs
+++ b/ergotree-ir/src/chain/json/sigma_protocol.rs
@@ -1,12 +1,10 @@
+//! SigmaBoolean JSON encoding
+
 use core::convert::TryFrom;
 use core::convert::TryInto;
 
-use alloc::vec::Vec;
-use bounded_vec::BoundedVecOutOfBounds;
-use ergo_chain_types::EcPoint;
-use serde::Deserialize;
-use serde::Serialize;
-
+use super::serialize_bytes;
+use crate::serialization::SigmaSerializable;
 use crate::sigma_protocol::sigma_boolean::cand::Cand;
 use crate::sigma_protocol::sigma_boolean::cor::Cor;
 use crate::sigma_protocol::sigma_boolean::cthreshold::Cthreshold;
@@ -15,11 +13,16 @@ use crate::sigma_protocol::sigma_boolean::ProveDlog;
 use crate::sigma_protocol::sigma_boolean::SigmaBoolean;
 use crate::sigma_protocol::sigma_boolean::SigmaConjecture;
 use crate::sigma_protocol::sigma_boolean::SigmaProofOfKnowledgeTree;
+use alloc::vec::Vec;
+use bounded_vec::BoundedVecOutOfBounds;
+use ergo_chain_types::EcPoint;
+use serde::Serialize;
+use serde::{Deserialize, Deserializer, Serializer};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(tag = "op")]
 #[allow(clippy::large_enum_variant)]
-pub enum SigmaBooleanJson {
+pub(crate) enum SigmaBooleanJson {
     #[serde(rename = "205")] // OpCode::PROVE_DLOG
     ProveDlog { h: EcPoint },
     #[serde(rename = "206")] // OpCode::PROVE_DIFFIE_HELLMAN_TUPLE
@@ -131,4 +134,30 @@ impl TryFrom<SigmaBooleanJson> for SigmaBoolean {
             .into(),
         })
     }
+}
+
+/// Serializer (used in Wasm bindings)
+pub fn serialize<S>(sb: &SigmaBoolean, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    use serde::ser::Error;
+
+    let bytes = sb
+        .sigma_serialize_bytes()
+        .map_err(|err| Error::custom(err.to_string()))?;
+    serialize_bytes(&bytes[..], serializer)
+}
+
+/// Deserializer (used in Wasm bindings)
+pub fn deserialize<'de, D>(deserializer: D) -> Result<SigmaBoolean, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    String::deserialize(deserializer)
+        .and_then(|str| base16::decode(&str).map_err(|err| Error::custom(err.to_string())))
+        .and_then(|bytes| {
+            SigmaBoolean::sigma_parse_bytes(&bytes).map_err(|err| Error::custom(err.to_string()))
+        })
 }


### PR DESCRIPTION
Uses base-16 serialization and deserialization for sigmaboolean for json representation in ergo-lib-wasm bindings. Same like ErgoTree