### PR TITLE
fix: Option DATA parser treats any nonzero tag as Some, per JVM getOption

### DIFF
--- a/ergotree-ir/src/serialization/constant.rs
+++ b/ergotree-ir/src/serialization/constant.rs
@@ -88,4 +88,26 @@ mod tests {
         assert!(c_res.is_err());
         assert!(matches!(c_res, Err(SigmaParsingError::ValueOutOfBounds(_))));
     }
+
+    #[test]
+    fn parse_option_nonzero_data_tag_is_some() {
+        // The JVM reads the Option DATA tag via `getOption`, which treats ANY
+        // nonzero tag byte as Some (sigma `Extensions.getOption`:
+        // `if (tag != 0) Some(getValue) else None`) — tag 0x02 parses as
+        // Some(5) and must not be rejected.
+        let constant_bytes = [0x28, 0x02, 0x0a]; // SOption(SInt): tag 0x02, Int 5
+        let expected = Constant {
+            tpe: SType::SOption(Arc::new(SType::SInt)),
+            v: Literal::Opt(Some(Literal::Int(5).into())),
+        };
+        let c = Constant::sigma_parse_bytes(&constant_bytes).unwrap();
+        assert_eq!(c, expected);
+
+        // The same constant segregated in a v3 tree (the conformance vector
+        // `SOption.nonzero_data_tag`, header size bit cleared) hydrates as
+        // Some(5) through the versioned tree-parse path.
+        let tree_bytes = base16::decode("130128020a7300").unwrap();
+        let tree = crate::ergo_tree::ErgoTree::sigma_parse_bytes(&tree_bytes).unwrap();
+        assert_eq!(tree.get_constants().unwrap().as_slice(), &[expected]);
+    }
 }

--- a/sigma-ser/src/vlq_encode.rs
+++ b/sigma-ser/src/vlq_encode.rs
@@ -255,11 +255,13 @@ pub trait ReadSigmaVlqExt: io::Read + io::Seek {
         &mut self,
         get_value: impl Fn(&mut Self) -> Result<T, E>,
     ) -> Result<Option<T>, E> {
-        let is_opt = self.get_u8()?;
-        Ok(match is_opt {
-            1 => Some(get_value(self)?),
-            // Should only ever be 0 or 1
-            _ => None,
+        let tag = self.get_u8()?;
+        // Any nonzero tag means Some: scorex/sigma `getOption` reads
+        // `if (tag != 0) Some(getValue) else None` (sigma `Extensions.getOption`).
+        Ok(if tag != 0 {
+            Some(get_value(self)?)
+        } else {
+            None
         })
     }
 }
@@ -1012,5 +1014,19 @@ mod tests {
             prop_assert_eq!(&bytes_i64(i as i64), &expected_bytes);
             prop_assert_eq!(&bytes_i32(i as i32), &expected_bytes);
         }
+    }
+
+    #[test]
+    fn option_any_nonzero_tag_is_some() {
+        // scorex/sigma `getOption` reads `if (tag != 0) Some(..) else None`
+        // (sigma `Extensions.getOption`) — any nonzero tag byte means Some.
+        let get = |bytes: &[u8]| -> Result<Option<u8>, VlqEncodingError> {
+            let mut r = Cursor::new(bytes.to_vec());
+            r.get_option(|r| r.get_u8().map_err(VlqEncodingError::from))
+        };
+        assert_eq!(get(&[0, 5]).unwrap(), None);
+        assert_eq!(get(&[1, 5]).unwrap(), Some(5));
+        assert_eq!(get(&[2, 5]).unwrap(), Some(5));
+        assert_eq!(get(&[255, 5]).unwrap(), Some(5));
     }
 }


### PR DESCRIPTION
The JVM reads the Option DATA tag through `getOption` (sigma `Extensions.getOption`): `if (tag != 0) Some(getValue) else None` — any nonzero tag byte is `Some`. Our shared sigma-ser `get_option` mapped only tag `1` to `Some` and silently returned `None` on other nonzero tags without consuming the value bytes, desyncing the stream: a v3 tree carrying an `SOption` constant with DATA tag `0x02` failed to parse where the JVM evaluates it to `Some(5)`.

Fixes the reader helper to mirror the convention; `put_option` still writes 0/1, so the write side is unchanged. The only other caller (ergo-p2p peer-spec parsing) aligns with the same scorex reader convention.

Tests: reader tag pins (0/1/2/255) and the corpus constant `28 02 0a`, standalone and segregated in a v3 tree.