### PR TITLE
ergo-lib: port ErgoTreePredef, EmissionRules, and genesis construction

### DIFF
--- a/ergo-lib/src/chain.rs
+++ b/ergo-lib/src/chain.rs
@@ -5,7 +5,10 @@ pub mod json;
 
 pub mod block;
 pub mod contract;
+pub mod emission;
 pub mod ergo_box;
 pub mod ergo_state_context;
+pub mod ergo_tree_predef;
+pub mod genesis;
 pub mod parameters;
 pub mod transaction;

--- a/ergo-lib/src/chain/emission.rs
+++ b/ergo-lib/src/chain/emission.rs
@@ -1,0 +1,269 @@
+//! Emission rules for the Ergo blockchain.
+//!
+//! Ports [`EmissionRules`] and [`MonetarySettings`] from the JVM's
+//! `sigmastate-interpreter` to Rust. These compute the total coin supply,
+//! per-block rewards, and foundation allocations from chain parameters.
+
+use core::cmp;
+
+/// Number of nanoERG in one ERG.
+pub const COINS_IN_ONE_ERGO: i64 = 1_000_000_000;
+
+/// Monetary parameters controlling the Ergo emission schedule.
+///
+/// Default values match the Ergo mainnet / testnet reference configuration
+/// from the JVM `MonetarySettings` case class.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MonetarySettings {
+    /// Number of blocks during which the total emission rate is fixed.
+    pub fixed_rate_period: i32,
+    /// Number of blocks in one epoch after the fixed-rate period.
+    pub epoch_length: i32,
+    /// Total emission per block during the fixed-rate period (nanoERG).
+    pub fixed_rate: i64,
+    /// Reduction in total emission per epoch (nanoERG).
+    pub one_epoch_reduction: i64,
+    /// Number of blocks a miner reward must mature before spending.
+    pub miner_reward_delay: i32,
+    /// Foundation's share of each block reward during the first epochs (nanoERG).
+    pub founders_initial_reward: i64,
+}
+
+impl Default for MonetarySettings {
+    fn default() -> Self {
+        Self {
+            fixed_rate_period: 30 * 2 * 24 * 365,
+            epoch_length: 90 * 24 * 30,
+            fixed_rate: 75 * COINS_IN_ONE_ERGO,
+            one_epoch_reduction: 3 * COINS_IN_ONE_ERGO,
+            miner_reward_delay: 720,
+            founders_initial_reward: 7_500_000_000,
+        }
+    }
+}
+
+/// Computed emission schedule derived from [`MonetarySettings`].
+///
+/// Eagerly computes total coin supply and allocation by iterating all
+/// block heights at construction time.
+#[derive(Debug, Clone)]
+pub struct EmissionRules {
+    /// The monetary parameters this schedule was computed from.
+    pub settings: MonetarySettings,
+    /// Total coins that will ever be emitted (nanoERG).
+    coins_total: i64,
+    /// Last block height with positive emission.
+    blocks_total: i32,
+    /// Total coins allocated to the foundation (nanoERG).
+    founders_coins_total: i64,
+    /// Total coins allocated to miners (nanoERG).
+    miners_coins_total: i64,
+}
+
+impl EmissionRules {
+    /// Compute emission rules from the given monetary settings.
+    ///
+    /// Iterates through all block heights to compute total coin supply.
+    pub fn new(settings: MonetarySettings) -> Self {
+        let (coins_total, blocks_total) = {
+            let mut height = 1i32;
+            let mut acc = 0i64;
+            loop {
+                let current_rate = emission_at_height_impl(&settings, i64::from(height));
+                if current_rate > 0 {
+                    acc += current_rate;
+                    height += 1;
+                } else {
+                    break (acc, height - 1);
+                }
+            }
+        };
+        let founders_coins_total = remaining_foundation_reward_impl(&settings, 0);
+        let miners_coins_total = coins_total - founders_coins_total;
+        EmissionRules {
+            settings,
+            coins_total,
+            blocks_total,
+            founders_coins_total,
+            miners_coins_total,
+        }
+    }
+
+    /// Total coins that will ever be emitted (nanoERG).
+    pub fn coins_total(&self) -> i64 {
+        self.coins_total
+    }
+
+    /// Last block height with positive emission.
+    pub fn blocks_total(&self) -> i32 {
+        self.blocks_total
+    }
+
+    /// Total coins allocated to the foundation (nanoERG).
+    pub fn founders_coins_total(&self) -> i64 {
+        self.founders_coins_total
+    }
+
+    /// Total coins allocated to miners (nanoERG).
+    pub fn miners_coins_total(&self) -> i64 {
+        self.miners_coins_total
+    }
+
+    /// Total emission (miners + foundation) at the given height (nanoERG).
+    ///
+    /// Returns the full block reward before splitting between miners and
+    /// foundation.
+    pub fn emission_at_height(&self, h: i64) -> i64 {
+        emission_at_height_impl(&self.settings, h)
+    }
+
+    /// Remaining foundation reward available at the given height (nanoERG).
+    ///
+    /// This is the value the foundation box should hold at height `h`.
+    pub fn remaining_foundation_reward_at_height(&self, h: i64) -> i64 {
+        remaining_foundation_reward_impl(&self.settings, h)
+    }
+
+    /// Miner's share of the block reward at the given height (nanoERG).
+    pub fn miners_reward_at_height(&self, h: i64) -> i64 {
+        miners_reward_at_height_impl(&self.settings, h)
+    }
+}
+
+/// Total emission at height `h` (pure function on settings).
+fn emission_at_height_impl(s: &MonetarySettings, h: i64) -> i64 {
+    if h < i64::from(s.fixed_rate_period) {
+        s.fixed_rate
+    } else {
+        let epoch = 1 + (h - i64::from(s.fixed_rate_period)) / i64::from(s.epoch_length);
+        cmp::max(s.fixed_rate - s.one_epoch_reduction * epoch, 0)
+    }
+}
+
+/// Remaining foundation reward at height `h` (pure function on settings).
+fn remaining_foundation_reward_impl(s: &MonetarySettings, h: i64) -> i64 {
+    let fir = s.founders_initial_reward;
+    let oer = s.one_epoch_reduction;
+    let el = i64::from(s.epoch_length);
+    let frp = i64::from(s.fixed_rate_period);
+    let full15 = (fir - 2 * oer) * el;
+    let full45 = (fir - oer) * el;
+
+    if h < frp {
+        full15 + full45 + (frp - h - 1) * fir
+    } else if h < frp + el {
+        full15 + (fir - oer) * (frp + el - h - 1)
+    } else if h < frp + 2 * el {
+        (fir - 2 * oer) * (frp + 2 * el - h - 1)
+    } else {
+        0
+    }
+}
+
+/// Miner's reward at height `h` (pure function on settings).
+fn miners_reward_at_height_impl(s: &MonetarySettings, h: i64) -> i64 {
+    if h < i64::from(s.fixed_rate_period) + 2 * i64::from(s.epoch_length) {
+        s.fixed_rate - s.founders_initial_reward
+    } else {
+        let epoch = 1 + (h - i64::from(s.fixed_rate_period)) / i64::from(s.epoch_length);
+        cmp::max(s.fixed_rate - s.one_epoch_reduction * epoch, 0)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn default_rules() -> EmissionRules {
+        EmissionRules::new(MonetarySettings::default())
+    }
+
+    #[test]
+    fn test_default_settings_constants() {
+        let s = MonetarySettings::default();
+        assert_eq!(s.fixed_rate_period, 525_600);
+        assert_eq!(s.epoch_length, 64_800);
+        assert_eq!(s.fixed_rate, 75_000_000_000);
+        assert_eq!(s.one_epoch_reduction, 3_000_000_000);
+        assert_eq!(s.miner_reward_delay, 720);
+        assert_eq!(s.founders_initial_reward, 7_500_000_000);
+    }
+
+    #[test]
+    fn test_coins_total_identity() {
+        let rules = default_rules();
+        assert_eq!(
+            rules.coins_total(),
+            rules.miners_coins_total() + rules.founders_coins_total()
+        );
+    }
+
+    #[test]
+    fn test_miners_coins_total() {
+        let rules = default_rules();
+        assert_eq!(rules.miners_coins_total(), 93_409_132_500_000_000);
+    }
+
+    #[test]
+    fn test_emission_at_height_fixed_rate() {
+        let rules = default_rules();
+        assert_eq!(rules.emission_at_height(0), 75_000_000_000);
+        assert_eq!(rules.emission_at_height(1), 75_000_000_000);
+        assert_eq!(rules.emission_at_height(525_599), 75_000_000_000);
+    }
+
+    #[test]
+    fn test_emission_at_height_epoch_transitions() {
+        let rules = default_rules();
+        // First epoch after fixed rate: rate drops by oneEpochReduction
+        assert_eq!(rules.emission_at_height(525_600), 72_000_000_000);
+        assert_eq!(rules.emission_at_height(590_399), 72_000_000_000);
+        // Second epoch
+        assert_eq!(rules.emission_at_height(590_400), 69_000_000_000);
+    }
+
+    #[test]
+    fn test_emission_at_height_last_epoch() {
+        let rules = default_rules();
+        // Last epoch with positive emission (epoch 24, rate = 3e9)
+        let last_height = rules.blocks_total() as i64;
+        assert!(rules.emission_at_height(last_height) > 0);
+        assert_eq!(rules.emission_at_height(last_height + 1), 0);
+    }
+
+    #[test]
+    fn test_remaining_foundation_reward_boundaries() {
+        let rules = default_rules();
+        // At height 0, full foundation allocation
+        assert_eq!(
+            rules.remaining_foundation_reward_at_height(0),
+            rules.founders_coins_total()
+        );
+        // After foundation period ends (fixedRatePeriod + 2*epochLength)
+        let after = i64::from(rules.settings.fixed_rate_period)
+            + 2 * i64::from(rules.settings.epoch_length);
+        assert_eq!(rules.remaining_foundation_reward_at_height(after), 0);
+    }
+
+    #[test]
+    fn test_miners_reward_during_fixed_period() {
+        let rules = default_rules();
+        // During fixed rate + 2 epochs: fixedRate - foundersInitialReward
+        assert_eq!(rules.miners_reward_at_height(0), 67_500_000_000);
+        assert_eq!(rules.miners_reward_at_height(1), 67_500_000_000);
+    }
+
+    #[test]
+    fn test_miners_reward_after_foundation() {
+        let rules = default_rules();
+        // After foundation period, miners get full emission
+        let after = i64::from(rules.settings.fixed_rate_period)
+            + 2 * i64::from(rules.settings.epoch_length);
+        assert_eq!(
+            rules.miners_reward_at_height(after),
+            rules.emission_at_height(after)
+        );
+    }
+}

--- a/ergo-lib/src/chain/ergo_tree_predef.rs
+++ b/ergo-lib/src/chain/ergo_tree_predef.rs
@@ -1,0 +1,530 @@
+//! Predefined ErgoTree scripts for Ergo consensus.
+//!
+//! Ports `ErgoTreePredef` from the JVM's `sigmastate-interpreter` to Rust.
+//! Each function constructs an [`ErgoTree`] by building the IR expression
+//! tree directly (no ErgoScript compilation), matching the JVM reference
+//! byte-for-byte.
+
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use ergo_chain_types::ec_point::generator;
+use ergotree_ir::chain::ergo_box::NonMandatoryRegisterId;
+use ergotree_ir::chain::ergo_box::RegisterId;
+use ergotree_ir::ergo_tree::{ErgoTree, ErgoTreeError, ErgoTreeHeader};
+use ergotree_ir::mir::and::And;
+use ergotree_ir::mir::bin_op::{ArithOp, BinOp, BinOpKind, RelationOp};
+use ergotree_ir::mir::bool_to_sigma::BoolToSigmaProp;
+use ergotree_ir::mir::coll_by_index::ByIndex;
+use ergotree_ir::mir::coll_size::SizeOf;
+use ergotree_ir::mir::collection::Collection;
+use ergotree_ir::mir::constant::Constant;
+use ergotree_ir::mir::create_provedlog::CreateProveDlog;
+use ergotree_ir::mir::decode_point::DecodePoint;
+use ergotree_ir::mir::deserialize_register::DeserializeRegister;
+use ergotree_ir::mir::expr::Expr;
+use ergotree_ir::mir::expr::InvalidArgumentError;
+use ergotree_ir::mir::extract_amount::ExtractAmount;
+use ergotree_ir::mir::extract_creation_info::ExtractCreationInfo;
+use ergotree_ir::mir::extract_script_bytes::ExtractScriptBytes;
+use ergotree_ir::mir::global_vars::GlobalVars;
+use ergotree_ir::mir::if_op::If;
+use ergotree_ir::mir::or::Or;
+use ergotree_ir::mir::select_field::SelectField;
+use ergotree_ir::mir::sigma_and::SigmaAnd;
+use ergotree_ir::mir::subst_const::SubstConstants;
+use ergotree_ir::mir::unary_op::OneArgOpTryBuild;
+use ergotree_ir::mir::upcast::Upcast;
+use ergotree_ir::serialization::SigmaSerializable;
+use ergotree_ir::serialization::SigmaSerializationError;
+use ergotree_ir::sigma_protocol::sigma_boolean::ProveDlog;
+use ergotree_ir::sigma_protocol::sigma_boolean::SigmaProp;
+use ergotree_ir::types::stype::SType;
+
+use super::emission::MonetarySettings;
+
+/// Errors that can occur when constructing predefined ErgoTrees.
+#[derive(Debug, thiserror::Error)]
+pub enum ErgoTreePredefError {
+    /// Invalid argument passed to an IR node constructor.
+    #[error("invalid argument: {0}")]
+    InvalidArgument(#[from] InvalidArgumentError),
+    /// Error constructing an ErgoTree from an expression.
+    #[error("ergo tree error: {0}")]
+    ErgoTree(#[from] ErgoTreeError),
+    /// Error serializing an ErgoTree (used during template construction).
+    #[error("serialization error: {0}")]
+    Serialization(#[from] SigmaSerializationError),
+}
+
+// ---------------------------------------------------------------------------
+// Private IR helpers — keep the tree-construction code readable
+// ---------------------------------------------------------------------------
+
+fn int_const(v: i32) -> Expr {
+    Expr::Const(Constant::from(v))
+}
+
+fn long_const(v: i64) -> Expr {
+    Expr::Const(Constant::from(v))
+}
+
+fn height() -> Expr {
+    Expr::GlobalVars(GlobalVars::Height)
+}
+
+fn self_box() -> Expr {
+    Expr::GlobalVars(GlobalVars::SelfBox)
+}
+
+fn outputs() -> Expr {
+    Expr::GlobalVars(GlobalVars::Outputs)
+}
+
+fn miner_pubkey() -> Expr {
+    Expr::GlobalVars(GlobalVars::MinerPubKey)
+}
+
+fn plus(left: Expr, right: Expr) -> Expr {
+    BinOp {
+        kind: BinOpKind::Arith(ArithOp::Plus),
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+    .into()
+}
+
+fn minus(left: Expr, right: Expr) -> Expr {
+    BinOp {
+        kind: BinOpKind::Arith(ArithOp::Minus),
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+    .into()
+}
+
+fn multiply(left: Expr, right: Expr) -> Expr {
+    BinOp {
+        kind: BinOpKind::Arith(ArithOp::Multiply),
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+    .into()
+}
+
+fn divide(left: Expr, right: Expr) -> Expr {
+    BinOp {
+        kind: BinOpKind::Arith(ArithOp::Divide),
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+    .into()
+}
+
+fn eq(left: Expr, right: Expr) -> Expr {
+    BinOp {
+        kind: BinOpKind::Relation(RelationOp::Eq),
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+    .into()
+}
+
+fn lt(left: Expr, right: Expr) -> Expr {
+    BinOp {
+        kind: BinOpKind::Relation(RelationOp::Lt),
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+    .into()
+}
+
+fn gt(left: Expr, right: Expr) -> Expr {
+    BinOp {
+        kind: BinOpKind::Relation(RelationOp::Gt),
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+    .into()
+}
+
+fn ge(left: Expr, right: Expr) -> Expr {
+    BinOp {
+        kind: BinOpKind::Relation(RelationOp::Ge),
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+    .into()
+}
+
+fn le(left: Expr, right: Expr) -> Expr {
+    BinOp {
+        kind: BinOpKind::Relation(RelationOp::Le),
+        left: Box::new(left),
+        right: Box::new(right),
+    }
+    .into()
+}
+
+/// AND over a collection of boolean expressions.
+fn bool_and(items: Vec<Expr>) -> Result<Expr, InvalidArgumentError> {
+    let coll = Collection::new(SType::SBoolean, items)?;
+    Ok(And {
+        input: Box::new(Expr::Collection(coll)),
+    }
+    .into())
+}
+
+/// OR over a collection of boolean expressions.
+fn bool_or(items: Vec<Expr>) -> Result<Expr, InvalidArgumentError> {
+    let coll = Collection::new(SType::SBoolean, items)?;
+    Ok(Or {
+        input: Box::new(Expr::Collection(coll)),
+    }
+    .into())
+}
+
+/// Convert a boolean expression to a SigmaProp.
+fn to_sigma_prop(bool_expr: Expr) -> Expr {
+    Expr::BoolToSigmaProp(BoolToSigmaProp {
+        input: Box::new(bool_expr),
+    })
+}
+
+/// `SelectField(ExtractCreationInfo(box_expr), 1)` — creation height of a box.
+fn box_creation_height(box_expr: Expr) -> Result<Expr, ErgoTreePredefError> {
+    let creation_info = Expr::ExtractCreationInfo(ExtractCreationInfo {
+        input: Box::new(box_expr),
+    });
+    let field_index = 1u8
+        .try_into()
+        .map_err(|_| InvalidArgumentError("tuple field index 1 out of bounds".into()))?;
+    let field = SelectField::new(creation_info, field_index)?;
+    Ok(field.into())
+}
+
+fn extract_amount(box_expr: Expr) -> Expr {
+    Expr::ExtractAmount(ExtractAmount {
+        input: Box::new(box_expr),
+    })
+}
+
+fn extract_script_bytes(box_expr: Expr) -> Expr {
+    Expr::ExtractScriptBytes(ExtractScriptBytes {
+        input: Box::new(box_expr),
+    })
+}
+
+fn size_of(coll_expr: Expr) -> Expr {
+    Expr::SizeOf(SizeOf {
+        input: Box::new(coll_expr),
+    })
+}
+
+fn by_index(coll: Expr, index: Expr) -> Result<Expr, InvalidArgumentError> {
+    Ok(ByIndex::new(coll, index, None)?.into())
+}
+
+fn upcast_to_long(expr: Expr) -> Result<Expr, InvalidArgumentError> {
+    Ok(Expr::Upcast(Upcast::new(expr, SType::SLong)?))
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// ErgoTree that always evaluates to `false` (spending is impossible).
+///
+/// Equivalent to JVM `ErgoTreePredef.FalseProp`.
+pub fn false_prop() -> Result<ErgoTree, ErgoTreePredefError> {
+    let expr = to_sigma_prop(Expr::Const(Constant::from(false)));
+    Ok(ErgoTree::new(ErgoTreeHeader::v0(true), &expr)?)
+}
+
+/// ErgoTree that always evaluates to `true` (anyone can spend).
+///
+/// Equivalent to JVM `ErgoTreePredef.TrueProp`.
+pub fn true_prop() -> Result<ErgoTree, ErgoTreePredefError> {
+    let expr = to_sigma_prop(Expr::Const(Constant::from(true)));
+    Ok(ErgoTree::new(ErgoTreeHeader::v0(true), &expr)?)
+}
+
+/// Miner reward output script: spendable after `delta` blocks by the miner.
+///
+/// ```text
+/// SigmaAnd(
+///   GE(HEIGHT, boxCreationHeight(SELF) + delta).toSigmaProp,
+///   SigmaPropConstant(minerPk)
+/// )
+/// ```
+///
+/// Equivalent to JVM `ErgoTreePredef.rewardOutputScript`.
+pub fn reward_output_script(
+    delta: i32,
+    miner_pk: ProveDlog,
+) -> Result<ErgoTree, ErgoTreePredefError> {
+    let height_check = ge(
+        height(),
+        plus(box_creation_height(self_box())?, int_const(delta)),
+    );
+    let miner_prop: Expr = Expr::Const(SigmaProp::from(miner_pk).into());
+    let expr = Expr::SigmaAnd(SigmaAnd::new(vec![
+        to_sigma_prop(height_check),
+        miner_prop,
+    ])?);
+    Ok(ErgoTree::new(ErgoTreeHeader::v0(true), &expr)?)
+}
+
+/// Build the `SubstConstants` expression that produces the expected miner
+/// output script bytes at evaluation time.
+///
+/// Creates a generic reward script template (using the generator point),
+/// serializes it, then uses `SubstConstants` to replace the miner PK
+/// constant (at position 1) with the actual miner's public key decoded
+/// from `miner_pk_bytes_val`.
+///
+/// Equivalent to JVM `ErgoTreePredef.expectedMinerOutScriptBytesVal`.
+pub fn expected_miner_out_script_bytes_val(
+    delta: i32,
+    miner_pk_bytes_val: Expr,
+) -> Result<Expr, ErgoTreePredefError> {
+    let generic_pk = ProveDlog::new(generator());
+    let generic_miner_prop = reward_output_script(delta, generic_pk)?;
+    let generic_miner_prop_bytes = generic_miner_prop.sigma_serialize_bytes()?;
+
+    let positions: Expr = Expr::Const(Constant::from(vec![1i32]));
+
+    let decoded_point = Expr::DecodePoint(DecodePoint::try_build(miner_pk_bytes_val)?);
+    let miner_pubkey_sigma_prop = Expr::CreateProveDlog(CreateProveDlog::try_build(decoded_point)?);
+    let new_vals = Collection::new(SType::SSigmaProp, vec![miner_pubkey_sigma_prop])?;
+
+    let subst = SubstConstants::new(
+        Expr::Const(Constant::from(generic_miner_prop_bytes)),
+        positions,
+        Expr::Collection(new_vals),
+    )?;
+    Ok(subst.into())
+}
+
+/// Fee proposition: a box spendable only in the same block it was created,
+/// with a single output matching the expected miner reward script.
+///
+/// ```text
+/// AND(
+///   EQ(HEIGHT, boxCreationHeight(Outputs(0))),
+///   EQ(ExtractScriptBytes(Outputs(0)), expectedMinerOutScriptBytesVal(delta, MinerPubkey)),
+///   EQ(SizeOf(Outputs), 1)
+/// ).toSigmaProp
+/// ```
+///
+/// Equivalent to JVM `ErgoTreePredef.feeProposition`.
+pub fn fee_proposition(delta: i32) -> Result<ErgoTree, ErgoTreePredefError> {
+    let out = by_index(outputs(), int_const(0))?;
+
+    let height_ok = eq(height(), box_creation_height(out.clone())?);
+    let script_ok = eq(
+        extract_script_bytes(out),
+        expected_miner_out_script_bytes_val(delta, miner_pubkey())?,
+    );
+    let outputs_ok = eq(size_of(outputs()), int_const(1));
+
+    let prop = to_sigma_prop(bool_and(vec![height_ok, script_ok, outputs_ok])?);
+    Ok(ErgoTree::new(ErgoTreeHeader::v0(true), &prop)?)
+}
+
+/// Emission box proposition: controls the release of miner rewards over time.
+///
+/// Equivalent to JVM `ErgoTreePredef.emissionBoxProp`.
+pub fn emission_box_prop(s: &MonetarySettings) -> Result<ErgoTree, ErgoTreePredefError> {
+    let reward_out = by_index(outputs(), int_const(0))?;
+    let miner_out = by_index(outputs(), int_const(1))?;
+
+    let miners_reward = s.fixed_rate - s.founders_initial_reward;
+    let miners_fixed_rate_period = i64::from(s.fixed_rate_period) + 2 * i64::from(s.epoch_length);
+
+    // epoch = 1 + (HEIGHT - fixedRatePeriod) / epochLength
+    let epoch = plus(
+        int_const(1),
+        divide(
+            minus(height(), int_const(s.fixed_rate_period)),
+            int_const(s.epoch_length),
+        ),
+    );
+
+    // coinsToIssue = If(HEIGHT < minersFixedRatePeriod, minersReward,
+    //                    fixedRate - oneEpochReduction * epoch.toLong)
+    let coins_to_issue = Expr::If(If {
+        condition: Box::new(lt(height(), int_const(miners_fixed_rate_period as i32))),
+        true_branch: Box::new(long_const(miners_reward)),
+        false_branch: Box::new(minus(
+            long_const(s.fixed_rate),
+            multiply(long_const(s.one_epoch_reduction), upcast_to_long(epoch)?),
+        )),
+    });
+
+    let same_script_rule = eq(
+        extract_script_bytes(self_box()),
+        extract_script_bytes(reward_out.clone()),
+    );
+    let height_correct = eq(box_creation_height(reward_out.clone())?, height());
+    let height_increased = gt(height(), box_creation_height(self_box())?);
+    let correct_coins_consumed = eq(
+        coins_to_issue,
+        minus(
+            extract_amount(self_box()),
+            extract_amount(reward_out.clone()),
+        ),
+    );
+    let last_coins = le(
+        extract_amount(self_box()),
+        long_const(s.one_epoch_reduction),
+    );
+    let outputs_num = eq(size_of(outputs()), int_const(2));
+
+    let correct_miner_output = bool_and(vec![
+        eq(
+            extract_script_bytes(miner_out.clone()),
+            expected_miner_out_script_bytes_val(s.miner_reward_delay, miner_pubkey())?,
+        ),
+        eq(height(), box_creation_height(miner_out)?),
+    ])?;
+
+    let normal_spending = bool_and(vec![
+        outputs_num,
+        same_script_rule,
+        correct_coins_consumed,
+        height_correct,
+    ])?;
+
+    let prop = to_sigma_prop(bool_and(vec![
+        height_increased,
+        correct_miner_output,
+        bool_or(vec![normal_spending, last_coins])?,
+    ])?);
+
+    Ok(ErgoTree::new(ErgoTreeHeader::v0(true), &prop)?)
+}
+
+/// Foundation script: controls the treasury box and its gradual depletion.
+///
+/// The remaining amount decreases according to the emission schedule, and
+/// the box can be spent if a custom proposition in register R4 is satisfied.
+///
+/// Equivalent to JVM `ErgoTreePredef.foundationScript`.
+pub fn foundation_script(s: &MonetarySettings) -> Result<ErgoTree, ErgoTreePredefError> {
+    let new_foundation_box = by_index(outputs(), int_const(0))?;
+
+    let fir = s.founders_initial_reward;
+    let oer = s.one_epoch_reduction;
+    let el = i64::from(s.epoch_length);
+    let frp = s.fixed_rate_period;
+    let frp_minus_1 = frp - 1;
+
+    let full15 = (fir - 2 * oer) * el;
+    let full45 = (fir - oer) * el;
+
+    // Nested If/If/If computing the remaining foundation amount at HEIGHT
+    let remaining_amount = Expr::If(If {
+        condition: Box::new(lt(height(), int_const(frp))),
+        true_branch: Box::new(plus(
+            long_const(full15 + full45),
+            multiply(
+                long_const(fir),
+                upcast_to_long(minus(int_const(frp_minus_1), height()))?,
+            ),
+        )),
+        false_branch: Box::new(Expr::If(If {
+            condition: Box::new(lt(height(), int_const(frp + s.epoch_length))),
+            true_branch: Box::new(plus(
+                long_const(full15),
+                multiply(
+                    long_const(fir - oer),
+                    upcast_to_long(minus(int_const(frp_minus_1 + s.epoch_length), height()))?,
+                ),
+            )),
+            false_branch: Box::new(Expr::If(If {
+                condition: Box::new(lt(height(), int_const(frp + 2 * s.epoch_length))),
+                true_branch: Box::new(multiply(
+                    long_const(fir - 2 * oer),
+                    upcast_to_long(minus(int_const(frp_minus_1 + 2 * s.epoch_length), height()))?,
+                )),
+                false_branch: Box::new(long_const(0)),
+            })),
+        })),
+    });
+
+    let amount_correct = ge(extract_amount(new_foundation_box.clone()), remaining_amount);
+    let same_script_rule = eq(
+        extract_script_bytes(self_box()),
+        extract_script_bytes(new_foundation_box),
+    );
+    let custom_proposition = Expr::DeserializeRegister(DeserializeRegister::new(
+        RegisterId::NonMandatoryRegisterId(NonMandatoryRegisterId::R4),
+        SType::SSigmaProp,
+        None,
+    )?);
+
+    let prop = Expr::SigmaAnd(SigmaAnd::new(vec![
+        to_sigma_prop(amount_correct),
+        to_sigma_prop(same_script_rule),
+        custom_proposition,
+    ])?);
+
+    Ok(ErgoTree::new(ErgoTreeHeader::v0(true), &prop)?)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_false_prop_hex() {
+        let tree = false_prop().unwrap();
+        let hex = tree.to_base16_bytes().unwrap();
+        assert_eq!(hex, "10010100d17300");
+    }
+
+    #[test]
+    fn test_true_prop_hex() {
+        let tree = true_prop().unwrap();
+        // TrueProp is the same structure as FalseProp but with `true`
+        let hex = tree.to_base16_bytes().unwrap();
+        // The constant is `true` (0x01) instead of `false` (0x00)
+        assert_eq!(hex, "10010101d17300");
+    }
+
+    #[test]
+    fn test_emission_box_prop_hex() {
+        let s = MonetarySettings::default();
+        let tree = emission_box_prop(&s).unwrap();
+        let hex = tree.to_base16_bytes().unwrap();
+        let expected = "101004020e36100204a00b08cd0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ea02d192a39a8cc7a7017300730110010204020404040004c0fd4f05808c82f5f6030580b8c9e5ae040580f882ad16040204c0944004c0f407040004000580f882ad16d19683030191a38cc7a7019683020193c2b2a57300007473017302830108cdeeac93a38cc7b2a573030001978302019683040193b1a5730493c2a7c2b2a573050093958fa3730673079973089c73097e9a730a9d99a3730b730c0599c1a7c1b2a5730d00938cc7b2a5730e0001a390c1a7730f";
+        assert_eq!(hex, expected);
+    }
+
+    #[test]
+    fn test_foundation_script_hex() {
+        let s = MonetarySettings::default();
+        let tree = foundation_script(&s).unwrap();
+        let hex = tree.to_base16_bytes().unwrap();
+        let expected = "100e040004c094400580809cde91e7b0010580acc7f03704be944004808948058080c7b7e4992c0580b4c4c32104fe884804c0fd4f0580bcc1960b04befd4f05000400ea03d192c1b2a5730000958fa373019a73029c73037e997304a305958fa373059a73069c73077e997308a305958fa373099c730a7e99730ba305730cd193c2a7c2b2a5730d00d5040800";
+        assert_eq!(hex, expected);
+    }
+
+    #[test]
+    fn test_reward_output_script_constructs() {
+        // Just verify it constructs without error
+        let pk = ProveDlog::new(generator());
+        let tree = reward_output_script(720, pk).unwrap();
+        assert!(tree.to_base16_bytes().unwrap().starts_with("10"));
+    }
+
+    #[test]
+    fn test_fee_proposition_constructs() {
+        let tree = fee_proposition(720).unwrap();
+        assert!(tree.to_base16_bytes().unwrap().starts_with("10"));
+    }
+}

--- a/ergo-lib/src/chain/genesis.rs
+++ b/ergo-lib/src/chain/genesis.rs
@@ -3,6 +3,9 @@
 //! Constructs the three genesis boxes (emission, no-premine, foundation)
 //! from chain parameters, matching the JVM reference implementation.
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use ergotree_ir::chain::ergo_box::box_value::BoxValue;
 use ergotree_ir::chain::ergo_box::box_value::BoxValueError;
 use ergotree_ir::chain::ergo_box::ErgoBox;
@@ -10,8 +13,16 @@ use ergotree_ir::chain::ergo_box::NonMandatoryRegisterId;
 use ergotree_ir::chain::ergo_box::NonMandatoryRegisters;
 use ergotree_ir::chain::ergo_box::NonMandatoryRegistersError;
 use ergotree_ir::chain::tx_id::TxId;
+use ergotree_ir::mir::atleast::Atleast;
+use ergotree_ir::mir::collection::Collection;
 use ergotree_ir::mir::constant::Constant;
+use ergotree_ir::mir::expr::Expr;
+use ergotree_ir::mir::expr::InvalidArgumentError;
+use ergotree_ir::serialization::SigmaSerializable;
 use ergotree_ir::serialization::SigmaSerializationError;
+use ergotree_ir::sigma_protocol::sigma_boolean::ProveDlog;
+use ergotree_ir::sigma_protocol::sigma_boolean::SigmaProp;
+use ergotree_ir::types::stype::SType;
 
 use super::emission::EmissionRules;
 use super::emission::MonetarySettings;
@@ -34,25 +45,63 @@ pub enum GenesisError {
     /// Error creating non-mandatory registers.
     #[error("register error: {0}")]
     Register(#[from] NonMandatoryRegistersError),
+    /// Error constructing an IR expression.
+    #[error("invalid argument: {0}")]
+    InvalidArgument(#[from] InvalidArgumentError),
+}
+
+/// Register IDs for no-premine proof strings (R4 through R8).
+const PROOF_REGISTER_IDS: [NonMandatoryRegisterId; 5] = [
+    NonMandatoryRegisterId::R4,
+    NonMandatoryRegisterId::R5,
+    NonMandatoryRegisterId::R6,
+    NonMandatoryRegisterId::R7,
+    NonMandatoryRegisterId::R8,
+];
+
+/// Build the founders box R4 constant from a k-of-n threshold over public keys.
+///
+/// The JVM reference serializes `Atleast(k, Coll(pk1, pk2, ...))` at the
+/// **Expr level** using `ValueSerializer.serialize`, then wraps the bytes
+/// in a `ByteArrayConstant`. This function reproduces that encoding.
+fn build_founders_r4(founders_pks: &[ProveDlog], threshold: u8) -> Result<Constant, GenesisError> {
+    let pk_exprs: Vec<Expr> = founders_pks
+        .iter()
+        .map(|pk| Expr::Const(Constant::from(SigmaProp::from(pk.clone()))))
+        .collect();
+    let bound = Expr::Const(Constant::from(i32::from(threshold)));
+    let input = Collection::new(SType::SSigmaProp, pk_exprs)?;
+    let atleast = Atleast::new(bound, Expr::Collection(input))?;
+    let atleast_bytes = Expr::Atleast(atleast).sigma_serialize_bytes()?;
+    Ok(Constant::from(atleast_bytes))
 }
 
 /// Construct the three genesis boxes for an Ergo network.
 ///
 /// Returns `(emission_box, no_premine_box, founders_box)`.
 ///
-/// - `settings`: monetary parameters for the chain
-/// - `founders_prop`: the SigmaProp constant stored in the founders box R4
-///   register (controls who can spend from the foundation treasury)
+/// # Parameters
 ///
-/// Genesis boxes use `TxId::zero()`, `creation_height = 0`, and indices
-/// 0, 1, 2 respectively.
+/// - `settings`: monetary parameters for the chain
+/// - `founders_pks`: public keys for the foundation multisig
+/// - `founders_threshold`: minimum number of founder signatures required
+/// - `no_premine_proofs`: proof-of-no-premine strings stored in the
+///   no-premine box registers R4–R8 (e.g. Bitcoin block hash, news
+///   headlines). At most 5 strings; extras are silently ignored.
+///
+/// All three genesis boxes use `TxId::zero()`, `creation_height = 0`,
+/// and `index = 0` (matching the JVM reference, which treats each as the
+/// first output of a virtual genesis transaction).
 pub fn genesis_boxes(
     settings: &MonetarySettings,
-    founders_prop: Constant,
+    founders_pks: &[ProveDlog],
+    founders_threshold: u8,
+    no_premine_proofs: &[&str],
 ) -> Result<(ErgoBox, ErgoBox, ErgoBox), GenesisError> {
     let rules = EmissionRules::new(settings.clone());
     let tx_id = TxId::zero();
 
+    // --- Emission box (index 0) ---
     let emission_box = ErgoBox::new(
         BoxValue::try_from(rules.miners_coins_total() as u64)?,
         ergo_tree_predef::emission_box_prop(settings)?,
@@ -63,18 +112,32 @@ pub fn genesis_boxes(
         0,
     )?;
 
+    // --- No-premine box (index 0) ---
+    let proof_regs: Vec<(NonMandatoryRegisterId, Constant)> = no_premine_proofs
+        .iter()
+        .zip(PROOF_REGISTER_IDS.iter())
+        .map(|(s, reg)| (*reg, Constant::from(s.as_bytes().to_vec())))
+        .collect();
+    let no_premine_registers = if proof_regs.is_empty() {
+        NonMandatoryRegisters::empty()
+    } else {
+        NonMandatoryRegisters::new(proof_regs)?
+    };
+
     let no_premine_box = ErgoBox::new(
         BoxValue::try_from(COINS_IN_ONE_ERGO as u64)?,
         ergo_tree_predef::false_prop()?,
         None,
-        NonMandatoryRegisters::empty(),
+        no_premine_registers,
         0,
         tx_id,
-        1,
+        0,
     )?;
 
+    // --- Founders box (index 0) ---
+    let founders_r4 = build_founders_r4(founders_pks, founders_threshold)?;
     let founders_registers =
-        NonMandatoryRegisters::new(vec![(NonMandatoryRegisterId::R4, founders_prop)])?;
+        NonMandatoryRegisters::new(vec![(NonMandatoryRegisterId::R4, founders_r4)])?;
     let founders_value = (rules.founders_coins_total() - COINS_IN_ONE_ERGO) as u64;
 
     let founders_box = ErgoBox::new(
@@ -84,7 +147,7 @@ pub fn genesis_boxes(
         founders_registers,
         0,
         tx_id,
-        2,
+        0,
     )?;
 
     Ok((emission_box, no_premine_box, founders_box))
@@ -95,32 +158,57 @@ pub fn genesis_boxes(
 #[allow(clippy::panic)]
 mod tests {
     use super::*;
-    use ergotree_ir::sigma_protocol::sigma_boolean::SigmaBoolean;
-    use ergotree_ir::sigma_protocol::sigma_boolean::SigmaProp;
+    use ergo_chain_types::EcPoint;
 
-    /// Build genesis boxes with TrueProp as founders proposition (simplest case).
-    fn build_test_genesis() -> (ErgoBox, ErgoBox, ErgoBox) {
+    /// Testnet no-premine proof strings.
+    const TESTNET_PROOFS: &[&str] = &[
+        "'Chaos reigns': what the papers say about the no-deal Brexit vote",
+        "习近平的两会时间|这里有份习近平两会日历，请查收！",
+        "ТАСС сообщил об обнаружении нескольких майнинговых ферм на столичных рынках",
+        "000000000000000000139a3e61bd5721827b51a5309a8bfeca0b8c4b5c060931",
+        "0xef1d584d77e74e3c509de625dc17893b22b73d040b5d5302bbf832065f928d03",
+    ];
+
+    /// Testnet founder public keys (hex-encoded compressed EC points).
+    const TESTNET_FOUNDER_PKS: &[&str] = &[
+        "039bb5fe52359a64c99a60fd944fc5e388cbdc4d37ff091cc841c3ee79060b8647",
+        "031fb52cf6e805f80d97cde289f4f757d49accf0c83fb864b27d2cf982c37f9a8b",
+        "0352ac2a471339b0d23b3d2c5ce0db0e81c969f77891b9edf0bda7fd39a78184e7",
+    ];
+
+    fn parse_founder_pks() -> Vec<ProveDlog> {
+        TESTNET_FOUNDER_PKS
+            .iter()
+            .map(|hex| {
+                let bytes = base16::decode(hex.as_bytes()).unwrap();
+                let point = EcPoint::sigma_parse_bytes(&bytes).unwrap();
+                ProveDlog::new(point)
+            })
+            .collect()
+    }
+
+    fn build_testnet_genesis() -> (ErgoBox, ErgoBox, ErgoBox) {
         let settings = MonetarySettings::default();
-        let true_prop = Constant::from(SigmaProp::new(SigmaBoolean::TrivialProp(true)));
-        genesis_boxes(&settings, true_prop).unwrap()
+        let pks = parse_founder_pks();
+        genesis_boxes(&settings, &pks, 2, TESTNET_PROOFS).unwrap()
     }
 
     #[test]
     fn test_genesis_emission_box_value() {
-        let (emission, _, _) = build_test_genesis();
+        let (emission, _, _) = build_testnet_genesis();
         let rules = EmissionRules::new(MonetarySettings::default());
         assert_eq!(emission.value.as_i64(), rules.miners_coins_total());
     }
 
     #[test]
     fn test_genesis_no_premine_box_value() {
-        let (_, no_premine, _) = build_test_genesis();
+        let (_, no_premine, _) = build_testnet_genesis();
         assert_eq!(no_premine.value.as_i64(), COINS_IN_ONE_ERGO);
     }
 
     #[test]
     fn test_genesis_founders_box_value() {
-        let (_, _, founders) = build_test_genesis();
+        let (_, _, founders) = build_testnet_genesis();
         let rules = EmissionRules::new(MonetarySettings::default());
         let expected = rules.founders_coins_total() - COINS_IN_ONE_ERGO;
         assert_eq!(founders.value.as_i64(), expected);
@@ -128,25 +216,55 @@ mod tests {
 
     #[test]
     fn test_genesis_total_value_equals_coins_total() {
-        let (emission, no_premine, founders) = build_test_genesis();
+        let (emission, no_premine, founders) = build_testnet_genesis();
         let rules = EmissionRules::new(MonetarySettings::default());
         let total = emission.value.as_i64() + no_premine.value.as_i64() + founders.value.as_i64();
         assert_eq!(total, rules.coins_total());
     }
 
     #[test]
-    fn test_genesis_box_indices() {
-        let (emission, no_premine, founders) = build_test_genesis();
+    fn test_genesis_all_indices_zero() {
+        let (emission, no_premine, founders) = build_testnet_genesis();
         assert_eq!(emission.index, 0);
-        assert_eq!(no_premine.index, 1);
-        assert_eq!(founders.index, 2);
+        assert_eq!(no_premine.index, 0);
+        assert_eq!(founders.index, 0);
     }
 
     #[test]
     fn test_genesis_box_creation_height() {
-        let (emission, no_premine, founders) = build_test_genesis();
+        let (emission, no_premine, founders) = build_testnet_genesis();
         assert_eq!(emission.creation_height, 0);
         assert_eq!(no_premine.creation_height, 0);
         assert_eq!(founders.creation_height, 0);
+    }
+
+    #[test]
+    fn test_testnet_emission_box_id() {
+        let (emission, _, _) = build_testnet_genesis();
+        let id: String = emission.box_id().into();
+        assert_eq!(
+            id,
+            "b69575e11c5c43400bfead5976ee0d6245a1168396b2e2a4f384691f275d501c"
+        );
+    }
+
+    #[test]
+    fn test_testnet_no_premine_box_id() {
+        let (_, no_premine, _) = build_testnet_genesis();
+        let id: String = no_premine.box_id().into();
+        assert_eq!(
+            id,
+            "3bfaf76c824df668822dfce71abaf688d0281f91c3ac2a271f92fa28c3efaac7"
+        );
+    }
+
+    #[test]
+    fn test_testnet_founders_box_id() {
+        let (_, _, founders) = build_testnet_genesis();
+        let id: String = founders.box_id().into();
+        assert_eq!(
+            id,
+            "5527430474b673e4aafb08e0079c639de23e6a17e87edd00f78662b43c88aeda"
+        );
     }
 }

--- a/ergo-lib/src/chain/genesis.rs
+++ b/ergo-lib/src/chain/genesis.rs
@@ -1,0 +1,152 @@
+//! Genesis block construction for the Ergo blockchain.
+//!
+//! Constructs the three genesis boxes (emission, no-premine, foundation)
+//! from chain parameters, matching the JVM reference implementation.
+
+use ergotree_ir::chain::ergo_box::box_value::BoxValue;
+use ergotree_ir::chain::ergo_box::box_value::BoxValueError;
+use ergotree_ir::chain::ergo_box::ErgoBox;
+use ergotree_ir::chain::ergo_box::NonMandatoryRegisterId;
+use ergotree_ir::chain::ergo_box::NonMandatoryRegisters;
+use ergotree_ir::chain::ergo_box::NonMandatoryRegistersError;
+use ergotree_ir::chain::tx_id::TxId;
+use ergotree_ir::mir::constant::Constant;
+use ergotree_ir::serialization::SigmaSerializationError;
+
+use super::emission::EmissionRules;
+use super::emission::MonetarySettings;
+use super::emission::COINS_IN_ONE_ERGO;
+use super::ergo_tree_predef;
+use super::ergo_tree_predef::ErgoTreePredefError;
+
+/// Errors that can occur during genesis box construction.
+#[derive(Debug, thiserror::Error)]
+pub enum GenesisError {
+    /// Error constructing a predefined ErgoTree.
+    #[error("ergo tree predef error: {0}")]
+    ErgoTreePredef(#[from] ErgoTreePredefError),
+    /// Error creating a box value.
+    #[error("box value error: {0}")]
+    BoxValue(#[from] BoxValueError),
+    /// Error serializing a box (for box ID computation).
+    #[error("serialization error: {0}")]
+    Serialization(#[from] SigmaSerializationError),
+    /// Error creating non-mandatory registers.
+    #[error("register error: {0}")]
+    Register(#[from] NonMandatoryRegistersError),
+}
+
+/// Construct the three genesis boxes for an Ergo network.
+///
+/// Returns `(emission_box, no_premine_box, founders_box)`.
+///
+/// - `settings`: monetary parameters for the chain
+/// - `founders_prop`: the SigmaProp constant stored in the founders box R4
+///   register (controls who can spend from the foundation treasury)
+///
+/// Genesis boxes use `TxId::zero()`, `creation_height = 0`, and indices
+/// 0, 1, 2 respectively.
+pub fn genesis_boxes(
+    settings: &MonetarySettings,
+    founders_prop: Constant,
+) -> Result<(ErgoBox, ErgoBox, ErgoBox), GenesisError> {
+    let rules = EmissionRules::new(settings.clone());
+    let tx_id = TxId::zero();
+
+    let emission_box = ErgoBox::new(
+        BoxValue::try_from(rules.miners_coins_total() as u64)?,
+        ergo_tree_predef::emission_box_prop(settings)?,
+        None,
+        NonMandatoryRegisters::empty(),
+        0,
+        tx_id,
+        0,
+    )?;
+
+    let no_premine_box = ErgoBox::new(
+        BoxValue::try_from(COINS_IN_ONE_ERGO as u64)?,
+        ergo_tree_predef::false_prop()?,
+        None,
+        NonMandatoryRegisters::empty(),
+        0,
+        tx_id,
+        1,
+    )?;
+
+    let founders_registers =
+        NonMandatoryRegisters::new(vec![(NonMandatoryRegisterId::R4, founders_prop)])?;
+    let founders_value = (rules.founders_coins_total() - COINS_IN_ONE_ERGO) as u64;
+
+    let founders_box = ErgoBox::new(
+        BoxValue::try_from(founders_value)?,
+        ergo_tree_predef::foundation_script(settings)?,
+        None,
+        founders_registers,
+        0,
+        tx_id,
+        2,
+    )?;
+
+    Ok((emission_box, no_premine_box, founders_box))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::panic)]
+mod tests {
+    use super::*;
+    use ergotree_ir::sigma_protocol::sigma_boolean::SigmaBoolean;
+    use ergotree_ir::sigma_protocol::sigma_boolean::SigmaProp;
+
+    /// Build genesis boxes with TrueProp as founders proposition (simplest case).
+    fn build_test_genesis() -> (ErgoBox, ErgoBox, ErgoBox) {
+        let settings = MonetarySettings::default();
+        let true_prop = Constant::from(SigmaProp::new(SigmaBoolean::TrivialProp(true)));
+        genesis_boxes(&settings, true_prop).unwrap()
+    }
+
+    #[test]
+    fn test_genesis_emission_box_value() {
+        let (emission, _, _) = build_test_genesis();
+        let rules = EmissionRules::new(MonetarySettings::default());
+        assert_eq!(emission.value.as_i64(), rules.miners_coins_total());
+    }
+
+    #[test]
+    fn test_genesis_no_premine_box_value() {
+        let (_, no_premine, _) = build_test_genesis();
+        assert_eq!(no_premine.value.as_i64(), COINS_IN_ONE_ERGO);
+    }
+
+    #[test]
+    fn test_genesis_founders_box_value() {
+        let (_, _, founders) = build_test_genesis();
+        let rules = EmissionRules::new(MonetarySettings::default());
+        let expected = rules.founders_coins_total() - COINS_IN_ONE_ERGO;
+        assert_eq!(founders.value.as_i64(), expected);
+    }
+
+    #[test]
+    fn test_genesis_total_value_equals_coins_total() {
+        let (emission, no_premine, founders) = build_test_genesis();
+        let rules = EmissionRules::new(MonetarySettings::default());
+        let total = emission.value.as_i64() + no_premine.value.as_i64() + founders.value.as_i64();
+        assert_eq!(total, rules.coins_total());
+    }
+
+    #[test]
+    fn test_genesis_box_indices() {
+        let (emission, no_premine, founders) = build_test_genesis();
+        assert_eq!(emission.index, 0);
+        assert_eq!(no_premine.index, 1);
+        assert_eq!(founders.index, 2);
+    }
+
+    #[test]
+    fn test_genesis_box_creation_height() {
+        let (emission, no_premine, founders) = build_test_genesis();
+        assert_eq!(emission.creation_height, 0);
+        assert_eq!(no_premine.creation_height, 0);
+        assert_eq!(founders.creation_height, 0);
+    }
+}


### PR DESCRIPTION
Ports three consensus-critical modules to ergo-lib: EmissionRules (per-block rewards + supply), ErgoTreePredef (predefined script construction via IR trees), and genesis (box construction). Rust nodes currently hardcode genesis ErgoTree bytes from the JVM API; this makes genesis constructible from chain parameters.

Additive — three new modules, no existing code touched, no new deps. ErgoTree hex byte-for-byte against JVM; testnet genesis box IDs verified.
