### PR TITLE
ergo-nipopow: validate the initial proof before selection

### DIFF
--- a/ergo-chain-generation/src/fake_pow_scheme.rs
+++ b/ergo-chain-generation/src/fake_pow_scheme.rs
@@ -8,7 +8,7 @@
 #[cfg(test)]
 mod tests {
     use ergo_lib::ergo_chain_types::{blake2b256_hash, ADDigest, BlockId, Digest32};
-    use ergo_nipopow::{NipopowAlgos, NipopowProof};
+    use ergo_nipopow::{NipopowAlgos, NipopowProof, NipopowVerifier, INTERLINK_VECTOR_PREFIX};
 
     use ergo_chain_types::{autolykos_pow_scheme::order_bigint, AutolykosSolution, Header, Votes};
     use ergo_lib::ergotree_interpreter::sigma_protocol::private_input::DlogProverInput;
@@ -177,6 +177,191 @@ mod tests {
         for b in block_stream(None).take(10) {
             assert!(popow_algos.max_level_of(&b.header).unwrap() >= 0);
         }
+    }
+
+    fn generated_nipopow_proof() -> (BlockId, NipopowProof) {
+        let m = 5;
+        let k = 5;
+        let chain = generate_popowheader_chain(100, None);
+        let genesis_id = chain[0].header.id;
+        let proof = NipopowAlgos::default().prove(&chain, k, m).unwrap();
+        assert_eq!(proof.prefix[0].header.id, genesis_id);
+        (genesis_id, proof)
+    }
+
+    fn assert_initial_proof_ignored(genesis_id: BlockId, proof: NipopowProof) {
+        let mut verifier = NipopowVerifier::new(genesis_id);
+        assert!(verifier.process(proof).is_ok());
+        assert!(verifier.best_proof().is_none());
+        assert!(verifier.best_chain().is_empty());
+    }
+
+    fn indexed_block_id(index: usize) -> BlockId {
+        let mut bytes = [0u8; 32];
+        bytes[..2].copy_from_slice(&u16::try_from(index).unwrap().to_be_bytes());
+        BlockId(Digest32::from(bytes))
+    }
+
+    fn set_first_prefix_interlinks_with_valid_proof(
+        proof: &mut NipopowProof,
+        interlinks: Vec<BlockId>,
+    ) {
+        let extension =
+            ExtensionCandidate::new(NipopowAlgos::pack_interlinks(interlinks.clone())).unwrap();
+        let interlinks_proof = NipopowAlgos::proof_for_interlink_vector(&extension).unwrap();
+        proof.prefix[0].interlinks = interlinks;
+        proof.prefix[0].interlinks_proof = interlinks_proof;
+    }
+
+    #[test]
+    fn test_nipopow_verifier_accepts_valid_initial_proof() {
+        let (genesis_id, proof) = generated_nipopow_proof();
+        let mut verifier = NipopowVerifier::new(genesis_id);
+        assert!(verifier.process(proof.clone()).is_ok());
+        assert_eq!(verifier.best_proof(), Some(proof));
+    }
+
+    #[test]
+    fn test_nipopow_verifier_ignores_wrong_genesis() {
+        let (_, proof) = generated_nipopow_proof();
+        let wrong_genesis = BlockId(Digest32::zero());
+        assert_ne!(proof.prefix[0].header.id, wrong_genesis);
+        assert_initial_proof_ignored(wrong_genesis, proof);
+    }
+
+    #[test]
+    fn test_nipopow_verifier_rejects_disconnected_initial_proof() {
+        let (genesis_id, mut proof) = generated_nipopow_proof();
+        assert!(!proof.suffix_tail.is_empty());
+        proof.suffix_tail[0].parent_id = BlockId(Digest32::zero());
+        assert!(!proof.has_valid_connections());
+        assert_initial_proof_ignored(genesis_id, proof);
+    }
+
+    #[test]
+    fn test_nipopow_verifier_rejects_non_increasing_initial_proof() {
+        let (genesis_id, mut proof) = generated_nipopow_proof();
+        assert!(!proof.suffix_tail.is_empty());
+        proof.suffix_tail[0].height = proof.suffix_head.header.height;
+        assert!(proof.has_valid_connections());
+        assert_initial_proof_ignored(genesis_id, proof);
+    }
+
+    #[test]
+    fn test_nipopow_verifier_rejects_invalid_interlinks_initial_proof() {
+        let (genesis_id, mut proof) = generated_nipopow_proof();
+        assert!(proof.suffix_head.check_interlinks_proof());
+        proof.suffix_head.interlinks.push(BlockId(Digest32::zero()));
+        assert!(!proof.suffix_head.check_interlinks_proof());
+        assert!(proof.has_valid_connections());
+        assert_initial_proof_ignored(genesis_id, proof);
+    }
+
+    #[test]
+    fn test_nipopow_verifier_rejects_empty_interlinks_with_nonempty_proof() {
+        let (genesis_id, mut proof) = generated_nipopow_proof();
+        let extension =
+            ExtensionCandidate::new(NipopowAlgos::pack_interlinks(vec![genesis_id])).unwrap();
+        let nonempty_proof = NipopowAlgos::proof_for_interlink_vector(&extension).unwrap();
+        assert!(!nonempty_proof.get_indices().is_empty());
+        proof.prefix[0].interlinks.clear();
+        proof.prefix[0].interlinks_proof = nonempty_proof;
+        assert!(proof.has_valid_connections());
+        assert_initial_proof_ignored(genesis_id, proof);
+    }
+
+    #[test]
+    fn test_nipopow_verifier_rejects_interlink_run_overflow() {
+        let (genesis_id, mut proof) = generated_nipopow_proof();
+        proof.prefix[0].interlinks = vec![genesis_id; usize::from(u8::MAX) + 1];
+        assert!(proof.has_valid_connections());
+        assert_initial_proof_ignored(genesis_id, proof);
+    }
+
+    #[test]
+    fn test_nipopow_verifier_rejects_interlink_key_overflow() {
+        let (genesis_id, mut proof) = generated_nipopow_proof();
+        proof.prefix[0].interlinks = (0..(usize::from(u8::MAX) + 2))
+            .map(indexed_block_id)
+            .collect();
+        assert!(proof.has_valid_connections());
+        assert_initial_proof_ignored(genesis_id, proof);
+    }
+
+    #[test]
+    fn test_nipopow_verifier_rejects_interlink_key_position_overflow() {
+        let (genesis_id, mut proof) = generated_nipopow_proof();
+        let second_run_id = indexed_block_id(1);
+        let third_run_id = indexed_block_id(2);
+        assert_ne!(genesis_id, second_run_id);
+        assert_ne!(genesis_id, third_run_id);
+        assert_ne!(second_run_id, third_run_id);
+        let mut interlinks = vec![genesis_id; usize::from(u8::MAX)];
+        interlinks.extend([second_run_id, third_run_id]);
+        let interlink_field_value = |count: u8, block_id: BlockId| {
+            let mut value = vec![count];
+            let block_id_bytes: Vec<u8> = block_id.0.into();
+            value.extend(block_id_bytes);
+            value
+        };
+        let extension = ExtensionCandidate::new(vec![
+            (
+                [INTERLINK_VECTOR_PREFIX, 0],
+                interlink_field_value(u8::MAX, genesis_id),
+            ),
+            (
+                [INTERLINK_VECTOR_PREFIX, 1],
+                interlink_field_value(1, second_run_id),
+            ),
+            (
+                [INTERLINK_VECTOR_PREFIX, 2],
+                interlink_field_value(1, third_run_id),
+            ),
+        ])
+        .unwrap();
+        proof.prefix[0].interlinks = interlinks;
+        proof.prefix[0].interlinks_proof =
+            NipopowAlgos::proof_for_interlink_vector(&extension).unwrap();
+        assert!(proof.has_valid_connections());
+        assert_initial_proof_ignored(genesis_id, proof);
+    }
+
+    #[test]
+    fn test_nipopow_verifier_accepts_maximum_interlink_run() {
+        let (genesis_id, mut proof) = generated_nipopow_proof();
+        set_first_prefix_interlinks_with_valid_proof(
+            &mut proof,
+            vec![genesis_id; usize::from(u8::MAX)],
+        );
+        assert!(proof.prefix[0].check_interlinks_proof());
+        let mut verifier = NipopowVerifier::new(genesis_id);
+        assert!(verifier.process(proof.clone()).is_ok());
+        assert_eq!(verifier.best_proof(), Some(proof));
+    }
+
+    #[test]
+    fn test_nipopow_verifier_accepts_maximum_interlink_key_count() {
+        let (genesis_id, mut proof) = generated_nipopow_proof();
+        let interlinks = (0..=usize::from(u8::MAX)).map(indexed_block_id).collect();
+        set_first_prefix_interlinks_with_valid_proof(&mut proof, interlinks);
+        assert!(proof.prefix[0].check_interlinks_proof());
+        let mut verifier = NipopowVerifier::new(genesis_id);
+        assert!(verifier.process(proof.clone()).is_ok());
+        assert_eq!(verifier.best_proof(), Some(proof));
+    }
+
+    #[test]
+    fn test_nipopow_verifier_accepts_valid_proof_after_invalid_initial_proof() {
+        let (genesis_id, valid_proof) = generated_nipopow_proof();
+        let mut invalid_proof = valid_proof.clone();
+        invalid_proof.suffix_tail[0].parent_id = BlockId(Digest32::zero());
+        assert!(!invalid_proof.has_valid_connections());
+
+        let mut verifier = NipopowVerifier::new(genesis_id);
+        assert!(verifier.process(invalid_proof).is_ok());
+        assert!(verifier.best_proof().is_none());
+        assert!(verifier.process(valid_proof.clone()).is_ok());
+        assert_eq!(verifier.best_proof(), Some(valid_proof));
     }
 
     #[test]

--- a/ergo-nipopow/src/nipopow_proof.rs
+++ b/ergo-nipopow/src/nipopow_proof.rs
@@ -82,7 +82,8 @@ impl NipopowProof {
         }
     }
 
-    fn is_valid(&self) -> bool {
+    /// Returns whether this proof satisfies the current structural validity checks.
+    pub(crate) fn is_valid(&self) -> bool {
         self.has_valid_connections() && self.has_valid_heights() && self.has_valid_proofs()
     }
 
@@ -215,28 +216,55 @@ pub struct PoPowHeader {
 }
 
 impl PoPowHeader {
+    fn has_packable_interlinks(&self) -> bool {
+        let Some(mut current) = self.interlinks.first() else {
+            return false;
+        };
+        let max_run_length = usize::from(u8::MAX);
+        let max_key_position = usize::from(u8::MAX);
+        let mut run_length = 1usize;
+
+        for (position, interlink) in self.interlinks.iter().enumerate().skip(1) {
+            if interlink == current {
+                if run_length == max_run_length {
+                    return false;
+                }
+                run_length += 1;
+            } else {
+                if position > max_key_position {
+                    return false;
+                }
+                current = interlink;
+                run_length = 1;
+            }
+        }
+        true
+    }
+
     /// Validates interlinks merkle root against provided proof
     pub fn check_interlinks_proof(&self) -> bool {
-        if self.interlinks.is_empty()
-            && self.interlinks_proof.get_indices().is_empty()
-            && self.interlinks_proof.get_proofs().is_empty()
-        {
-            true
-        } else {
-            let fields: Vec<ergo_merkle_tree::MerkleNode> =
-                NipopowAlgos::pack_interlinks(self.interlinks.clone())
-                    .into_iter()
-                    .map(|(k, v)| -> Vec<u8> {
-                        std::iter::once(2u8)
-                            .chain(k.iter().copied())
-                            .chain(v)
-                            .collect()
-                    })
-                    .map(ergo_merkle_tree::MerkleNode::from_bytes)
-                    .collect();
-            let tree = ergo_merkle_tree::MerkleTree::new(fields);
-            self.interlinks_proof.valid(tree.root_hash().as_ref())
+        let proof_is_empty = self.interlinks_proof.get_indices().is_empty()
+            && self.interlinks_proof.get_proofs().is_empty();
+        if self.interlinks.is_empty() {
+            return proof_is_empty;
         }
+        if !self.has_packable_interlinks() {
+            return false;
+        }
+
+        let fields: Vec<ergo_merkle_tree::MerkleNode> =
+            NipopowAlgos::pack_interlinks(self.interlinks.clone())
+                .into_iter()
+                .map(|(k, v)| -> Vec<u8> {
+                    std::iter::once(2u8)
+                        .chain(k.iter().copied())
+                        .chain(v)
+                        .collect()
+                })
+                .map(ergo_merkle_tree::MerkleNode::from_bytes)
+                .collect();
+        let tree = ergo_merkle_tree::MerkleTree::new(fields);
+        self.interlinks_proof.valid(tree.root_hash().as_ref())
     }
 }
 

--- a/ergo-nipopow/src/nipopow_verifier.rs
+++ b/ergo-nipopow/src/nipopow_verifier.rs
@@ -42,7 +42,7 @@ impl NipopowVerifier {
                     if new_proof.is_better_than(p)? {
                         self.best_proof = Some(new_proof);
                     }
-                } else {
+                } else if new_proof.is_valid() {
                     self.best_proof = Some(new_proof);
                 }
             }


### PR DESCRIPTION
## Merge dependency

This PR is ready for code review, but it must not merge before #852 and #866.
The current structural predicate rejects real JVM-node proofs until #852 fixes
prefix lookback semantics and #866 fixes canonical interlink-key encoding.
Neither prerequisite's diff is included here.

A manual replay of a mainnet proof ending at block 1,784,124 confirmed the
boundary: the proof is rejected by the candidate on standalone `develop` and
selected when the same candidate is stacked on the exact #852 and #866 heads.
The current #852 head also needs formatting cleanup, and the current #866 head
trips the crate's `clippy::expect_used` denial.

## Summary

- require a genesis-anchored initial proof to pass the verifier's existing
  structural validity predicate before it can become `best_proof`
- reject interlink vectors that cannot be represented by the one-byte run
  length and canonical first-occurrence key position before validation calls
  the unchecked packer
- keep invalid-proof handling and the public `process()` API unchanged
- add isolated regression coverage for invalid connections, heights, interlink
  proofs and encoding bounds, genesis anchoring, valid admission, and recovery

## Why

`NipopowVerifier::process` previously stored the first genesis-anchored proof
without calling the predicate used during later proof comparisons. A
structurally invalid first proof could therefore become observable through
`best_proof()` and `best_chain()`.

This PR applies the existing predicate to that initial state transition. It
also makes interlink validation reject an empty-vector/proof mismatch, a run
longer than 255 entries, or a run beginning after position 255 before reaching
`pack_interlinks`.

Invalid proofs continue to be ignored with `Ok(())`, leaving the verifier empty
so that a later valid proof can be accepted.

## Validation

Candidate on the #863 dependency-repair head:

- focused verifier tests: 12/12 in debug and 12/12 in release
- `ergo-chain-generation` library tests: 28/28
- `cargo fmt --all -- --check`
- `cargo clippy -p ergo-nipopow -p ergo-chain-generation --all-targets -- -D warnings`

Candidate stacked on #852, #866, #863, and #903:

- focused verifier tests: 12/12 in debug and 12/12 in release
- `ergo-chain-generation` library tests: 28/28
- `ergo-nipopow` library tests: 2/2
- mainnet block-1,784,124 proof: all interlink proofs valid, connections valid,
  and initial proof selected

The RED phases separately demonstrated the initial-selection bypass, three
unchecked-packer panics, and acceptance of a sparse run beginning at position
256. All focused cases pass with the complete change.

Fresh `develop` currently cannot resolve the yanked `core2` dependency, so
Cargo validation used #863. The isolated JSON target additionally used #903.
Those build repairs are not included in this PR.

## Scope

This PR does not add proof-of-work, `m`/`k`, or continuous-mode difficulty
validation, and it does not claim complete JVM parity, deployed exploitation,
or established funds impact.
