### PR TITLE
perf: lazy constant resolution in ErgoTree evaluation

### DIFF
--- a/ergo-lib/src/wallet/signing.rs
+++ b/ergo-lib/src/wallet/signing.rs
@@ -112,6 +112,7 @@ pub fn make_context<'ctx, T: ErgoTransaction>(
         headers: state_ctx.headers.clone(),
         tree_version: Default::default(),
         extension_provider: &tx_ctx.spending_tx,
+        constants: None,
     })
 }
 // Updates a Context, changing its self box and context extension to transaction.inputs[i]

--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -479,7 +479,18 @@ pub mod test_util {
         expr: &Expr,
         ctx: &'ctx Context<'ctx>,
     ) -> Result<T, EvalError> {
-        let expr = expr.clone().substitute_deserialize(ctx)?;
+        // Mirror `Interpreter.fullReduction`: a deserialize-bearing segregated
+        // tree is reduced from its constants-substituted proposition, not the
+        // lazy placeholder form used for ordinary trees. Values are identical
+        // either way; the distinction becomes observable once JIT costing
+        // lands (Constant vs ConstantPlaceholder visit costs).
+        let expr = match ctx.constants {
+            Some(constants) if expr.has_deserialize() => {
+                expr.clone().substitute_constants(constants)?
+            }
+            _ => expr.clone(),
+        };
+        let expr = expr.substitute_deserialize(ctx)?;
         try_eval_out(&expr, ctx)
     }
 

--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -581,19 +581,16 @@ mod test {
         use ergotree_ir::ergo_tree::ErgoTreeHeader;
         use ergotree_ir::mir::bool_to_sigma::BoolToSigmaProp;
 
-        let expr: Expr = Expr::BoolToSigmaProp(
-            BoolToSigmaProp {
-                input: Box::new(
-                    BinOp {
-                        kind: BinOpKind::Relation(RelationOp::Eq),
-                        left: Box::new(Expr::Const(1i32.into())),
-                        right: Box::new(Expr::Const(1i32.into())),
-                    }
-                    .into(),
-                ),
-            }
-            .into(),
-        );
+        let expr: Expr = Expr::BoolToSigmaProp(BoolToSigmaProp {
+            input: Box::new(
+                BinOp {
+                    kind: BinOpKind::Relation(RelationOp::Eq),
+                    left: Box::new(Expr::Const(1i32.into())),
+                    right: Box::new(Expr::Const(1i32.into())),
+                }
+                .into(),
+            ),
+        });
         let tree = ErgoTree::new(ErgoTreeHeader::v1(true), &expr).unwrap();
         // Verify this tree actually uses constant segregation
         assert!(

--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -154,35 +154,72 @@ pub fn reduce_to_crypto(tree: &ErgoTree, ctx: &Context) -> Result<ReductionResul
             })
     }
 
-    let expr = tree.proposition()?;
-    let expr = if tree.has_deserialize() {
-        expr.substitute_deserialize(ctx)?
-    } else {
-        expr
-    };
-    let res = inner(&expr, ctx);
-    if let Ok(reduction) = res {
-        if reduction.sigma_prop == SigmaBoolean::TrivialProp(false) {
-            let (_, printed_expr_str) = expr
+    // Deserialize trees need an owned Expr for substitute_deserialize.
+    // This is the rare path — most scripts don't have deserialize nodes.
+    if tree.has_deserialize() {
+        let expr = tree.proposition()?;
+        let expr = expr.substitute_deserialize(ctx)?;
+        let res = inner(&expr, ctx);
+        return match res {
+            Ok(reduction) if reduction.sigma_prop == SigmaBoolean::TrivialProp(false) => {
+                let (_, printed_expr_str) = expr
+                    .pretty_print()
+                    .map_err(|e| EvalError::Misc(e.to_string()))?;
+                Ok(ReductionResult {
+                    sigma_prop: SigmaBoolean::TrivialProp(false),
+                    cost: reduction.cost,
+                    diag: ReductionDiagnosticInfo {
+                        env: reduction.diag.env,
+                        pretty_printed_expr: Some(printed_expr_str),
+                    },
+                })
+            }
+            Ok(reduction) => Ok(reduction),
+            Err(_) => {
+                let (spanned_expr, printed_expr_str) = expr
+                    .pretty_print()
+                    .map_err(|e| EvalError::Misc(e.to_string()))?;
+                inner(&spanned_expr, ctx)
+                    .map_err(|e| e.wrap_spanned_with_src(printed_expr_str.to_string()))
+            }
+        };
+    }
+
+    // Common path: lazy constant resolution — no clone, no tree walk.
+    // ConstPlaceholder nodes are resolved on-demand during evaluation
+    // by looking up ctx.constants[placeholder.id].
+    let root = tree.root_expr()?;
+    let constants = tree.constants()?;
+    let ctx = ctx.with_constants(constants);
+    let res = inner(root, &ctx);
+    match res {
+        Ok(reduction) if reduction.sigma_prop == SigmaBoolean::TrivialProp(false) => {
+            // Diagnostic path: use proposition() for fully-resolved pretty-printing.
+            // This clones, but only on the rare false-reduction diagnostic path.
+            let resolved = tree.proposition()?;
+            let (_, printed_expr_str) = resolved
                 .pretty_print()
                 .map_err(|e| EvalError::Misc(e.to_string()))?;
-            let new_reduction = ReductionResult {
+            Ok(ReductionResult {
                 sigma_prop: SigmaBoolean::TrivialProp(false),
                 cost: reduction.cost,
                 diag: ReductionDiagnosticInfo {
                     env: reduction.diag.env,
                     pretty_printed_expr: Some(printed_expr_str),
                 },
-            };
-            return Ok(new_reduction);
-        } else {
-            return Ok(reduction);
+            })
+        }
+        Ok(reduction) => Ok(reduction),
+        Err(_) => {
+            // Error path: use proposition() for fully-resolved spanned re-evaluation.
+            let resolved = tree.proposition()?;
+            let (spanned_expr, printed_expr_str) = resolved
+                .pretty_print()
+                .map_err(|e| EvalError::Misc(e.to_string()))?;
+            inner(&spanned_expr, &ctx)
+                .map_err(|e| e.wrap_spanned_with_src(printed_expr_str.to_string()))
         }
     }
-    let (spanned_expr, printed_expr_str) = expr
-        .pretty_print()
-        .map_err(|e| EvalError::Misc(e.to_string()))?;
-    inner(&spanned_expr, ctx).map_err(|e| e.wrap_spanned_with_src(printed_expr_str.to_string()))
 }
 
 /// Expects SigmaProp constant value and returns it's value. Otherwise, returns an error.
@@ -536,5 +573,43 @@ mod test {
             v1: 1
         "#]]
         .assert_eq(&res.diag.to_string());
+    }
+
+    #[test]
+    fn reduce_to_crypto_with_constant_segregation() {
+        // Build a simple script: { 1 == 1 } with constant segregation enabled
+        use ergotree_ir::ergo_tree::ErgoTreeHeader;
+        use ergotree_ir::mir::bool_to_sigma::BoolToSigmaProp;
+
+        let expr: Expr = Expr::BoolToSigmaProp(
+            BoolToSigmaProp {
+                input: Box::new(
+                    BinOp {
+                        kind: BinOpKind::Relation(RelationOp::Eq),
+                        left: Box::new(Expr::Const(1i32.into())),
+                        right: Box::new(Expr::Const(1i32.into())),
+                    }
+                    .into(),
+                ),
+            }
+            .into(),
+        );
+        let tree = ErgoTree::new(ErgoTreeHeader::v1(true), &expr).unwrap();
+        // Verify this tree actually uses constant segregation
+        assert!(
+            tree.header().unwrap().is_constant_segregation(),
+            "tree must use constant segregation"
+        );
+        // The root should contain ConstPlaceholder nodes, not Const nodes
+        let root = tree.root_expr().unwrap();
+        let has_placeholders = format!("{:?}", root).contains("ConstPlaceholder");
+        assert!(
+            has_placeholders,
+            "root should contain ConstPlaceholder nodes"
+        );
+
+        let ctx = force_any_val::<Context>();
+        let res = reduce_to_crypto(&tree, &ctx).unwrap();
+        assert_eq!(res.sigma_prop, SigmaBoolean::TrivialProp(true));
     }
 }

--- a/ergotree-interpreter/src/eval/deserialize_context.rs
+++ b/ergotree-interpreter/src/eval/deserialize_context.rs
@@ -148,4 +148,49 @@ mod tests {
             UnsignedBigInt::zero()
         );
     }
+
+    // `Interpreter.fullReduction` reduces a deserialize-bearing SEGREGATED tree
+    // from its constants-substituted proposition, not the lazy placeholder form
+    // it uses for ordinary trees; `try_eval_with_deserialize` mirrors that
+    // conditionality. Values are identical either way — the distinction becomes
+    // observable once JIT costing lands (Constant vs ConstantPlaceholder visit
+    // costs; the costing lineage pins the blessed cost 20 on these trees). This
+    // drives the substituted route end-to-end over the conformance vector trees
+    // `{ if (true) true else deserializeContext[Boolean](0|1) }`, with both
+    // vars bound to valid serialized scripts (this branch substitutes eagerly
+    // over the whole tree, dead branches included).
+    #[test]
+    fn deserialize_bearing_segregated_tree_evals_substituted() {
+        let inner_bytes: Constant = Expr::from(true).sigma_serialize_bytes().unwrap().into();
+        for hex in [
+            "1b0d02010101019573007301d40100", // deserializeContext(0) on the dead branch
+            "1b0d02010101019573007301d40101", // deserializeContext(1) on the dead branch
+        ] {
+            let bytes: Vec<u8> = (0..hex.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+                .collect();
+            // Clear the size bit and drop the size byte (non-SigmaProp root —
+            // the conformance runner's lenient parse path).
+            let mut lenient = Vec::with_capacity(bytes.len() - 1);
+            lenient.push(bytes[0] & !0x08);
+            lenient.extend_from_slice(&bytes[2..]);
+            let tree = ErgoTree::sigma_parse_bytes(&lenient).unwrap();
+
+            let ctx_ext = ContextExtension {
+                values: [(0u8, inner_bytes.clone()), (1u8, inner_bytes.clone())]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            };
+            let mut ctx = force_any_val::<Context>().with_extension(&ctx_ext);
+            ctx.pre_header.version = 4;
+            ctx.tree_version.set(ErgoTreeVersion::V3);
+            let constants = tree.constants().unwrap();
+            let eval_ctx = ctx.with_constants(constants);
+            assert!(
+                try_eval_with_deserialize::<bool>(tree.root_expr().unwrap(), &eval_ctx).unwrap()
+            );
+        }
+    }
 }

--- a/ergotree-interpreter/src/eval/expr.rs
+++ b/ergotree-interpreter/src/eval/expr.rs
@@ -41,9 +41,18 @@ impl Evaluable for Expr {
             Expr::BlockValue(op) => op.expr().eval(env, ctx),
             Expr::SelectField(op) => op.eval(env, ctx),
             Expr::ExtractAmount(op) => op.eval(env, ctx),
-            Expr::ConstPlaceholder(_) => Err(EvalError::UnexpectedExpr(
-                ("ConstPlaceholder is not supported").to_string(),
-            )),
+            Expr::ConstPlaceholder(cp) => {
+                let constant = ctx
+                    .constants
+                    .and_then(|cs| cs.get(cp.id as usize))
+                    .ok_or_else(|| {
+                        EvalError::UnexpectedExpr(format!(
+                            "ConstPlaceholder({}): constant not found",
+                            cp.id
+                        ))
+                    })?;
+                Ok(Value::from(constant.v.clone()))
+            }
             Expr::Collection(op) => op.eval(env, ctx),
             Expr::ValDef(_) => Err(EvalError::UnexpectedExpr(
                 ("ValDef should be evaluated in BlockValue").to_string(),
@@ -105,5 +114,40 @@ impl<T: Evaluable> Evaluable for Spanned<T> {
         ctx: &Context<'ctx>,
     ) -> Result<Value<'ctx>, EvalError> {
         self.expr.eval(env, ctx)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use ergotree_ir::mir::constant::Constant;
+    use ergotree_ir::mir::constant::ConstantPlaceholder;
+    use ergotree_ir::types::stype::SType;
+    use sigma_test_util::force_any_val;
+
+    #[test]
+    fn eval_const_placeholder_with_constants_in_ctx() {
+        let expr = Expr::ConstPlaceholder(ConstantPlaceholder {
+            id: 0,
+            tpe: SType::SInt,
+        });
+        let constants = vec![Constant::from(42i32)];
+        let base_ctx = force_any_val::<Context>();
+        let ctx = base_ctx.with_constants(&constants);
+        let mut env = Env::empty();
+        let result = expr.eval(&mut env, &ctx).unwrap();
+        assert_eq!(result, Value::from(42i32));
+    }
+
+    #[test]
+    fn eval_const_placeholder_without_constants_errors() {
+        let expr = Expr::ConstPlaceholder(ConstantPlaceholder {
+            id: 0,
+            tpe: SType::SInt,
+        });
+        let ctx = force_any_val::<Context>();
+        let mut env = Env::empty();
+        assert!(expr.eval(&mut env, &ctx).is_err());
     }
 }

--- a/ergotree-ir/src/chain/context.rs
+++ b/ergotree-ir/src/chain/context.rs
@@ -2,6 +2,7 @@
 use core::cell::Cell;
 
 use crate::chain::ergo_box::ErgoBox;
+use crate::mir::constant::Constant;
 use crate::{chain::context_extension::ContextExtension, ergo_tree::ErgoTreeVersion};
 use bounded_vec::BoundedVec;
 use ergo_chain_types::{Header, PreHeader};
@@ -33,6 +34,9 @@ pub struct Context<'ctx> {
     /// ContextExtension provider for inputs of transaction
     #[debug(skip)]
     pub extension_provider: &'ctx dyn ContextExtensionProvider,
+    /// Constants from ErgoTree for lazy ConstPlaceholder resolution during evaluation.
+    /// None when constants were already substituted (e.g. via proposition()).
+    pub constants: Option<&'ctx [Constant]>,
 }
 
 impl<'ctx> Context<'ctx> {
@@ -50,6 +54,19 @@ impl<'ctx> Context<'ctx> {
     /// Version of ergotree being evaluated under context
     pub fn tree_version(&self) -> ErgoTreeVersion {
         self.tree_version.get()
+    }
+
+    /// Create a copy of this context with constants set for lazy ConstPlaceholder resolution.
+    /// The returned Context may have a shorter lifetime 'a to accommodate
+    /// the constants reference alongside the existing borrowed fields.
+    pub fn with_constants<'a>(&self, constants: &'a [Constant]) -> Context<'a>
+    where
+        'ctx: 'a,
+    {
+        Context {
+            constants: Some(constants),
+            ..self.clone()
+        }
     }
 }
 
@@ -126,6 +143,7 @@ pub mod arbitrary {
                             extension_provider: Box::leak(
                                 DummyContextExtensionProvider(extensions).into(),
                             ),
+                            constants: None,
                         }
                     },
                 )

--- a/ergotree-ir/src/ergo_tree.rs
+++ b/ergotree-ir/src/ergo_tree.rs
@@ -238,6 +238,19 @@ impl ErgoTree {
         }
     }
 
+    /// Returns a reference to the root expression without cloning or substituting constants.
+    /// Use this with [`Context::with_constants`] for lazy ConstPlaceholder resolution
+    /// during evaluation, avoiding the deep clone that [`proposition`](Self::proposition) performs.
+    pub fn root_expr(&self) -> Result<&Expr, ErgoTreeError> {
+        Ok(&self.parsed_tree()?.root)
+    }
+
+    /// Returns a reference to the segregated constants array.
+    /// Empty when the tree does not use constant segregation.
+    pub fn constants(&self) -> Result<&[Constant], ErgoTreeError> {
+        Ok(&self.parsed_tree()?.constants)
+    }
+
     /// Check if ErgoTree root has [`crate::mir::deserialize_context::DeserializeContext`] or [`crate::mir::deserialize_register::DeserializeRegister`] nodes
     pub fn has_deserialize(&self) -> bool {
         match self {

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -394,7 +394,7 @@ impl Expr {
     }
 
     /// Returns true if the [`Expr`] has deserialize nodes, see: [`DeserializeContext`] and [`DeserializeRegister`]
-    pub(crate) fn has_deserialize(&self) -> bool {
+    pub fn has_deserialize(&self) -> bool {
         self.iter().any(|c| {
             matches!(
                 c,


### PR DESCRIPTION
Resolve ConstPlaceholder from the eval context on demand instead of deep-cloning the AST via proposition() each reduce_to_crypto call. Mainnet-sync profiling in ergo-node-rust showed the per-input clone-and-substitute was 8-12% of total CPU.

Adds root_expr() / constants() accessors and Context::with_constants(). Deserialize trees fall back to proposition() (incompatible with lazy resolution). proposition() itself unchanged.

Beware of conflicts with #854, see comments below