### PR TITLE
fix: BigInt256 modulo must use mathematical mod, not remainder

### DIFF
--- a/ergotree-ir/src/bigint256.rs
+++ b/ergotree-ir/src/bigint256.rs
@@ -210,7 +210,15 @@ impl CheckedRem for BigInt256 {
         if v.is_negative() {
             return None;
         }
-        self.0.checked_rem(v.0).map(Self)
+        // Use mathematical modulo (always non-negative for positive divisor),
+        // matching JVM BigInteger.mod() semantics.
+        // Rust's checked_rem returns the remainder which can be negative.
+        let rem = self.0.checked_rem(v.0)?;
+        if rem.is_negative() {
+            Some(Self(rem + v.0))
+        } else {
+            Some(Self(rem))
+        }
     }
 }
 


### PR DESCRIPTION
BigInt256::checked_rem uses Rust remainder (%) and returns negative values for negative dividends; ErgoScript's % on BigInt maps to java.math.BigInteger.mod(), which is always non-negative. Mainnet block 670,557: byteArrayToBigInt(boxId.slice(0,15)) % 5 returns JVM 2 vs sigma-rust -3.

Fix only affects BigInt256; primitive int types keep remainder semantics — JVM uses % for those too.
