### PR TITLE
Update iOS README for Xcode 15+

### DIFF
--- a/bindings/ergo-lib-ios/README.md
+++ b/bindings/ergo-lib-ios/README.md
@@ -41,7 +41,9 @@ swift test -Xlinker -L../../target/release/ --skip RestNodeApiTests --skip RestN
 The `RestNodeApiTests` assume you have an ergo node running on localhost.
  
 
-### Building Xcode 13 project for `iPhoneSimulator` 
+### Building Xcode 15+ project for `iPhoneSimulator`
+
+These steps are updated for Xcode 15 or newer.
 
 Make sure `ergo-lib-c` is built as described above.
 
@@ -61,7 +63,7 @@ Then double click `ErgoLib.xcodeproj` which opens Xcode. You need to manually po
 
 Set `Other Linker Flags` to be `-L/absolute/path/to/sigma-rust/target/release` for x86_64 and ` -L/absolute/path/to/sigma-rust/target/aarch64-apple-ios-sim/release` for simulator on Apple silicon macs. The project can now be built.
 
-### Building Xcode 13 project for `iPhone(iOS)`
+### Building Xcode 15+ project for `iPhone(iOS)`
 
 First we need to build an ARM64 target for `ergo-lib-c`: 
 


### PR DESCRIPTION
## Summary
- update iOS build headings to Xcode 15+ to reflect current toolchain
- clarify that the instructions are intended for Xcode 15 or newer

## Testing
- Not run (documentation-only)

## Issue
- https://github.com/ergoplatform/sigma-rust/issues/759