### PR TITLE
Register GroupElement.expUnsigned in the method descriptor table

### DIFF
--- a/ergotree-ir/src/types/sgroup_elem.rs
+++ b/ergotree-ir/src/types/sgroup_elem.rs
@@ -32,7 +32,13 @@ lazy_static! {
     pub(crate) static ref METHOD_DESC: Vec<SMethodDesc> =
         vec![
             GET_ENCODED_METHOD_DESC.clone(),
-            NEGATE_METHOD_DESC.clone()
+            NEGATE_METHOD_DESC.clone(),
+            // expUnsigned (v6/V3): defined + evaluable, but previously absent from
+            // this registry, so `from_ids` rejected it (UnknownMethodId) and any
+            // ErgoTree using it failed to deserialize — while the JVM parses + evals
+            // it. (exponentiate/multiply are intentionally absent: they serialize as
+            // dedicated `Exponentiate`/`MultiplyGroup` ops, not method calls.)
+            EXPONENTIATE_UNSIGNED_METHOD_DESC.clone(),
         ]
     ;
 }
@@ -123,5 +129,13 @@ mod tests {
                 == Ok("getEncoded")
         );
         assert!(SMethod::from_ids(TYPE_CODE, NEGATE_METHOD_ID).map(|e| e.name()) == Ok("negate"));
+        // Regression: expUnsigned (method 6, v6/V3) must be resolvable by the
+        // deserializer. It was defined + evaluable but missing from METHOD_DESC,
+        // so `from_ids` returned UnknownMethodId and any tree using it failed to
+        // parse (the JVM parses + evals it — a consensus divergence).
+        assert!(
+            SMethod::from_ids(TYPE_CODE, EXPONENTIATE_UNSIGNED_METHOD_ID).map(|e| e.method_id())
+                == Ok(EXPONENTIATE_UNSIGNED_METHOD_ID)
+        );
     }
 }


### PR DESCRIPTION
`GroupElement.expUnsigned` (method id 6, v6/V3) had a descriptor and an eval fn but was never added to `SGroupElement`'s `METHOD_DESC`. So `SMethod::from_ids` rejected it with `UnknownMethodId(6, 7)` — any ErgoTree calling `expUnsigned` failed to deserialize, while sigma-state parses + evaluates it. A crafted tree using it is accepted by a JVM node and rejected by a sigma-rust node — a consensus divergence.

Fix: add `EXPONENTIATE_UNSIGNED_METHOD_DESC` to `METHOD_DESC` (V3-gated via its existing `min_version`). `exponentiate`/`multiply` stay out — they serialize as dedicated ops, not method calls.

Verified against the v6 spec vectors: `G^1`→G, `G^0`/`G^order`→identity, all now parse + eval. Adds a `from_ids` regression test.
