### PR TITLE
fix: accept SOption(T) where T expected in check_post_eval_tpe

### DIFF
--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -321,24 +321,47 @@ impl Expr {
         }
     }
 
-    /// Check if given expected_tpe type is the same as the expression's post-evaluation type
+    /// Check that the expression's post-evaluation type is compatible with the
+    /// expected type.
+    ///
+    /// Strict equality is the primary acceptance rule. As a parse-time leniency,
+    /// `SOption(T)` is also accepted where `T` is expected — this matches the
+    /// JVM v6.0.3 sigmastate-interpreter, whose
+    /// `OneArgumentOperationSerializer.parse` uses an unchecked `asValue[T]`
+    /// cast and performs no type validation when deserializing. Real on-chain
+    /// scripts trigger this case by passing `getVar[T](id)` (post-eval type
+    /// `SOption(T)`) directly into a combinator that statically expects `T` —
+    /// most commonly `blake2b256` / `sha256` / `byteArrayToBigInt` /
+    /// `byteArrayToLong` of `getVar[Coll[Byte]](id)` without an explicit
+    /// `.get`. Such scripts are accepted by the JVM at parse time and would
+    /// fail at evaluation time only if actually executed (our evaluator's
+    /// `EvalError::UnexpectedValue` arm matches the JVM runtime failure).
+    /// Without this leniency sigma-rust would reject txs the JVM accepts and
+    /// ergo-node-rust would diverge from consensus.
+    ///
+    /// See: mainnet block 1,711,120 tx[1] output[0] for a real-world reproducer
+    /// (`parse_block_1711120_output0` in `serialization::expr::tests`).
     pub fn check_post_eval_tpe(
         &self,
         expected_tpe: &SType,
     ) -> Result<(), InvalidExprEvalTypeError> {
         let expr_tpe = self.post_eval_tpe();
         if &expr_tpe == expected_tpe {
-            Ok(())
-        } else {
-            #[cfg(feature = "std")]
-            let backtrace = std::backtrace::Backtrace::capture();
-            #[cfg(not(feature = "std"))]
-            let backtrace = "Backtraces not supported without std";
-            Err(InvalidExprEvalTypeError(format!(
-                "expected: {0:?}, got: {1:?}\nBacktrace:\n{backtrace}",
-                expected_tpe, expr_tpe
-            )))
+            return Ok(());
         }
+        if let SType::SOption(inner) = &expr_tpe {
+            if inner.as_ref() == expected_tpe {
+                return Ok(());
+            }
+        }
+        #[cfg(feature = "std")]
+        let backtrace = std::backtrace::Backtrace::capture();
+        #[cfg(not(feature = "std"))]
+        let backtrace = "Backtraces not supported without std";
+        Err(InvalidExprEvalTypeError(format!(
+            "expected: {0:?}, got: {1:?}\nBacktrace:\n{backtrace}",
+            expected_tpe, expr_tpe
+        )))
     }
 
     /// Rewrite tree bottom-up, matching nodes that satisfy `rule` and applying `subst` to them

--- a/ergotree-ir/src/serialization/expr.rs
+++ b/ergotree-ir/src/serialization/expr.rs
@@ -350,11 +350,9 @@ mod tests {
         use crate::ergo_tree::ErgoTree;
         let hex = "00ea02d193b4cbe3010e040004300e183092aafc2966e1c791f619b14b084b26d41825661c6c040bd40801";
         let bytes = base16::decode(hex).unwrap();
-        let tree = ErgoTree::sigma_parse_bytes(&bytes)
-            .expect("output[0] of block 1,711,120 tx[1] must parse");
-        let reser = tree
-            .sigma_serialize_bytes()
-            .expect("output[0] must reserialize");
+        let tree = ErgoTree::sigma_parse_bytes(&bytes).unwrap();
+        // Round-trip: serialized bytes must match the input exactly.
+        let reser = tree.sigma_serialize_bytes().unwrap();
         assert_eq!(reser, bytes, "round-trip bytes must be identical");
     }
 
@@ -367,11 +365,8 @@ mod tests {
         use crate::ergo_tree::ErgoTree;
         let hex = "1005040004000e36100204a00b08cd0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ea02d192a39a8cc7a701730073011001020402d19683030193a38cc7b2a57300000193c2b2a57301007473027303830108cdeeac93b1a57304";
         let bytes = base16::decode(hex).unwrap();
-        let tree = ErgoTree::sigma_parse_bytes(&bytes)
-            .expect("output[2] of block 1,711,120 tx[1] must parse");
-        let reser = tree
-            .sigma_serialize_bytes()
-            .expect("output[2] must reserialize");
+        let tree = ErgoTree::sigma_parse_bytes(&bytes).unwrap();
+        let reser = tree.sigma_serialize_bytes().unwrap();
         assert_eq!(reser, bytes, "round-trip bytes must be identical");
     }
 

--- a/ergotree-ir/src/serialization/expr.rs
+++ b/ergotree-ir/src/serialization/expr.rs
@@ -337,6 +337,44 @@ mod tests {
         assert_eq!(sigma_serialize_roundtrip(&e), e);
     }
 
+    /// Regression test for ergo-node-rust mainnet sync failure at block 1,711,120 tx[1]
+    /// (`dce90de114a7d36cb2dd724c04ccc11b461a02bd2a783ef820234046cb47ff2c`,
+    /// block id `bcfb89f0d7c3c6c3f13d885e037c79e349a1ffa37301cb899a1a24c8f47ba49f`).
+    /// `output[0]` uses `blake2b256(getVar[Coll[Byte]](1))` directly (no `.get`),
+    /// which the JVM v6.0.3 reference node parses cleanly because its
+    /// `OneArgumentOperationSerializer` does an unchecked `asValue[T]` cast at parse
+    /// time. sigma-rust must match that leniency at parse time; runtime behavior
+    /// (`EvalError::UnexpectedValue`) stays the same.
+    #[test]
+    fn parse_block_1711120_output0() {
+        use crate::ergo_tree::ErgoTree;
+        let hex = "00ea02d193b4cbe3010e040004300e183092aafc2966e1c791f619b14b084b26d41825661c6c040bd40801";
+        let bytes = base16::decode(hex).unwrap();
+        let tree = ErgoTree::sigma_parse_bytes(&bytes)
+            .expect("output[0] of block 1,711,120 tx[1] must parse");
+        let reser = tree
+            .sigma_serialize_bytes()
+            .expect("output[0] must reserialize");
+        assert_eq!(reser, bytes, "round-trip bytes must be identical");
+    }
+
+    /// Companion regression for `output[2]` of the same tx. This box has the
+    /// constant-segregation header (`0x10`) and uses `0xea` (SIGMA_AND) deeper in the
+    /// tree body. Already passes today, but pinned here so a future regression that
+    /// only breaks `output[0]` is caught alongside one that breaks `output[2]`.
+    #[test]
+    fn parse_block_1711120_output2() {
+        use crate::ergo_tree::ErgoTree;
+        let hex = "1005040004000e36100204a00b08cd0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798ea02d192a39a8cc7a701730073011001020402d19683030193a38cc7b2a57300000193c2b2a57301007473027303830108cdeeac93b1a57304";
+        let bytes = base16::decode(hex).unwrap();
+        let tree = ErgoTree::sigma_parse_bytes(&bytes)
+            .expect("output[2] of block 1,711,120 tx[1] must parse");
+        let reser = tree
+            .sigma_serialize_bytes()
+            .expect("output[2] must reserialize");
+        assert_eq!(reser, bytes, "round-trip bytes must be identical");
+    }
+
     proptest! {
 
         #[test]


### PR DESCRIPTION
Widens Expr::check_post_eval_tpe to accept SOption(T) where T is expected — matches JVM OneArgumentOperationSerializer.parse's unchecked asValue[T] cast. Without this, sigma-rust rejects mainnet block 1,711,120 tx dce9…ff2c (uses blake2b256(getVar[Coll[Byte]](1)) without .get).

Eval-time type check unchanged — UnexpectedValue still fires at runtime if the var is missing.
