### PR TITLE
fix(interpreter): wrap Resolver closures in Arc::new for upstream API change

### DIFF
--- a/ergotree-interpreter/src/eval/create_avl_tree.rs
+++ b/ergotree-interpreter/src/eval/create_avl_tree.rs
@@ -50,9 +50,11 @@ mod tests {
     use super::*;
     use crate::eval::test_util::eval_out_wo_ctx;
 
+    use alloc::sync::Arc;
     use ergo_avltree_rust::authenticated_tree_ops::AuthenticatedTreeOps;
     use ergo_avltree_rust::batch_avl_prover::BatchAVLProver;
     use ergo_avltree_rust::batch_node::{AVLTree, Node, NodeHeader};
+    use ergo_avltree_rust::operation::Digest32;
     use ergo_chain_types::ADDigest;
     use ergotree_ir::mir::{
         avl_tree_data::{AvlTreeData, AvlTreeFlags},
@@ -64,7 +66,7 @@ mod tests {
     fn eval_create_avl_tree() {
         let prover = BatchAVLProver::new(
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 1,
                 None,
             ),

--- a/ergotree-interpreter/src/eval/savltree.rs
+++ b/ergotree-interpreter/src/eval/savltree.rs
@@ -11,6 +11,7 @@ use ergo_avltree_rust::batch_avl_verifier::BatchAVLVerifier;
 use ergo_avltree_rust::batch_node::AVLTree;
 use ergo_avltree_rust::batch_node::Node;
 use ergo_avltree_rust::batch_node::NodeHeader;
+use ergo_avltree_rust::operation::Digest32;
 use ergo_avltree_rust::operation::KeyValue;
 use ergo_avltree_rust::operation::Operation;
 use ergo_chain_types::ADDigest;
@@ -113,7 +114,7 @@ pub(crate) static GET_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, args| {
         &starting_digest,
         &proof,
         AVLTree::new(
-            |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+            Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
             avl_tree_data.key_length as usize,
             avl_tree_data
                 .value_length_opt
@@ -161,7 +162,7 @@ pub(crate) static GET_MANY_EVAL_FN: EvalFn =
             &starting_digest,
             &proof,
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 avl_tree_data.key_length as usize,
                 avl_tree_data
                     .value_length_opt
@@ -228,7 +229,7 @@ pub(crate) static INSERT_EVAL_FN: EvalFn =
             &starting_digest,
             &proof,
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 avl_tree_data.key_length as usize,
                 avl_tree_data
                     .value_length_opt
@@ -293,7 +294,7 @@ pub(crate) static REMOVE_EVAL_FN: EvalFn =
             &starting_digest,
             &proof,
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 avl_tree_data.key_length as usize,
                 avl_tree_data
                     .value_length_opt
@@ -349,7 +350,7 @@ pub(crate) static CONTAINS_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, args| {
         &starting_digest,
         &proof,
         AVLTree::new(
-            |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+            Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
             avl_tree_data.key_length as usize,
             avl_tree_data
                 .value_length_opt
@@ -397,7 +398,7 @@ pub(crate) static UPDATE_EVAL_FN: EvalFn =
             &starting_digest,
             &proof,
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 avl_tree_data.key_length as usize,
                 avl_tree_data
                     .value_length_opt
@@ -456,7 +457,7 @@ pub(crate) static INSERT_OR_UPDATE_EVAL_FN: EvalFn = |_mc, _env, _ctx, obj, args
         &starting_digest,
         &proof,
         AVLTree::new(
-            |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+            Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
             avl_tree_data.key_length as usize,
             avl_tree_data
                 .value_length_opt
@@ -666,7 +667,7 @@ mod tests {
         // This example taken from `ergo_avltree_rust` README
         let mut prover = BatchAVLProver::new(
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 1,
                 None,
             ),
@@ -772,7 +773,7 @@ mod tests {
     fn eval_avl_insert_or_update() {
         let mut prover = BatchAVLProver::new(
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 1,
                 None,
             ),
@@ -1188,7 +1189,7 @@ mod tests {
     fn populate_tree(entries: Vec<(Vec<u8>, Vec<u8>)>) -> BatchAVLProver {
         let mut prover = BatchAVLProver::new(
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 1,
                 None,
             ),

--- a/ergotree-interpreter/src/eval/tree_lookup.rs
+++ b/ergotree-interpreter/src/eval/tree_lookup.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use bytes::Bytes;
 use ergotree_ir::mir::tree_lookup::TreeLookup;
@@ -10,6 +11,7 @@ use crate::eval::EvalError;
 use crate::eval::Evaluable;
 use ergo_avltree_rust::batch_avl_verifier::BatchAVLVerifier;
 use ergo_avltree_rust::batch_node::{AVLTree, Node, NodeHeader};
+use ergo_avltree_rust::operation::Digest32;
 use ergo_avltree_rust::operation::Operation;
 use ergotree_ir::mir::avl_tree_data::AvlTreeData;
 use ergotree_ir::mir::constant::TryExtractInto;
@@ -35,7 +37,7 @@ impl Evaluable for TreeLookup {
             &starting_digest,
             &proof,
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 normalized_tree_val.key_length as usize,
                 normalized_tree_val
                     .value_length_opt
@@ -151,7 +153,7 @@ mod tests {
     fn populate_tree(entries: Vec<(Vec<u8>, Vec<u8>)>) -> BatchAVLProver {
         let mut prover = BatchAVLProver::new(
             AVLTree::new(
-                |digest| Node::LabelOnly(NodeHeader::new(Some(*digest), None)),
+                Arc::new(|digest: &Digest32| Node::LabelOnly(NodeHeader::new(Some(*digest), None))),
                 1,
                 None,
             ),


### PR DESCRIPTION
Adapts the 13 AVLTree::new call sites in ergotree-interpreter (savltree.rs, tree_lookup.rs, create_avl_tree.rs) from bare fn closure to Arc::new(...), matching the Resolver type change in ergoplatform/ergo_avltree_rust#10. Arc not Box because AVLTree: Clone.

Draft. Blocked on #10 merge + ergo_avltree_rust version bump. Locally validated on integration/ergots via [patch.crates-io].
