### PR TITLE
fix: selfBoxIndex must return -1 for pre-JIT script versions

### DIFF
--- a/ergotree-interpreter/src/eval/scontext.rs
+++ b/ergotree-interpreter/src/eval/scontext.rs
@@ -36,6 +36,12 @@ pub(crate) static SELF_BOX_INDEX_EVAL_FN: EvalFn = |_mc, _env, ctx, obj, _args| 
             obj
         )));
     }
+    // JVM bug compatibility: selfBoxIndex always returned -1 before JIT activation
+    // (v5.0, block version 3, activated_script_version >= 2).
+    // See: https://github.com/ScorexFoundation/sigmastate-interpreter/issues/603
+    if ctx.activated_script_version() < ergotree_ir::ergo_tree::ErgoTreeVersion::V2 {
+        return Ok(Value::Int(-1));
+    }
     let box_index = ctx
         .inputs
         .iter()
@@ -140,28 +146,46 @@ mod tests {
     use ergotree_ir::types::stype_param::STypeVar;
     use sigma_test_util::force_any_val;
 
-    fn make_ctx_inputs_includes_self_box() -> Context<'static> {
+    fn make_ctx_inputs_includes_self_box(block_version: u8) -> Context<'static> {
         let ctx = force_any_val::<Context>();
         let self_box = &*Box::leak(Box::new(force_any_val::<ErgoBox>()));
         let inputs = vec![&*Box::leak(Box::new(force_any_val::<ErgoBox>())), self_box]
             .try_into()
             .unwrap();
+        let pre_header = PreHeader {
+            version: block_version,
+            ..ctx.pre_header.clone()
+        };
         Context {
             height: 0u32,
             self_box,
             inputs,
+            pre_header,
             ..ctx
         }
     }
 
     #[test]
-    fn eval_self_box_index() {
+    fn eval_self_box_index_post_jit() {
         let expr: Expr =
             PropertyCall::new(Expr::Context, scontext::SELF_BOX_INDEX_PROPERTY.clone())
                 .unwrap()
                 .into();
-        let context = make_ctx_inputs_includes_self_box();
+        // Block version 3 → activated_script_version = 2 (JIT active)
+        let context = make_ctx_inputs_includes_self_box(3);
         assert_eq!(eval_out::<i32>(&expr, &context), 1);
+    }
+
+    #[test]
+    fn eval_self_box_index_pre_jit() {
+        let expr: Expr =
+            PropertyCall::new(Expr::Context, scontext::SELF_BOX_INDEX_PROPERTY.clone())
+                .unwrap()
+                .into();
+        // Block version 1 → activated_script_version = 0 (pre-JIT)
+        // JVM bug #603: selfBoxIndex always returned -1
+        let context = make_ctx_inputs_includes_self_box(1);
+        assert_eq!(eval_out::<i32>(&expr, &context), -1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `CONTEXT.selfBoxIndex` must return `-1` when `activated_script_version < V2` (pre-JIT), matching the JVM's `CContext.selfBoxIndex` behavior
- Without this fix, sigma-rust rejects valid mainnet blocks (e.g. block 342,964) that contain scripts relying on the pre-JIT behavior
- Adds separate tests for pre-JIT (`-1`) and post-JIT (real index) evaluation

## Context

The JVM sigmastate-interpreter had a known bug ([ScorexFoundation/sigmastate-interpreter#603](https://github.com/ScorexFoundation/sigmastate-interpreter/issues/603)) where `CONTEXT.selfBoxIndex` always returned `-1` before JIT activation (v5.0, block version 3). Scripts deployed during the v4.x era used `R4=SInt(-1)` in output registers to match `selfBoxIndex`. The fix was applied in the JVM with a version check in `CContext.selfBoxIndex`:

```scala
override def selfBoxIndex: Int = {
  if (VersionContext.current.isJitActivated) {
    selfIndex  // fixed in v5.0
  } else {
    -1  // bug in v4.x
  }
}
```

This PR applies the equivalent fix to sigma-rust.

## Test plan

- [x] `eval_self_box_index_post_jit` — block version 3, returns real index (1)
- [x] `eval_self_box_index_pre_jit` — block version 1, returns -1
- [x] Verified against mainnet block 342,964 tx `9302a298...` input[2]

🤖 Generated with [Claude Code](https://claude.com/claude-code)