### PR TITLE
fix: reject non-pair tuples at eval to match sigma-state consensus

### DIFF
--- a/ergotree-interpreter/src/eval/tuple.rs
+++ b/ergotree-interpreter/src/eval/tuple.rs
@@ -12,6 +12,21 @@ impl Evaluable for Tuple {
         env: &mut Env<'ctx>,
         ctx: &Context<'ctx>,
     ) -> Result<Value<'ctx>, EvalError> {
+        // sigma-state restricts tuples to exactly 2 elements: `Tuple.eval`
+        // rejects `items.length != 2` with "Invalid tuple" before doing any work
+        // (sigma `values.scala`: "in v5.0 version we support only tuples of 2
+        // elements to be equivalent with v4.x"). The check is unconditional —
+        // no version gate, and sigma-state 6.0.3 evaluates every height through
+        // it. sigma-rust models tuples as flat N-ary (`TupleItems =
+        // BoundedVec<2,255>`), so without this guard it accepts arity>=3 tuples
+        // the JVM rejects — a consensus accept/reject divergence (sigma-rust
+        // would accept a spend the JVM rejects). Mirror the JVM: reject non-pairs.
+        if self.items.len() != 2 {
+            return Err(EvalError::Misc(format!(
+                "Tuple: sigma-state allows only 2-element tuples, got {}",
+                self.items.len()
+            )));
+        }
         let items_v = self.items.try_mapped_ref(|i| i.eval(env, ctx));
         Ok(Value::Tup(items_v?))
     }
@@ -21,9 +36,11 @@ impl Evaluable for Tuple {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eval::test_util::eval_out_wo_ctx;
+    use crate::eval::test_util::{eval_out_wo_ctx, try_eval_out};
+    use ergotree_ir::chain::context::Context;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;
+    use sigma_test_util::force_any_val;
 
     #[test]
     fn eval() {
@@ -33,5 +50,23 @@ mod tests {
         let tuple: Expr = Tuple::new(exprs).unwrap().into();
         let res = eval_out_wo_ctx::<Value>(&tuple);
         assert!(matches!(res, Value::Tup(_)));
+    }
+
+    #[test]
+    fn eval_rejects_non_pair_tuple() {
+        // sigma-state rejects tuples with length != 2 ("Invalid tuple", JVM
+        // consensus). A flat arity-3 tuple is constructible here (TupleItems
+        // allows 2..=255), but must be rejected at eval to match the JVM — else
+        // sigma-rust would accept a spend the JVM rejects.
+        let e1: Expr = 1i64.into();
+        let e2: Expr = 2i64.into();
+        let e3: Expr = 3i64.into();
+        let tuple: Expr = Tuple::new(vec![e1, e2, e3]).unwrap().into();
+        let ctx = force_any_val::<Context>();
+        let res = try_eval_out::<Value>(&tuple, &ctx);
+        assert!(
+            res.is_err(),
+            "arity-3 Tuple must be rejected at eval, got {res:?}"
+        );
     }
 }


### PR DESCRIPTION
`Tuple` eval accepted any arity (`TupleItems = BoundedVec<2,255>`), but sigma-state restricts tuples to exactly 2 at eval — `Tuple.eval` (values.scala): `if (items.length != 2) error("Invalid tuple")`, unconditional; the deserializer accepts arity-N. So sigma-rust evaluated arity-≥3 tuples the reference rejects — a consensus accept/reject divergence (accepted here, rejected by sigma-state).

Found vs sigma-state 6.0.3: tree `0086030101020703a413` = `Tuple(TrueLeaf, Byte 7, Short 1234)` → JVM rejects "Invalid tuple"; sigma-rust accepted `Tuple[true, 7, 1234]`.

Fix: reject `items.len() != 2` at eval (before cost, as sigma-state). No compiled script emits flat arity-≥3 tuples, so it can't regress sync. Regression test added.
