### PR TITLE
Reject CThreshold parsing when k > 255

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ getrandom = { version = "0.2.16" }
 itertools = { version = "0.14", default-features = false }
 miette = { version = "7.6.0", features = ["fancy"] }
 hashbrown = { version = "0.16.1", features = ["serde"] }
-core2 = { version = "0.4.0", default-features = false, features = ["alloc"] }
+no_std_io2 = { version = "0.9.4", default-features = false, features = ["alloc"] }
 # dev-dependencies
 proptest = { version = "=1.6.0", default-features = false, features = [
     "alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ getrandom = { version = "0.2.16" }
 itertools = { version = "0.14", default-features = false }
 miette = { version = "7.6.0", features = ["fancy"] }
 hashbrown = { version = "0.16.1", features = ["serde"] }
-no_std_io2 = { version = "0.9.4", default-features = false, features = ["alloc"] }
+no_std_io2 = { git = "https://github.com/ergoplatform/no-std-io2", rev = "68dbe54373c7d884b7a8a2e02fb0b734dbd590cc", default-features = false, features = ["alloc"] }
 # dev-dependencies
 proptest = { version = "=1.6.0", default-features = false, features = [
     "alloc",

--- a/ergo-chain-types/Cargo.toml
+++ b/ergo-chain-types/Cargo.toml
@@ -26,7 +26,7 @@ serde_with = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 num-traits = { workspace = true }
-core2 = { workspace = true }
+no_std_io2 = { workspace = true }
 
 [features]
 default = ["std", "json"]

--- a/ergo-chain-types/src/header.rs
+++ b/ergo-chain-types/src/header.rs
@@ -5,7 +5,7 @@ use crate::autolykos_pow_scheme::{
 use crate::{ADDigest, BlockId, Digest32, EcPoint};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core2::io::Write;
+use no_std_io2::io::Write;
 use num_bigint::{BigUint, ToBigInt};
 use sigma_ser::vlq_encode::{ReadSigmaVlqExt, WriteSigmaVlqExt};
 use sigma_ser::{

--- a/ergotree-interpreter/Cargo.toml
+++ b/ergotree-interpreter/Cargo.toml
@@ -38,7 +38,7 @@ ergo_avltree_rust = { version = "0.1.1" }
 gf2_192 = { version = "^0.28.0", path = "../gf2_192" }
 miette = { workspace = true, optional = true }
 hashbrown = { workspace = true }
-core2 = { workspace = true }
+no_std_io2 = { workspace = true }
 sigma-test-util = { workspace = true, optional = true }
 
 generic-array = "=0.14.7" #TODO: unpin this when k256 and elliptic-curve upgrade to generic-array 1.0 and remove the deprecation warnings

--- a/ergotree-interpreter/src/sigma_protocol/challenge.rs
+++ b/ergotree-interpreter/src/sigma_protocol/challenge.rs
@@ -37,12 +37,15 @@ impl Challenge {
         FiatShamirHash::try_from(res.as_slice()).unwrap().into()
     }
 
-    pub fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> Result<(), core2::io::Error> {
+    pub fn sigma_serialize<W: SigmaByteWrite>(
+        &self,
+        w: &mut W,
+    ) -> Result<(), no_std_io2::io::Error> {
         w.write_all(self.0 .0.as_ref())?;
         Ok(())
     }
 
-    pub fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, core2::io::Error> {
+    pub fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, no_std_io2::io::Error> {
         let mut chal_bytes: [u8; super::SOUNDNESS_BYTES] = [0; super::SOUNDNESS_BYTES];
         r.read_exact(&mut chal_bytes)?;
         Ok(Challenge::from(FiatShamirHash(Box::new(chal_bytes))))

--- a/ergotree-interpreter/src/sigma_protocol/fiat_shamir.rs
+++ b/ergotree-interpreter/src/sigma_protocol/fiat_shamir.rs
@@ -130,8 +130,8 @@ pub enum FiatShamirTreeSerializationError {
     IoError(String),
 }
 
-impl From<core2::io::Error> for FiatShamirTreeSerializationError {
-    fn from(error: core2::io::Error) -> FiatShamirTreeSerializationError {
+impl From<no_std_io2::io::Error> for FiatShamirTreeSerializationError {
+    fn from(error: no_std_io2::io::Error) -> FiatShamirTreeSerializationError {
         FiatShamirTreeSerializationError::IoError(error.to_string())
     }
 }

--- a/ergotree-interpreter/src/sigma_protocol/sig_serializer.rs
+++ b/ergotree-interpreter/src/sigma_protocol/sig_serializer.rs
@@ -49,7 +49,7 @@ fn sig_write_bytes<W: SigmaByteWrite>(
     node: &UncheckedTree,
     w: &mut W,
     write_challenges: bool,
-) -> Result<(), core2::io::Error> {
+) -> Result<(), no_std_io2::io::Error> {
     if write_challenges {
         node.challenge().sigma_serialize(w)?;
     }
@@ -289,7 +289,7 @@ pub enum SigParsingError {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use core2::io::Cursor;
+    use no_std_io2::io::Cursor;
 
     use ergotree_ir::serialization::{
         constant_store::ConstantStore, sigma_byte_reader::SigmaByteReader,

--- a/ergotree-ir/Cargo.toml
+++ b/ergotree-ir/Cargo.toml
@@ -39,7 +39,7 @@ strum = { version = "0.27.2", default-features = false, features = ["derive"] }
 strum_macros = { version = "0.27.2", default-features = false }
 miette = { workspace = true, optional = true }
 hashbrown = { workspace = true }
-core2 = { workspace = true }
+no_std_io2 = { workspace = true }
 foldhash = { version = "0.2.0", default-features = false }
 [features]
 default = ["json", "std"]
@@ -52,7 +52,7 @@ json = [
     "ergo-chain-types/json",
     "indexmap/serde",
 ]
-std = ["core2/std", "dep:miette", "ergo-chain-types/std", "sigma-ser/std"]
+std = ["no_std_io2/std", "dep:miette", "ergo-chain-types/std", "sigma-ser/std"]
 
 [dev-dependencies]
 sigma-test-util = { workspace = true }

--- a/ergotree-ir/src/ergo_tree.rs
+++ b/ergotree-ir/src/ergo_tree.rs
@@ -20,9 +20,9 @@ use sigma_ser::vlq_encode::WriteSigmaVlqExt;
 
 use crate::serialization::constant_store::ConstantStore;
 use core::convert::TryFrom;
-use core2::io;
 use derive_more::From;
 use io::Cursor;
+use no_std_io2::io;
 #[cfg(feature = "std")]
 use std::sync::OnceLock;
 use thiserror::Error;
@@ -440,8 +440,8 @@ impl TryFrom<ErgoTree> for ProveDlog {
     }
 }
 
-impl From<core2::io::Error> for ErgoTreeError {
-    fn from(e: core2::io::Error) -> Self {
+impl From<no_std_io2::io::Error> for ErgoTreeError {
+    fn from(e: no_std_io2::io::Error) -> Self {
         ErgoTreeError::IoError(e.to_string())
     }
 }

--- a/ergotree-ir/src/ergo_tree/tree_header.rs
+++ b/ergotree-ir/src/ergo_tree/tree_header.rs
@@ -33,7 +33,10 @@ pub struct ErgoTreeHeader {
 
 impl ErgoTreeHeader {
     /// Serialization
-    pub fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> Result<(), core2::io::Error> {
+    pub fn sigma_serialize<W: SigmaByteWrite>(
+        &self,
+        w: &mut W,
+    ) -> Result<(), no_std_io2::io::Error> {
         w.put_u8(self.serialized())
     }
     /// Deserialization

--- a/ergotree-ir/src/mir/val_def.rs
+++ b/ergotree-ir/src/mir/val_def.rs
@@ -24,7 +24,10 @@ use proptest_derive::Arbitrary;
 pub struct ValId(pub u32);
 
 impl ValId {
-    pub(crate) fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> core2::io::Result<()> {
+    pub(crate) fn sigma_serialize<W: SigmaByteWrite>(
+        &self,
+        w: &mut W,
+    ) -> no_std_io2::io::Result<()> {
         w.put_u32(self.0)
     }
 

--- a/ergotree-ir/src/serialization/constant_placeholder.rs
+++ b/ergotree-ir/src/serialization/constant_placeholder.rs
@@ -38,7 +38,7 @@ mod tests {
     };
 
     use alloc::vec::Vec;
-    use core2::io::Cursor;
+    use no_std_io2::io::Cursor;
     use proptest::prelude::*;
 
     proptest! {

--- a/ergotree-ir/src/serialization/serializable.rs
+++ b/ergotree-ir/src/serialization/serializable.rs
@@ -18,8 +18,8 @@ use alloc::vec::Vec;
 use bounded_vec::BoundedVec;
 use bounded_vec::BoundedVecOutOfBounds;
 use core::convert::TryInto;
-use core2::io;
 use io::Cursor;
+use no_std_io2::io;
 use sigma_ser::{vlq_encode, ScorexParsingError, ScorexSerializationError};
 use thiserror::Error;
 

--- a/ergotree-ir/src/serialization/sigma_byte_reader.rs
+++ b/ergotree-ir/src/serialization/sigma_byte_reader.rs
@@ -3,9 +3,9 @@ use crate::ergo_tree::ErgoTreeVersion;
 
 use super::constant_store::ConstantStore;
 use super::val_def_type_store::ValDefTypeStore;
-use core2::io::Cursor;
-use core2::io::Read;
-use core2::io::Seek;
+use no_std_io2::io::Cursor;
+use no_std_io2::io::Read;
+use no_std_io2::io::Seek;
 use sigma_ser::vlq_encode::ReadSigmaVlqExt;
 
 /// Implementation of SigmaByteRead
@@ -74,14 +74,14 @@ pub trait SigmaByteRead: ReadSigmaVlqExt {
     fn set_deserialize(&mut self, has_deserialize: bool);
 
     /// Get position of reader in buffer. This is functionally equivalent to [`std::io::Seek::stream_position`] but redefined here so it can be used in no_std contexts
-    fn position(&mut self) -> core2::io::Result<u64> {
+    fn position(&mut self) -> no_std_io2::io::Result<u64> {
         #[cfg(feature = "std")]
         {
             <Self as Seek>::stream_position(self)
         }
         #[cfg(not(feature = "std"))]
         {
-            self.seek(core2::io::SeekFrom::Current(0))
+            self.seek(no_std_io2::io::SeekFrom::Current(0))
         }
     }
 
@@ -97,23 +97,23 @@ pub trait SigmaByteRead: ReadSigmaVlqExt {
 }
 
 impl<R: Read> Read for SigmaByteReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> core2::io::Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> no_std_io2::io::Result<usize> {
         self.inner.read(buf)
     }
 }
 
 impl<R: Seek> Seek for SigmaByteReader<R> {
-    fn seek(&mut self, pos: core2::io::SeekFrom) -> core2::io::Result<u64> {
+    fn seek(&mut self, pos: no_std_io2::io::SeekFrom) -> no_std_io2::io::Result<u64> {
         self.inner.seek(pos)
     }
 
     #[cfg(feature = "std")]
-    fn rewind(&mut self) -> core2::io::Result<()> {
+    fn rewind(&mut self) -> no_std_io2::io::Result<()> {
         self.inner.rewind()
     }
 
     #[cfg(feature = "std")]
-    fn stream_position(&mut self) -> core2::io::Result<u64> {
+    fn stream_position(&mut self) -> no_std_io2::io::Result<u64> {
         self.inner.stream_position()
     }
 }

--- a/ergotree-ir/src/serialization/sigma_byte_writer.rs
+++ b/ergotree-ir/src/serialization/sigma_byte_writer.rs
@@ -2,7 +2,7 @@
 use crate::ergo_tree::ErgoTreeVersion;
 
 use super::constant_store::ConstantStore;
-use core2::io::Write;
+use no_std_io2::io::Write;
 use sigma_ser::vlq_encode::WriteSigmaVlqExt;
 
 /// Implementation for SigmaByteWrite
@@ -39,11 +39,11 @@ pub trait SigmaByteWrite: WriteSigmaVlqExt {
 }
 
 impl<'a, W: Write> Write for SigmaByteWriter<'a, W> {
-    fn write(&mut self, buf: &[u8]) -> core2::io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> no_std_io2::io::Result<usize> {
         self.inner.write(buf)
     }
 
-    fn flush(&mut self) -> core2::io::Result<()> {
+    fn flush(&mut self) -> no_std_io2::io::Result<()> {
         self.inner.flush()
     }
 }

--- a/ergotree-ir/src/sigma_protocol/sigma_boolean/cthreshold.rs
+++ b/ergotree-ir/src/sigma_protocol/sigma_boolean/cthreshold.rs
@@ -113,7 +113,9 @@ impl SigmaSerializable for Cthreshold {
     }
 
     fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> Result<Self, SigmaParsingError> {
-        let k = r.get_u16()? as u8; // safe because we serialized u8 as u16
+        let k_u16 = r.get_u16()?;
+        let k = u8::try_from(k_u16)
+            .map_err(|_| SigmaParsingError::Misc(format!("Cthreshold k={k_u16} exceeds 255")))?;
         let items_count = r.get_u16()?;
         let mut items = Vec::with_capacity(items_count as usize);
         for _ in 0..items_count {
@@ -123,5 +125,22 @@ impl SigmaSerializable for Cthreshold {
             k,
             children: items.try_into()?,
         })
+    }
+}
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::serialization::{sigma_byte_writer::SigmaByteWriter, SigmaSerializable};
+    use sigma_ser::vlq_encode::WriteSigmaVlqExt;
+
+    #[test]
+    fn k_above_255() {
+        let mut data = Vec::new();
+        let mut w = SigmaByteWriter::new(&mut data, None);
+        w.put_u16(300).unwrap();
+        w.put_u16(0).unwrap();
+        let err = Cthreshold::sigma_parse_bytes(&data).unwrap_err();
+        assert!(matches!(err, SigmaParsingError::Misc(ref msg) if msg.contains("k=300")),);
     }
 }

--- a/ergotree-ir/src/types/smethod.rs
+++ b/ergotree-ir/src/types/smethod.rs
@@ -22,11 +22,14 @@ use crate::serialization::SigmaParsingError::UnknownMethodId;
 pub struct MethodId(pub u8);
 
 impl MethodId {
-    pub(crate) fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> core2::io::Result<()> {
+    pub(crate) fn sigma_serialize<W: SigmaByteWrite>(
+        &self,
+        w: &mut W,
+    ) -> no_std_io2::io::Result<()> {
         w.put_u8(self.0)
     }
 
-    pub(crate) fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> core2::io::Result<Self> {
+    pub(crate) fn sigma_parse<R: SigmaByteRead>(r: &mut R) -> no_std_io2::io::Result<Self> {
         Ok(Self(r.get_u8()?))
     }
 }

--- a/sigma-ser/Cargo.toml
+++ b/sigma-ser/Cargo.toml
@@ -9,13 +9,13 @@ description = "Ergo binary serialization primitives"
 
 [features]
 default = ["std"]
-std = ["core2/std"]
+std = ["no_std_io2/std"]
 
 [dependencies]
 thiserror = { workspace = true }
 bitvec = { workspace = true }
 bounded-vec = { workspace = true }
-core2 = { workspace = true }
+no_std_io2 = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/sigma-ser/src/scorex_serialize.rs
+++ b/sigma-ser/src/scorex_serialize.rs
@@ -3,8 +3,8 @@ use alloc::string::ToString;
 use alloc::vec::Vec;
 use alloc::{string::String, vec};
 use core::convert::TryInto;
-use core2::io;
-use core2::io::Cursor;
+use no_std_io2::io;
+use no_std_io2::io::Cursor;
 
 use crate::vlq_encode;
 use crate::vlq_encode::*;

--- a/sigma-ser/src/vlq_encode.rs
+++ b/sigma-ser/src/vlq_encode.rs
@@ -5,7 +5,7 @@ use alloc::{
     vec::Vec,
 };
 use core::convert::TryFrom;
-use core2::io;
+use no_std_io2::io;
 
 use bitvec::order::Lsb0;
 use bitvec::prelude::BitVec;
@@ -276,9 +276,9 @@ mod tests {
     use super::*;
     use alloc::format;
     use alloc::vec;
-    use core2::io::Cursor;
-    use core2::io::Read;
-    use core2::io::Write;
+    use no_std_io2::io::Cursor;
+    use no_std_io2::io::Read;
+    use no_std_io2::io::Write;
     use proptest::collection;
 
     extern crate derive_more;


### PR DESCRIPTION
k was cast from u16 to u8 without a bounds check, so a wire value of
k > 255 would be silently accepted with a truncated threshold (e.g.
k=300 becomes k=44).

Return a parsing error if k exceeds 255, matching
sigmastate-interpreter's require(k <= children.length <= 255) check.

LLM disclosure: I used Claude to review the parsing implementations in Rust. It's found some interesting differences so far, this is one of them. I'm currently reviewing some of the other issues it has discovered.

Depends on #863 to get CI working
