### PR TITLE
fix(ergotree-interpreter): implement numeric cast to UnsignedBigInt in eval

### DIFF
--- a/ergotree-interpreter/src/eval/downcast.rs
+++ b/ergotree-interpreter/src/eval/downcast.rs
@@ -4,6 +4,7 @@ use ergotree_ir::ergo_tree::ErgoTreeVersion;
 use ergotree_ir::mir::downcast::Downcast;
 use ergotree_ir::mir::value::Value;
 use ergotree_ir::types::stype::SType;
+use ergotree_ir::unsignedbigint256::UnsignedBigInt;
 use num_traits::ToPrimitive;
 
 use crate::eval::env::Env;
@@ -108,6 +109,32 @@ fn downcast_to_byte<'a>(in_v: Value<'a>, ctx: &Context<'_>) -> Result<Value<'a>,
     }
 }
 
+fn downcast_to_unsigned_bigint<'a>(in_v: Value<'a>) -> Result<Value<'a>, EvalError> {
+    // Mirrors Scala `SUnsignedBigInt.downcast` (identical to its upcast): Byte/Short/Int/Long
+    // widen, an UnsignedBigInt passes through, and negatives are rejected. No signed-BigInt
+    // source arm (use `.toSigned`/`.toUnsigned`). The target-UnsignedBigInt path is
+    // unreachable below V3 (the type is V3-gated at parse), so no version guard is needed.
+    fn non_negative<'a>(v: i64) -> Result<Value<'a>, EvalError> {
+        if v < 0 {
+            return Err(EvalError::UnexpectedValue(format!(
+                "Downcast: cannot downcast negative value {v} to UnsignedBigInt"
+            )));
+        }
+        Ok(UnsignedBigInt::from(v as u64).into())
+    }
+    match in_v {
+        Value::Byte(v) => non_negative(v as i64),
+        Value::Short(v) => non_negative(v as i64),
+        Value::Int(v) => non_negative(v as i64),
+        Value::Long(v) => non_negative(v),
+        Value::UnsignedBigInt(_) => Ok(in_v),
+        _ => Err(EvalError::UnexpectedValue(format!(
+            "Downcast: cannot downcast {0:?} to UnsignedBigInt",
+            in_v
+        ))),
+    }
+}
+
 impl Evaluable for Downcast {
     fn eval<'ctx>(
         &self,
@@ -121,6 +148,7 @@ impl Evaluable for Downcast {
             SType::SInt => downcast_to_int(input_v, ctx),
             SType::SShort => downcast_to_short(input_v, ctx),
             SType::SByte => downcast_to_byte(input_v, ctx),
+            SType::SUnsignedBigInt => downcast_to_unsigned_bigint(input_v),
             _ => Err(EvalError::UnexpectedValue(format!(
                 "Downcast: expected numeric value, got {0:?}",
                 input_v
@@ -143,6 +171,52 @@ mod tests {
 
     fn downcast(c: impl Into<Constant>, return_type: SType) -> Expr {
         Downcast::new(c.into().into(), return_type).unwrap().into()
+    }
+
+    #[test]
+    fn downcast_to_unsigned_bigint() {
+        assert_eq!(
+            eval_out_wo_ctx::<UnsignedBigInt>(&downcast(7i8, SType::SUnsignedBigInt)),
+            UnsignedBigInt::from(7u32)
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<UnsignedBigInt>(&downcast(10000i32, SType::SUnsignedBigInt)),
+            UnsignedBigInt::from(10000u32)
+        );
+        assert_eq!(
+            eval_out_wo_ctx::<UnsignedBigInt>(&downcast(
+                1_000_000_000_000i64,
+                SType::SUnsignedBigInt
+            )),
+            UnsignedBigInt::from(1_000_000_000_000u64)
+        );
+        // an UnsignedBigInt passes through unchanged
+        assert_eq!(
+            eval_out_wo_ctx::<UnsignedBigInt>(&downcast(
+                UnsignedBigInt::from(42u32),
+                SType::SUnsignedBigInt
+            )),
+            UnsignedBigInt::from(42u32)
+        );
+    }
+
+    #[test]
+    fn downcast_to_unsigned_bigint_rejects_negative_and_signed_bigint() {
+        // the JVM errors when converting a negative numeric to UnsignedBigInt
+        assert!(
+            try_eval_out_wo_ctx::<UnsignedBigInt>(&downcast(-1i32, SType::SUnsignedBigInt))
+                .is_err()
+        );
+        assert!(
+            try_eval_out_wo_ctx::<UnsignedBigInt>(&downcast(-1i64, SType::SUnsignedBigInt))
+                .is_err()
+        );
+        // there is no signed-BigInt -> UnsignedBigInt downcast (use .toUnsigned)
+        assert!(try_eval_out_wo_ctx::<UnsignedBigInt>(&downcast(
+            BigInt256::from(5i64),
+            SType::SUnsignedBigInt
+        ))
+        .is_err());
     }
 
     proptest! {

--- a/ergotree-interpreter/src/eval/upcast.rs
+++ b/ergotree-interpreter/src/eval/upcast.rs
@@ -3,6 +3,7 @@ use ergotree_ir::ergo_tree::ErgoTreeVersion;
 use ergotree_ir::mir::upcast::Upcast;
 use ergotree_ir::mir::value::Value;
 use ergotree_ir::types::stype::SType;
+use ergotree_ir::unsignedbigint256::UnsignedBigInt;
 
 use crate::eval::env::Env;
 use crate::eval::Context;
@@ -69,6 +70,32 @@ fn upcast_to_byte(in_v: Value) -> Result<Value, EvalError> {
     }
 }
 
+fn upcast_to_unsigned_bigint<'a>(in_v: Value<'a>) -> Result<Value<'a>, EvalError> {
+    // Mirrors Scala `SUnsignedBigInt.upcast`: widen Byte/Short/Int/Long (and accept an
+    // UnsignedBigInt unchanged), then reject negatives — the JVM errors when widening a
+    // negative numeric to UnsignedBigInt. There is deliberately no signed-BigInt source
+    // arm (ErgoScript uses `.toUnsigned`/`.toUnsignedMod` for that).
+    fn non_negative<'a>(v: i64) -> Result<Value<'a>, EvalError> {
+        if v < 0 {
+            return Err(EvalError::UnexpectedValue(format!(
+                "Upcast: cannot upcast negative value {v} to UnsignedBigInt"
+            )));
+        }
+        Ok(UnsignedBigInt::from(v as u64).into())
+    }
+    match in_v {
+        Value::Byte(v) => non_negative(v as i64),
+        Value::Short(v) => non_negative(v as i64),
+        Value::Int(v) => non_negative(v as i64),
+        Value::Long(v) => non_negative(v),
+        Value::UnsignedBigInt(_) => Ok(in_v),
+        _ => Err(EvalError::UnexpectedValue(format!(
+            "Upcast: cannot upcast {0:?} to UnsignedBigInt",
+            in_v
+        ))),
+    }
+}
+
 impl Evaluable for Upcast {
     fn eval<'ctx>(
         &self,
@@ -82,6 +109,7 @@ impl Evaluable for Upcast {
             SType::SInt => upcast_to_int(input_v),
             SType::SShort => upcast_to_short(input_v),
             SType::SByte => upcast_to_byte(input_v),
+            SType::SUnsignedBigInt => upcast_to_unsigned_bigint(input_v),
             _ => Err(EvalError::UnexpectedValue(format!(
                 "Upcast: expected numeric value, got {0:?}",
                 input_v
@@ -97,10 +125,50 @@ mod tests {
     use ergotree_ir::mir::constant::Constant;
     use sigma_test_util::force_any_val;
 
-    use crate::eval::test_util::{eval_out_wo_ctx, try_eval_out_with_version};
+    use crate::eval::test_util::{eval_out_wo_ctx, try_eval_out_with_version, try_eval_out_wo_ctx};
 
     use super::*;
     use proptest::prelude::*;
+
+    #[test]
+    fn upcast_to_unsigned_bigint() {
+        fn to_ubi(c: Constant) -> UnsignedBigInt {
+            eval_out_wo_ctx::<UnsignedBigInt>(
+                &Upcast::new(c.into(), SType::SUnsignedBigInt)
+                    .unwrap()
+                    .into(),
+            )
+        }
+        assert_eq!(to_ubi(7i8.into()), UnsignedBigInt::from(7u32));
+        assert_eq!(to_ubi(300i16.into()), UnsignedBigInt::from(300u32));
+        assert_eq!(to_ubi(10000i32.into()), UnsignedBigInt::from(10000u32));
+        assert_eq!(
+            to_ubi(1_000_000_000_000i64.into()),
+            UnsignedBigInt::from(1_000_000_000_000u64)
+        );
+        // an UnsignedBigInt passes through unchanged
+        assert_eq!(
+            to_ubi(UnsignedBigInt::from(42u32).into()),
+            UnsignedBigInt::from(42u32)
+        );
+    }
+
+    #[test]
+    fn upcast_to_unsigned_bigint_rejects_negative_and_signed_bigint() {
+        fn try_ubi(c: Constant) -> Result<UnsignedBigInt, EvalError> {
+            try_eval_out_wo_ctx::<UnsignedBigInt>(
+                &Upcast::new(c.into(), SType::SUnsignedBigInt)
+                    .unwrap()
+                    .into(),
+            )
+        }
+        // the JVM errors when widening a negative numeric to UnsignedBigInt
+        assert!(try_ubi((-1i32).into()).is_err());
+        assert!(try_ubi((-1i64).into()).is_err());
+        // there is no signed-BigInt -> UnsignedBigInt upcast (ErgoScript uses .toUnsigned)
+        assert!(try_ubi(BigInt256::from(5i64).into()).is_err());
+    }
+
     proptest! {
         #[test]
         fn from_byte(v in any::<i8>()) {


### PR DESCRIPTION
`Upcast`/`Downcast` to `UnsignedBigInt` had no eval arm, so evaluating one hit the `_` catch-all and errored ("expected numeric value"). This adds the `SUnsignedBigInt` target arm to both, mirroring Scala `SUnsignedBigInt.upcast`/`downcast`: widen `Byte`/`Short`/`Int`/`Long`, pass an `UnsignedBigInt` through unchanged, and **reject negatives** (the JVM errors when widening a negative numeric to `UnsignedBigInt`). No signed-`BigInt` source arm — ErgoScript uses `.toUnsigned`.

Surfaced by a full node on testnet block 28,474 (Autolykos-2 verify): `coll.map(x => Global.powHit(..)).exists((u: UnsignedBigInt) => ..)`, whose predicate runs `Upcast(Int -> UnsignedBigInt)`. JVM 6.0.3 accepts it.

Tests cover each source type, the identity pass-through, and negative / signed-BigInt rejection.
