### PR TITLE
fix: tolerate absent/non-bytearray context var in DeserializeContext substitution

### DIFF
--- a/ergotree-interpreter/src/eval/deserialize_context.rs
+++ b/ergotree-interpreter/src/eval/deserialize_context.rs
@@ -6,6 +6,7 @@ mod tests {
     use ergotree_ir::mir::deserialize_context::DeserializeContext;
     use ergotree_ir::mir::expr::Expr;
     use ergotree_ir::mir::global_vars::GlobalVars;
+    use ergotree_ir::mir::if_op::If;
     use ergotree_ir::mir::value::Value;
     use ergotree_ir::serialization::SigmaSerializable;
     use ergotree_ir::types::stype::SType;
@@ -71,6 +72,31 @@ mod tests {
         let extension = ContextExtension::empty();
         let ctx = force_any_val::<Context>().with_extension(&extension);
         assert!(try_eval_with_deserialize::<bool>(&expr, &ctx).is_err());
+    }
+
+    // Regression for testnet block 111,927: a `DeserializeContext` over an
+    // absent context var sitting on a dead `if` branch must NOT sink reduction.
+    // Substitution walks the whole tree but, mirroring the JVM
+    // `Interpreter.substDeserialize` `else None`, leaves the absent-var node in
+    // place; the live branch then reduces normally. A leftover node on the
+    // *live* path still errors at eval (see `eval_id_not_found`).
+    #[test]
+    fn eval_absent_var_on_dead_branch() {
+        let deser: Expr = DeserializeContext {
+            tpe: SType::SBoolean,
+            id: 0,
+        }
+        .into();
+        // if (true) true else deserializeContext(0)
+        let expr: Expr = If {
+            condition: Expr::Const(true.into()).into(),
+            true_branch: Expr::Const(true.into()).into(),
+            false_branch: deser.into(),
+        }
+        .into();
+        let extension = ContextExtension::empty();
+        let ctx = force_any_val::<Context>().with_extension(&extension);
+        assert!(try_eval_with_deserialize::<bool>(&expr, &ctx).unwrap());
     }
 
     #[test]

--- a/ergotree-interpreter/src/eval/deserialize_context.rs
+++ b/ergotree-interpreter/src/eval/deserialize_context.rs
@@ -99,6 +99,34 @@ mod tests {
         assert!(try_eval_with_deserialize::<bool>(&expr, &ctx).unwrap());
     }
 
+    // Parity with the JVM `Interpreter.substDeserialize` inner `case _ => None`:
+    // a context var that is present but not a `Coll[Byte]` is not substituted,
+    // so a dead-branch deserialize over a wrong-typed var does not sink
+    // reduction either. (A wrong-typed var on the *live* path still errors at
+    // eval — see `eval_context_extension_wrong_type`.)
+    #[test]
+    fn eval_wrong_type_var_on_dead_branch() {
+        let deser: Expr = DeserializeContext {
+            tpe: SType::SBoolean,
+            id: 0,
+        }
+        .into();
+        // if (true) true else deserializeContext(0)
+        let expr: Expr = If {
+            condition: Expr::Const(true.into()).into(),
+            true_branch: Expr::Const(true.into()).into(),
+            false_branch: deser.into(),
+        }
+        .into();
+        // var 0 present but an Int, not a Coll[Byte]
+        let ctx_ext_val: Constant = 1i32.into();
+        let ctx_ext = ContextExtension {
+            values: [(0u8, ctx_ext_val)].iter().cloned().collect(),
+        };
+        let ctx = force_any_val::<Context>().with_extension(&ctx_ext);
+        assert!(try_eval_with_deserialize::<bool>(&expr, &ctx).unwrap());
+    }
+
     #[test]
     fn eval_context_extension_wrong_type() {
         let expr: Expr = DeserializeContext {

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -428,7 +428,15 @@ impl Expr {
                             // how the JVM accepts testnet block 111,927.
                             None => return Ok(()),
                         };
-                        let vec = value.try_extract_into::<Vec<u8>>()?;
+                        // Present but not a `Coll[Byte]`: leave the node
+                        // unchanged too, mirroring the JVM
+                        // `Interpreter.substDeserialize` inner `case _ => None`
+                        // (a non-SByteArray extension value is not substituted;
+                        // the leftover node errors only on the live eval path).
+                        let vec = match value.try_extract_into::<Vec<u8>>() {
+                            Ok(vec) => vec,
+                            Err(_) => return Ok(()),
+                        };
                         (
                             tpe,
                             sigma_byte_reader::from_bytes(&vec)

--- a/ergotree-ir/src/mir/expr.rs
+++ b/ergotree-ir/src/mir/expr.rs
@@ -416,13 +416,19 @@ impl Expr {
             |expr| {
                 let (tpe, parsed_expr): (&mut SType, Expr) = match expr {
                     Expr::DeserializeContext(DeserializeContext { tpe, id }) => {
-                        let vec = ctx
-                            .extension
-                            .values
-                            .get(&*id)
-                            .ok_or(SubstDeserializeError::ExtensionKeyNotFound(*id))?
-                            .clone()
-                            .try_extract_into::<Vec<u8>>()?;
+                        let value = match ctx.extension.values.get(&*id) {
+                            Some(value) => value.clone(),
+                            // Absent context variable: leave the DeserializeContext
+                            // node unchanged, mirroring the JVM
+                            // `Interpreter.substDeserialize` `else None` (and the
+                            // DeserializeRegister branch below). A leftover node
+                            // errors only if the *live* reduction path evaluates it
+                            // (eval/expr.rs: "DeserializeContext cannot be
+                            // evaluated"); on a dead branch it is harmless, which is
+                            // how the JVM accepts testnet block 111,927.
+                            None => return Ok(()),
+                        };
+                        let vec = value.try_extract_into::<Vec<u8>>()?;
                         (
                             tpe,
                             sigma_byte_reader::from_bytes(&vec)
@@ -675,8 +681,6 @@ impl From<BoundedVecOutOfBounds> for InvalidArgumentError {
 pub enum SubstDeserializeError {
     #[error("TryExtractFromError: {0}")]
     TryExtractFromError(#[from] TryExtractFromError),
-    #[error("Could not find context extension variable {0}")]
-    ExtensionKeyNotFound(u8),
     #[error("executeFromReg: Register out of bounds {0}")]
     InvalidRegister(#[from] RegisterIdOutOfBounds),
     #[error("Register {0} does not exist")]


### PR DESCRIPTION
`substitute_deserialize` rewrites the whole tree, so a `DeserializeContext` over a context-extension variable that is absent (or present but not `Coll[Byte]`) errored even when the node sat on a branch the live reduction never takes.

The JVM `Interpreter.substDeserialize` returns `None` in both cases, leaving the node; the sibling `DeserializeRegister` already does the same. This mirrors them. A leftover node on the *live* path still errors at eval (`DeserializeContext cannot be evaluated`), so a live-path deserialize cannot silently pass.

Fixes a full-node sync wedge on testnet block 111,927 (tx 2 input 0: empty proof, empty extension, `DeserializeContext(0)` on a dead `if` branch).

Two commits: absent var, then non-bytearray var (full `substDeserialize` parity).
