### PR TITLE
fix: deserialize FunDef (0xd7) — polymorphic val definitions

### DIFF
--- a/ergotree-interpreter/src/eval.rs
+++ b/ergotree-interpreter/src/eval.rs
@@ -513,6 +513,7 @@ mod test {
             BlockValue {
                 items: vec![ValDef {
                     id: 1.into(),
+                    tpe_args: vec![],
                     rhs: Box::new(Expr::Const(1i32.into())),
                 }
                 .into()],

--- a/ergotree-interpreter/src/eval/apply.rs
+++ b/ergotree-interpreter/src/eval/apply.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use ergotree_ir::mir::apply::Apply;
 use ergotree_ir::mir::val_def::ValId;
 use ergotree_ir::mir::value::Value;
+use ergotree_ir::types::stype::SType;
 use hashbrown::HashMap;
 
 use crate::eval::env::Env;
@@ -23,6 +24,19 @@ impl Evaluable for Apply {
             .collect::<Result<_, EvalError>>()?;
         match func_v {
             Value::Lambda(fv) => {
+                // The JVM rejects applying a lambda whose argument type is
+                // still a type variable (a `FunDef`-bound polymorphic lambda
+                // applied without instantiation): `Value.checkType(argTpe, v)`
+                // inside the closure reaches `isValueOfType`'s catch-all →
+                // `Unknown type T`. The error fires only on application —
+                // binding such a lambda and never applying it is accepted,
+                // since the closure body never runs.
+                if let Some(arg) = fv.args.iter().find(|a| matches!(a.tpe, SType::STypeVar(_))) {
+                    return Err(EvalError::Misc(format!(
+                        "Apply: Unknown type {:?} of lambda argument {}",
+                        arg.tpe, arg.idx
+                    )));
+                }
                 let arg_ids: Vec<ValId> = fv.args.iter().map(|a| a.idx).collect();
                 let mut existing_variables = HashMap::new();
                 let mut new_variables = vec![];
@@ -72,6 +86,74 @@ mod tests {
 
     use super::*;
 
+    // SANTA HOF regression (`eval/v6/authored` vectors): `FunDef` (0xd7)
+    // trees deserialize, the polymorphic *construct* evaluates, and applying
+    // a lambda whose argument type is still a type variable is rejected —
+    // mirroring the JVM boundary (`Unknown type T` fires at application via
+    // `Value.checkType` inside the closure, never at binding).
+    #[test]
+    fn fundef_polymorphic_apply_boundary() {
+        use crate::eval::test_util::try_eval_out_with_version;
+        use ergotree_ir::chain::context::Context;
+        use ergotree_ir::ergo_tree::ErgoTree;
+        use ergotree_ir::serialization::SigmaSerializable;
+        use sigma_test_util::force_any_val;
+
+        fn hx(s: &str) -> alloc::vec::Vec<u8> {
+            (0..s.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+                .collect()
+        }
+        // The vector trees carry arbitrary-typed roots (eval-tier corpus);
+        // the sized parse path rejects non-SigmaProp roots, so clear the
+        // size bit and drop the size byte to route through the non-sized
+        // path — the same leniency the conformance runner applies.
+        fn lenient(bytes: &[u8]) -> alloc::vec::Vec<u8> {
+            let mut out = alloc::vec::Vec::with_capacity(bytes.len() - 1);
+            out.push(bytes[0] & !0x08);
+            out.extend_from_slice(&bytes[2..]); // size VLQ is 1 byte here
+            out
+        }
+
+        // End-to-end: parse → substitute constants → eval. The reject trees
+        // may fail at either layer (Rust's `Apply::new` arg-type check fires
+        // at parse, where the JVM defers to eval — both reject the spend).
+        let run = |hex: &str| -> Result<i32, alloc::string::String> {
+            let tree = ErgoTree::sigma_parse_bytes(&lenient(&hx(hex)))
+                .map_err(|e| alloc::format!("parse: {e:?}"))?;
+            let expr = tree
+                .proposition()
+                .map_err(|e| alloc::format!("proposition: {e:?}"))?;
+            let ctx = force_any_val::<Context>();
+            try_eval_out_with_version::<i32>(&expr, &ctx, 3, 3)
+                .map_err(|e| alloc::format!("eval: {e:?}"))
+        };
+
+        // { val id[T] = {(x: Int) => x}; id(7) } — tpeArgs=[T], concrete arg type
+        // { val id[T] = {(x: T) => x}; 5 }      — type-var arg, bound but never applied
+        let accepts: &[(&str, i32)] = &[
+            ("1b1701040ed801d70101670154d90102047202da7201017300", 7),
+            ("1b1501040ad801d70101670154d9010267015472027300", 5),
+        ];
+        // Applying through the type var — all reject:
+        // (x: T) => x  /  (x: T) => 5  /  (x: T) => x + x, each applied as id(7)
+        let rejects: &[&str] = &[
+            "1b1901040ed801d70101670154d901026701547202da7201017300",
+            "1b1b02040a040ed801d70101670154d901026701547300da7201017301",
+            "1b1c01040ed801d70101670154d901026701549a72027202da7201017300",
+        ];
+        for (hex, expected) in accepts {
+            assert_eq!(run(hex).unwrap(), *expected, "{hex}: value mismatch");
+        }
+        for hex in rejects {
+            assert!(
+                run(hex).is_err(),
+                "{hex}: applying a type-var-typed lambda argument must reject"
+            );
+        }
+    }
+
     #[test]
     fn eval_user_defined_func_call() {
         let arg = Expr::Const(1i32.into());
@@ -99,6 +181,7 @@ mod tests {
             BlockValue {
                 items: vec![ValDef {
                     id: 2.into(),
+                    tpe_args: vec![],
                     rhs: Box::new(Expr::Const(1i32.into())),
                 }
                 .into()],

--- a/ergotree-interpreter/src/eval/error.rs
+++ b/ergotree-interpreter/src/eval/error.rs
@@ -288,16 +288,19 @@ mod tests {
                 items: vec![
                     ValDef {
                         id: lhs_val_id,
+                        tpe_args: vec![],
                         rhs: Box::new(Expr::Const(42i32.into())),
                     }
                     .into(),
                     ValDef {
                         id: rhs_val_id,
+                        tpe_args: vec![],
                         rhs: Box::new(Expr::Const(0i32.into())),
                     }
                     .into(),
                     ValDef {
                         id: res_val_id,
+                        tpe_args: vec![],
                         rhs: Box::new(
                             BinOp {
                                 kind: ArithOp::Divide.into(),
@@ -357,6 +360,7 @@ mod tests {
             BlockValue {
                 items: vec![ValDef {
                     id: v1_id,
+                    tpe_args: vec![],
                     rhs: Box::new(Expr::Const(99999999i32.into())),
                 }
                 .into()],

--- a/ergotree-ir/src/mir/val_def.rs
+++ b/ergotree-ir/src/mir/val_def.rs
@@ -6,15 +6,17 @@ use crate::serialization::SigmaSerializable;
 use crate::serialization::SigmaSerializeResult;
 use crate::traversable::impl_traversable_expr;
 use crate::types::stype::SType;
+use crate::types::stype_param::STypeVar;
 
 use super::expr::Expr;
 
 extern crate derive_more;
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 use derive_more::Display;
 use derive_more::From;
 
-use crate::has_opcode::HasStaticOpCode;
+use crate::has_opcode::HasOpCode;
 #[cfg(feature = "arbitrary")]
 use proptest_derive::Arbitrary;
 
@@ -43,6 +45,11 @@ impl ValId {
 pub struct ValDef {
     /// Variable id
     pub id: ValId,
+    /// Type parameters — non-empty for the polymorphic `FunDef` form
+    /// (`val id[T] = ...`, opcode 0xd7), empty for a plain `ValDef` (0xd6).
+    /// The JVM models both as one node (`ValDef(id, tpeArgs, rhs)`) with the
+    /// opcode chosen by `tpeArgs.isEmpty` — mirrored here.
+    pub tpe_args: Vec<STypeVar>,
     /// Expr, bound to the variable
     pub rhs: Box<Expr>,
 }
@@ -52,15 +59,71 @@ impl ValDef {
     pub fn tpe(&self) -> SType {
         self.rhs.tpe()
     }
+
+    /// Parse the `FunDef`-opcoded form (0xd7): type parameters precede the
+    /// rhs (JVM `ValDefSerializer` with `FunDefCode`).
+    pub(crate) fn sigma_parse_fun_def<R: SigmaByteRead>(
+        r: &mut R,
+    ) -> Result<Self, SigmaParsingError> {
+        let id = ValId::sigma_parse(r)?;
+        // The JVM reads the count as a SIGNED byte (`r.getByte()`) and fails
+        // on a negative size when allocating the array — mirror by rejecting
+        // counts above 127 (bytes 0x80..=0xff).
+        let n_tpe_args = r.get_i8()?;
+        if n_tpe_args < 0 {
+            return Err(SigmaParsingError::Misc(format!(
+                "FunDef: negative type parameter count {}",
+                n_tpe_args
+            )));
+        }
+        // Type parameters are written with the full type encoding
+        // (JVM `w.putType(arg)` / `r.getType().asInstanceOf[STypeVar]`),
+        // so each must parse as an `SType` that IS a type variable.
+        let tpe_args = (0..n_tpe_args)
+            .map(|_| match SType::sigma_parse(r)? {
+                SType::STypeVar(tv) => Ok(tv),
+                other => Err(SigmaParsingError::Misc(format!(
+                    "FunDef: expected a type variable as type parameter, got {:?}",
+                    other
+                ))),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let rhs = Expr::sigma_parse(r)?;
+        r.val_def_type_store().insert(id, rhs.tpe());
+        Ok(ValDef {
+            id,
+            tpe_args,
+            rhs: Box::new(rhs),
+        })
+    }
 }
 
-impl HasStaticOpCode for ValDef {
-    const OP_CODE: OpCode = OpCode::VAL_DEF;
+impl HasOpCode for ValDef {
+    /// `FunDef` (0xd7) when type parameters are present, plain `ValDef`
+    /// (0xd6) otherwise — the JVM serializes both shapes from the same node
+    /// (`ValDefSerializer`, registered under both opcodes).
+    fn op_code(&self) -> OpCode {
+        if self.tpe_args.is_empty() {
+            OpCode::VAL_DEF
+        } else {
+            OpCode::FUN_DEF
+        }
+    }
 }
 
 impl SigmaSerializable for ValDef {
     fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> SigmaSerializeResult {
         self.id.sigma_serialize(w)?;
+        if !self.tpe_args.is_empty() {
+            // FunDef form: type parameters precede the rhs (JVM
+            // `ValDefSerializer` "type arguments" section; the count is a
+            // single byte and each parameter uses the full type encoding —
+            // `w.putType(arg)`).
+            w.put_u8(self.tpe_args.len() as u8)?;
+            for tpe_arg in &self.tpe_args {
+                SType::STypeVar(tpe_arg.clone()).sigma_serialize(w)?;
+            }
+        }
         self.rhs.sigma_serialize(w)
     }
 
@@ -70,6 +133,7 @@ impl SigmaSerializable for ValDef {
         r.val_def_type_store().insert(id, rhs.tpe());
         Ok(ValDef {
             id,
+            tpe_args: Vec::new(),
             rhs: Box::new(rhs),
         })
     }

--- a/ergotree-ir/src/pretty_printer.rs
+++ b/ergotree-ir/src/pretty_printer.rs
@@ -135,6 +135,7 @@ mod tests {
             BlockValue {
                 items: vec![ValDef {
                     id: val_id,
+                    tpe_args: vec![],
                     rhs: Box::new(Expr::Const(1i32.into())),
                 }
                 .into()],
@@ -166,6 +167,7 @@ mod tests {
             BlockValue {
                 items: vec![ValDef {
                     id: val_id,
+                    tpe_args: vec![],
                     rhs: Box::new(
                         BinOp {
                             kind: ArithOp::Divide.into(),
@@ -199,7 +201,7 @@ mod tests {
         check_spans(
             expr,
             expect![[
-                r#"BlockValue(Spanned { source_span: SourceSpan { offset: 0, length: 26 }, expr: BlockValue { items: [ValDef(Spanned { source_span: SourceSpan { offset: 4, length: 14 }, expr: ValDef { id: ValId(1), rhs: BinOp(Spanned { source_span: SourceSpan { offset: 13, length: 5 }, expr: BinOp { kind: Arith(Divide), left: Const("4: SInt"), right: Const("2: SInt") } }) } })], result: ValUse(ValUse { val_id: ValId(1), tpe: SInt }) } })"#
+                r#"BlockValue(Spanned { source_span: SourceSpan { offset: 0, length: 26 }, expr: BlockValue { items: [ValDef(Spanned { source_span: SourceSpan { offset: 4, length: 14 }, expr: ValDef { id: ValId(1), tpe_args: [], rhs: BinOp(Spanned { source_span: SourceSpan { offset: 13, length: 5 }, expr: BinOp { kind: Arith(Divide), left: Const("4: SInt"), right: Const("2: SInt") } }) } })], result: ValUse(ValUse { val_id: ValId(1), tpe: SInt }) } })"#
             ]],
         );
     }

--- a/ergotree-ir/src/pretty_printer/print.rs
+++ b/ergotree-ir/src/pretty_printer/print.rs
@@ -220,6 +220,7 @@ impl Print for ValDef {
             source_span: SourceSpan { offset, length },
             expr: ValDef {
                 id: self.id,
+                tpe_args: self.tpe_args.clone(),
                 rhs: Box::new(rhs),
             },
         }

--- a/ergotree-ir/src/serialization/expr.rs
+++ b/ergotree-ir/src/serialization/expr.rs
@@ -151,6 +151,7 @@ impl Expr {
                 OpCode::FUNC_VALUE => Ok(Expr::FuncValue(FuncValue::sigma_parse(r)?)),
                 OpCode::APPLY => Ok(Expr::Apply(Apply::sigma_parse(r)?)),
                 OpCode::VAL_DEF => Ok(Expr::ValDef(ValDef::sigma_parse(r)?.into())),
+                OpCode::FUN_DEF => Ok(Expr::ValDef(ValDef::sigma_parse_fun_def(r)?.into())),
                 OpCode::VAL_USE => Ok(Expr::ValUse(ValUse::sigma_parse(r)?)),
                 ExtractAmount::OP_CODE => Ok(Expr::ExtractAmount(ExtractAmount::sigma_parse(r)?)),
                 OpCode::SELECT_FIELD => Ok(Expr::SelectField(SelectField::sigma_parse(r)?.into())),

--- a/ergotree-ir/src/types/stype_param.rs
+++ b/ergotree-ir/src/types/stype_param.rs
@@ -96,3 +96,21 @@ impl SigmaSerializable for STypeVar {
 pub struct STypeParam {
     pub(crate) ident: STypeVar,
 }
+
+#[cfg(feature = "arbitrary")]
+#[allow(clippy::unwrap_used)]
+mod arbitrary {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for STypeVar {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            "[A-Z][A-Z0-9]{0,2}"
+                .prop_map(|name| STypeVar::new_from_bytes(name.into_bytes()).unwrap())
+                .boxed()
+        }
+    }
+}


### PR DESCRIPTION
`FUN_DEF` (0xd7) had no parse arm: any tree with a polymorphic definition (`val id[T] = ...`) failed deserialization with `NotImplementedOpCode` — a box guarded by such a chain-valid v3 tree shape would wedge a node on spend.

Mirrors the JVM (`ValDefSerializer`, one node, two opcodes): `ValDef` gains `tpe_args: Vec<STypeVar>`, the opcode is picked by `tpe_args.is_empty()`, and the FunDef parse arm reads the signed count byte + type parameters (full type encoding) before the rhs. The construct evaluates with no eval changes; applying a lambda whose argument type is still a type variable rejects, mirroring the JVM's apply-time `Unknown type T` (`Value.checkType` inside the closure).

Surfaced by SANTA's v6 HOF conformance vectors: 2 accepts + 3 rejects now match the JVM exactly.
