### PR TITLE
ergo-lib: add SoftForkVotesCollected and SoftForkStartingHeight Parameter variants

### DIFF
--- a/ergo-lib/src/chain/parameters.rs
+++ b/ergo-lib/src/chain/parameters.rs
@@ -3,8 +3,13 @@ use hashbrown::HashMap;
 
 #[repr(i8)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-// TODO: soft-fork parameter
-/// A parameter that can be adjusted by voting
+/// A parameter that can be adjusted by voting.
+///
+/// Note: `SoftForkDisablingRules` (id 124) is intentionally not represented here.
+/// Its on-chain value is a variable-length `ErgoValidationSettingsUpdate` byte
+/// vector, which is incompatible with the current `HashMap<Parameter, i32>`
+/// storage type. Supporting it will require a follow-up change to the storage
+/// representation.
 pub enum Parameter {
     /// Storage fee factor (per byte per storage period)
     StorageFeeFactor = 1,
@@ -22,6 +27,16 @@ pub enum Parameter {
     DataInputCost = 7,
     /// Cost per one transaction output
     OutputCost = 8,
+    /// Number of soft-fork votes collected during the current voting period.
+    /// Tracked in `parameters_table` while a soft-fork vote is in progress;
+    /// removed at activation or expiration. Mirrors JVM
+    /// `Parameters.SoftForkVotesCollected`.
+    SoftForkVotesCollected = 121,
+    /// Height at which the current soft-fork voting period began.
+    /// Tracked in `parameters_table` while a soft-fork vote is in progress;
+    /// removed at activation or expiration. Mirrors JVM
+    /// `Parameters.SoftForkStartingHeight`.
+    SoftForkStartingHeight = 122,
     /// Current block version
     BlockVersion = 123,
 }
@@ -76,6 +91,26 @@ impl Parameters {
         self.parameters_table[&Parameter::OutputCost]
     }
 
+    /// Number of soft-fork votes collected, if a vote is currently in progress.
+    ///
+    /// Returns `None` when no soft-fork vote is in progress; the entry is only
+    /// present in `parameters_table` during an active voting period.
+    pub fn soft_fork_votes_collected(&self) -> Option<i32> {
+        self.parameters_table
+            .get(&Parameter::SoftForkVotesCollected)
+            .copied()
+    }
+
+    /// Height at which the current soft-fork voting period began, if any.
+    ///
+    /// Returns `None` when no soft-fork vote is in progress; the entry is only
+    /// present in `parameters_table` during an active voting period.
+    pub fn soft_fork_starting_height(&self) -> Option<i32> {
+        self.parameters_table
+            .get(&Parameter::SoftForkStartingHeight)
+            .copied()
+    }
+
     /// Create new parameters from provided blockchain parameters
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -117,5 +152,49 @@ impl Default for Parameters {
         parameters_table.insert(Parameter::MaxBlockSize, 512 * 1024);
         parameters_table.insert(Parameter::BlockVersion, 1);
         Self { parameters_table }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_does_not_contain_soft_fork_variants() {
+        let params = Parameters::default();
+        assert!(!params
+            .parameters_table
+            .contains_key(&Parameter::SoftForkVotesCollected));
+        assert!(!params
+            .parameters_table
+            .contains_key(&Parameter::SoftForkStartingHeight));
+    }
+
+    #[test]
+    fn default_soft_fork_votes_collected_is_none() {
+        assert_eq!(Parameters::default().soft_fork_votes_collected(), None);
+    }
+
+    #[test]
+    fn default_soft_fork_starting_height_is_none() {
+        assert_eq!(Parameters::default().soft_fork_starting_height(), None);
+    }
+
+    #[test]
+    fn soft_fork_votes_collected_returns_inserted_value() {
+        let mut params = Parameters::default();
+        params
+            .parameters_table
+            .insert(Parameter::SoftForkVotesCollected, 42);
+        assert_eq!(params.soft_fork_votes_collected(), Some(42));
+    }
+
+    #[test]
+    fn soft_fork_starting_height_returns_inserted_value() {
+        let mut params = Parameters::default();
+        params
+            .parameters_table
+            .insert(Parameter::SoftForkStartingHeight, 1000);
+        assert_eq!(params.soft_fork_starting_height(), Some(1000));
     }
 }

--- a/ergo-lib/src/chain/parameters.rs
+++ b/ergo-lib/src/chain/parameters.rs
@@ -27,6 +27,11 @@ pub enum Parameter {
     DataInputCost = 7,
     /// Cost per one transaction output
     OutputCost = 8,
+    /// Number of sub-blocks per block, on average. Introduced by the 6.0
+    /// soft-fork (block version 4). Mirrors JVM
+    /// `Parameters.SubblocksPerBlockIncrease`. Auto-inserted by
+    /// `Parameters.update` whenever `BlockVersion == 4`.
+    SubblocksPerBlock = 9,
     /// Number of soft-fork votes collected during the current voting period.
     /// Tracked in `parameters_table` while a soft-fork vote is in progress;
     /// removed at activation or expiration. Mirrors JVM
@@ -89,6 +94,14 @@ impl Parameters {
     /// Validation cost per one output
     pub fn output_cost(&self) -> i32 {
         self.parameters_table[&Parameter::OutputCost]
+    }
+
+    /// Number of sub-blocks per block. Returns `None` pre-6.0 (block version
+    /// less than 4) or when the parameter is otherwise absent from the table.
+    pub fn sub_blocks_per_block(&self) -> Option<i32> {
+        self.parameters_table
+            .get(&Parameter::SubblocksPerBlock)
+            .copied()
     }
 
     /// Number of soft-fork votes collected, if a vote is currently in progress.
@@ -196,5 +209,18 @@ mod tests {
             .parameters_table
             .insert(Parameter::SoftForkStartingHeight, 1000);
         assert_eq!(params.soft_fork_starting_height(), Some(1000));
+    }
+
+    #[test]
+    fn sub_blocks_per_block_default_none() {
+        let p = Parameters::default();
+        assert_eq!(p.sub_blocks_per_block(), None);
+    }
+
+    #[test]
+    fn sub_blocks_per_block_set_and_get() {
+        let mut p = Parameters::default();
+        p.parameters_table.insert(Parameter::SubblocksPerBlock, 30);
+        assert_eq!(p.sub_blocks_per_block(), Some(30));
     }
 }


### PR DESCRIPTION
Adds three Parameter enum variants introduced by the 6.0 soft-fork — SubblocksPerBlock (9), SoftForkVotesCollected (121), SoftForkStartingHeight (122) — with matching Option<i32> accessors. Without them, Rust nodes can't represent in-progress soft-fork voting or the sub-blocks parameter.

SoftForkDisablingRules (124) deferred — variable-length encoding doesn't fit HashMap<Parameter, i32>. Additive: defaults unchanged.
