### PR TITLE
Fix json+no_std build of ergotree-ir (missing alloc imports)

### DIFF
--- a/ergotree-ir/src/chain/json/sigma_protocol.rs
+++ b/ergotree-ir/src/chain/json/sigma_protocol.rs
@@ -13,6 +13,8 @@ use crate::sigma_protocol::sigma_boolean::ProveDlog;
 use crate::sigma_protocol::sigma_boolean::SigmaBoolean;
 use crate::sigma_protocol::sigma_boolean::SigmaConjecture;
 use crate::sigma_protocol::sigma_boolean::SigmaProofOfKnowledgeTree;
+use alloc::string::String;
+use alloc::string::ToString;
 use alloc::vec::Vec;
 use bounded_vec::BoundedVecOutOfBounds;
 use ergo_chain_types::EcPoint;


### PR DESCRIPTION
`cargo check -p ergo-nipopow` — or any build resolving ergotree-ir with the `json` feature but without `std` — fails since 072f8587: the SigmaBoolean base16 serializer added to `chain/json/sigma_protocol.rs` uses `String::deserialize` / `.to_string()` from the std prelude, without the `alloc` imports the crate uses elsewhere under `no_std`.

CI and workspace-wide builds never hit it: the workspace dep table pins `default-features = false`, but some member always enables `ergotree-ir/std` and feature unification applies it to every crate in the graph. A solo `-p ergo-nipopow` build resolves exactly the broken combination.

Fix: the two missing `alloc::string` imports — the same pattern the rest of the crate uses (e.g. `serialization/serializable.rs`).