### PR TITLE
fix(nipopow): pack_interlinks key encoding — use first-occurrence position

### DIFF
--- a/ergo-nipopow/src/nipopow_algos.rs
+++ b/ergo-nipopow/src/nipopow_algos.rs
@@ -348,3 +348,45 @@ fn extension_merkletree(kv: &[([u8; 2], Vec<u8>)]) -> ergo_merkle_tree::MerkleTr
         .collect::<Vec<ergo_merkle_tree::MerkleNode>>();
     ergo_merkle_tree::MerkleTree::new(leafs)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blockid(byte: u8) -> BlockId {
+        BlockId(Digest32::from([byte; 32]))
+    }
+
+    #[test]
+    fn pack_interlinks_keys_are_first_occurrence_positions() {
+        // JVM Ergo encodes ExtensionKV keys as [INTERLINK_VECTOR_PREFIX, pos_of_first_occurrence]
+        // where pos is the index of the first interlink in each duplicate-run within the input
+        // vector. Verified against mainnet block 1784124 (11/11 leaf hashes match with this
+        // encoding; 2/11 with the prior sequential distinct_ix counter).
+        let a = blockid(0xa0);
+        let b = blockid(0xb0);
+        let c = blockid(0xc0);
+        let d = blockid(0xd0);
+        // [A, B, B, B, B, C, D] — positions 0, 1..4 (run), 5, 6
+        let interlinks = vec![a, b, b, b, b, c, d];
+
+        let packed = NipopowAlgos::pack_interlinks(interlinks);
+
+        assert_eq!(packed.len(), 4);
+        assert_eq!(packed[0].0, [INTERLINK_VECTOR_PREFIX, 0]);
+        assert_eq!(packed[1].0, [INTERLINK_VECTOR_PREFIX, 1]);
+        assert_eq!(packed[2].0, [INTERLINK_VECTOR_PREFIX, 5]);
+        assert_eq!(packed[3].0, [INTERLINK_VECTOR_PREFIX, 6]);
+
+        assert_eq!(packed[0].1[0], 1);
+        assert_eq!(packed[1].1[0], 4);
+        assert_eq!(packed[2].1[0], 1);
+        assert_eq!(packed[3].1[0], 1);
+    }
+
+    #[test]
+    fn pack_interlinks_empty_returns_empty() {
+        let packed = NipopowAlgos::pack_interlinks(vec![]);
+        assert!(packed.is_empty());
+    }
+}

--- a/ergo-nipopow/src/nipopow_algos.rs
+++ b/ergo-nipopow/src/nipopow_algos.rs
@@ -196,36 +196,48 @@ impl NipopowAlgos {
         NipopowProof::new(m, k, prefix, suffix_head, suffix_tail)
     }
     /// Packs interlinks into key-value format of the block extension.
+    ///
+    /// Each duplicate-run of `BlockId`s in the input is packed into a single
+    /// `([INTERLINK_VECTOR_PREFIX, first_pos], [qty, blockid_bytes...])` entry,
+    /// where `first_pos` is the input-vector index of the run's first element.
+    /// This matches JVM Ergo's `org.ergoplatform.modifiers.history.popow.NipopowAlgos`
+    /// encoding — the Merkle-leaf hash of each entry depends on `first_pos`, so a
+    /// sequential distinct-group counter (used here pre-fix) produces leaves that
+    /// hash differently and break `check_interlinks_proof` against JVM-generated
+    /// proofs.
     pub fn pack_interlinks(interlinks: Vec<BlockId>) -> Vec<([u8; 2], Vec<u8>)> {
+        if interlinks.is_empty() {
+            return vec![];
+        }
         let mut res = vec![];
-        let mut ix_distinct_block_ids = 0;
-        let mut curr_block_id_count = 1;
+        let mut curr_block_id_count: u8 = 1;
         let mut curr_block_id = interlinks[0];
-        for id in interlinks.into_iter().skip(1) {
-            if id == curr_block_id {
+        let mut curr_first_pos: usize = 0;
+        for (i, id) in interlinks.iter().enumerate().skip(1) {
+            if *id == curr_block_id {
                 curr_block_id_count += 1;
             } else {
                 let block_id_bytes: Vec<u8> = curr_block_id.0.into();
                 let packed_value = std::iter::once(curr_block_id_count)
                     .chain(block_id_bytes)
                     .collect();
-                res.push((
-                    [INTERLINK_VECTOR_PREFIX, ix_distinct_block_ids],
-                    packed_value,
-                ));
-                curr_block_id = id;
+                let ix_byte: u8 = curr_first_pos
+                    .try_into()
+                    .expect("interlinks first-position byte index > 255");
+                res.push(([INTERLINK_VECTOR_PREFIX, ix_byte], packed_value));
+                curr_block_id = *id;
                 curr_block_id_count = 1;
-                ix_distinct_block_ids += 1;
+                curr_first_pos = i;
             }
         }
         let block_id_bytes: Vec<u8> = curr_block_id.0.into();
         let packed_value = std::iter::once(curr_block_id_count)
             .chain(block_id_bytes)
             .collect();
-        res.push((
-            [INTERLINK_VECTOR_PREFIX, ix_distinct_block_ids],
-            packed_value,
-        ));
+        let ix_byte: u8 = curr_first_pos
+            .try_into()
+            .expect("interlinks first-position byte index > 255");
+        res.push(([INTERLINK_VECTOR_PREFIX, ix_byte], packed_value));
         res
     }
     /// Unpacks interlinks from key-value format of block extension.


### PR DESCRIPTION
pack_interlinks encodes ExtensionKV.key[1] as a sequential distinct-group counter; JVM uses the input-vector index of each duplicate-run's first element. The mismatch is invisible internally (unpack ignores key[1]) but Merkle leaves hash differently from JVM, so check_interlinks_proof and is_better_than reject every real mainnet proof.

Verified against mainnet block 1784124: 11/11 leaf hashes match JVM post-fix (2/11 pre-fix). Also fixes panic on empty input.
