### PR TITLE
fix(bindings): close CI regressions on ci-fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,10 @@ jobs:
           npm run build-nodejs-alpha
           npm run build-browser-alpha
 
+      - name: check generated TypeScript declarations
+        working-directory: bindings/ergo-lib-wasm
+        run: npm run test-types
+
       - name: publish nodejs alpha version to npm
         if: github.event_name == 'push' && env.HAS_NPM_TOKEN == 'true'
         uses: JS-DevTools/npm-publish@v1
@@ -222,6 +226,7 @@ jobs:
   ios_tests:
     name: Test Swift(iOS) bindings
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     # Service containers to run `ergo` node in `devnet` mode
     services:

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64
           - runner: macos-14
             target: aarch64

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -205,6 +205,9 @@ jobs:
       - name: Test stubs
         working-directory: bindings/ergo-lib-python
         run: "source ../../.venv/bin/activate && stubtest ergo_lib_python --allowlist .mypy_allowlist.txt"
+      - name: Type-check constructor signatures
+        working-directory: bindings/ergo-lib-python
+        run: "source ../../.venv/bin/activate && python -m mypy --warn-unused-ignores tests/typing/ergo_box_candidate_constructor.py"
       - name: Run doctests
         working-directory: bindings/ergo-lib-python
         run: "source ../../.venv/bin/activate && cd docs && make doctest"

--- a/bindings/ergo-lib-c-core/src/rest/api/callback.rs
+++ b/bindings/ergo-lib-c-core/src/rest/api/callback.rs
@@ -1,6 +1,8 @@
 use std::ffi::c_void;
 use std::ptr;
 use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use ergo_lib::ergo_rest::NodeResponse;
 
@@ -62,5 +64,217 @@ impl From<&CompletionCallback> for AbortCallback {
             user_data: cc.user_data,
             abort_callback: cc.abort_callback,
         }
+    }
+}
+
+/// Shared one-shot terminal gate for a completion callback and its abort callback.
+pub(crate) struct CallbackGate {
+    claimed: AtomicBool,
+}
+
+impl CallbackGate {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            claimed: AtomicBool::new(false),
+        })
+    }
+
+    fn claim(&self) -> bool {
+        self.claimed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    /// Establish abort as terminal before cancelling the task and releasing caller context.
+    pub(crate) fn abort_with(&self, callback: &AbortCallback, abort_task: impl FnOnce()) {
+        if self.claim() {
+            abort_task();
+            callback.abort_callback();
+        }
+    }
+}
+
+/// Completion callback paired with the same terminal gate held by the request handle.
+pub(crate) struct GatedCompletionCallback {
+    callback: CompletionCallback,
+    gate: Arc<CallbackGate>,
+}
+
+impl GatedCompletionCallback {
+    pub(crate) fn new(callback: CompletionCallback) -> Self {
+        let gate = CallbackGate::new();
+        Self { callback, gate }
+    }
+
+    pub(crate) fn gate(&self) -> Arc<CallbackGate> {
+        Arc::clone(&self.gate)
+    }
+
+    pub(crate) fn succeeded<T: NodeResponse>(self, value: T) {
+        if self.gate.claim() {
+            self.callback.succeeded(value);
+        }
+    }
+
+    pub(crate) fn failed(self, error: Error) {
+        if self.gate.claim() {
+            self.callback.failed(error);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::c_void;
+    use std::ptr::{self, NonNull};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+
+    use futures_util::future::AbortHandle;
+
+    use super::{CompletionCallback, GatedCompletionCallback};
+    use crate::rest::api::node::rest_api_node_get_info;
+    use crate::rest::api::request_handle::RequestHandle;
+    use crate::Error;
+
+    #[derive(Default)]
+    struct CallbackEvents {
+        completions: AtomicUsize,
+        aborts: AtomicUsize,
+    }
+
+    extern "C" fn completion_callback(
+        user_data: NonNull<c_void>,
+        _response: *const c_void,
+        error: *const Error,
+    ) {
+        let events = unsafe { user_data.cast::<CallbackEvents>().as_ref() };
+        events.completions.fetch_add(1, Ordering::SeqCst);
+        if !error.is_null() {
+            unsafe { drop(Box::from_raw(error.cast_mut())) };
+        }
+    }
+
+    extern "C" fn abort_callback(user_data: NonNull<c_void>) {
+        let events = unsafe { user_data.cast::<CallbackEvents>().as_ref() };
+        events.aborts.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn callback_fixture() -> (CompletionCallback, NonNull<CallbackEvents>) {
+        let events = NonNull::from(Box::leak(Box::new(CallbackEvents::default())));
+        let callback = CompletionCallback {
+            user_data: events.cast(),
+            completion_callback,
+            abort_callback,
+        };
+        (callback, events)
+    }
+
+    fn gated_request(callback: CompletionCallback) -> (GatedCompletionCallback, RequestHandle) {
+        let abort_callback = (&callback).into();
+        let callback = GatedCompletionCallback::new(callback);
+        let gate = callback.gate();
+        let (abort_handle, _abort_registration) = AbortHandle::new_pair();
+        let request = RequestHandle::with_gate(abort_handle, abort_callback, gate);
+        (callback, request)
+    }
+
+    fn assert_events(events: NonNull<CallbackEvents>, completions: usize, aborts: usize) {
+        let events_ref = unsafe { events.as_ref() };
+        assert_eq!(events_ref.completions.load(Ordering::SeqCst), completions);
+        assert_eq!(events_ref.aborts.load(Ordering::SeqCst), aborts);
+        unsafe { drop(Box::from_raw(events.as_ptr())) };
+    }
+
+    fn fail(callback: GatedCompletionCallback) {
+        callback.failed(Error::InvalidArgument("callback gate test"));
+    }
+
+    #[test]
+    fn completion_then_abort_has_one_terminal_callback() {
+        let (callback, events) = callback_fixture();
+        let (callback, request) = gated_request(callback);
+
+        fail(callback);
+        request.abort();
+        drop(request);
+
+        assert_events(events, 1, 0);
+    }
+
+    #[test]
+    fn abort_then_completion_has_one_terminal_callback() {
+        let (callback, events) = callback_fixture();
+        let (callback, request) = gated_request(callback);
+
+        request.abort();
+        fail(callback);
+        drop(request);
+
+        assert_events(events, 0, 1);
+    }
+
+    #[test]
+    fn repeated_abort_is_a_no_op_after_the_first_abort() {
+        let (callback, events) = callback_fixture();
+        let (callback, request) = gated_request(callback);
+
+        request.abort();
+        request.abort();
+        drop(callback);
+        drop(request);
+
+        assert_events(events, 0, 1);
+    }
+
+    #[test]
+    fn completion_abort_race_has_exactly_one_terminal_callback() {
+        for _ in 0..128 {
+            let (callback, events) = callback_fixture();
+            let (callback, request) = gated_request(callback);
+            let barrier = Arc::new(Barrier::new(2));
+
+            let completion_barrier = Arc::clone(&barrier);
+            let completion = std::thread::spawn(move || {
+                completion_barrier.wait();
+                fail(callback);
+            });
+
+            barrier.wait();
+            request.abort();
+            completion.join().expect("completion thread must not panic");
+            drop(request);
+
+            let events_ref = unsafe { events.as_ref() };
+            assert_eq!(
+                events_ref.completions.load(Ordering::SeqCst)
+                    + events_ref.aborts.load(Ordering::SeqCst),
+                1
+            );
+            unsafe { drop(Box::from_raw(events.as_ptr())) };
+        }
+    }
+
+    #[test]
+    fn dropping_pending_callback_preserves_existing_no_callback_semantics() {
+        let (callback, events) = callback_fixture();
+        let (callback, request) = gated_request(callback);
+
+        drop(callback);
+        drop(request);
+
+        assert_events(events, 0, 0);
+    }
+
+    #[test]
+    fn synchronous_validation_error_leaves_callback_with_caller() {
+        let (callback, events) = callback_fixture();
+
+        let result = unsafe {
+            rest_api_node_get_info(ptr::null_mut(), ptr::null_mut(), callback, ptr::null_mut())
+        };
+
+        assert!(result.is_err());
+        assert_events(events, 0, 0);
     }
 }

--- a/bindings/ergo-lib-c-core/src/rest/api/node.rs
+++ b/bindings/ergo-lib-c-core/src/rest/api/node.rs
@@ -14,6 +14,7 @@ use self::abortable::spawn_abortable;
 
 use super::callback::AbortCallback;
 use super::callback::CompletionCallback;
+use super::callback::GatedCompletionCallback;
 use super::request_handle::RequestHandle;
 use super::request_handle::RequestHandlePtr;
 use super::runtime::RestApiRuntimePtr;
@@ -30,13 +31,15 @@ pub unsafe fn rest_api_node_get_info(
     let runtime = const_ptr_as_ref(runtime_ptr, "runtime_ptr")?;
     let node_conf = const_ptr_as_ref(node_conf_ptr, "node_conf_ptr")?.0;
     let abort_callback: AbortCallback = (&callback).into();
+    let callback = GatedCompletionCallback::new(callback);
+    let callback_gate = callback.gate();
     let abort_handle = spawn_abortable(runtime, async move {
         match ergo_lib::ergo_rest::api::node::get_info(node_conf).await {
             Ok(node_info) => callback.succeeded(node_info),
             Err(e) => callback.failed(e.into()),
         }
     })?;
-    let request_handle = RequestHandle::new(abort_handle, abort_callback);
+    let request_handle = RequestHandle::with_gate(abort_handle, abort_callback, callback_gate);
     *request_handle_out = Box::into_raw(Box::new(request_handle));
     Ok(())
 }
@@ -53,13 +56,15 @@ pub unsafe fn rest_api_node_get_header(
     let node_conf = const_ptr_as_ref(node_conf_ptr, "node_conf_ptr")?.0;
     let header_id = const_ptr_as_ref(header_id_ptr, "header_id_ptr")?.0;
     let abort_callback: AbortCallback = (&callback).into();
+    let callback = GatedCompletionCallback::new(callback);
+    let callback_gate = callback.gate();
     let abort_handle = spawn_abortable(runtime, async move {
         match ergo_lib::ergo_rest::api::node::get_header(node_conf, header_id).await {
             Ok(header) => callback.succeeded(header),
             Err(e) => callback.failed(e.into()),
         }
     })?;
-    let request_handle = RequestHandle::new(abort_handle, abort_callback);
+    let request_handle = RequestHandle::with_gate(abort_handle, abort_callback, callback_gate);
     *request_handle_out = Box::into_raw(Box::new(request_handle));
     Ok(())
 }
@@ -79,6 +84,8 @@ pub unsafe fn rest_api_node_get_blocks_header_id_proof_for_tx_id(
     let header_id = const_ptr_as_ref(header_id_ptr, "header_id_ptr")?.0;
     let tx_id = const_ptr_as_ref(tx_id_ptr, "tx_id_ptr")?.0;
     let abort_callback: AbortCallback = (&callback).into();
+    let callback = GatedCompletionCallback::new(callback);
+    let callback_gate = callback.gate();
     let abort_handle = spawn_abortable(runtime, async move {
         match ergo_lib::ergo_rest::api::node::get_blocks_header_id_proof_for_tx_id(
             node_conf, header_id, tx_id,
@@ -90,7 +97,7 @@ pub unsafe fn rest_api_node_get_blocks_header_id_proof_for_tx_id(
             Err(e) => callback.failed(e.into()),
         }
     })?;
-    let request_handle = RequestHandle::new(abort_handle, abort_callback);
+    let request_handle = RequestHandle::with_gate(abort_handle, abort_callback, callback_gate);
     *request_handle_out = Box::into_raw(Box::new(request_handle));
     Ok(())
 }
@@ -109,6 +116,8 @@ pub unsafe fn rest_api_node_get_nipopow_proof_by_header_id(
     let node_conf = const_ptr_as_ref(node_conf_ptr, "node_conf_ptr")?.0;
     let header_id = const_ptr_as_ref(header_id_ptr, "header_id_ptr")?.0;
     let abort_callback: AbortCallback = (&callback).into();
+    let callback = GatedCompletionCallback::new(callback);
+    let callback_gate = callback.gate();
     let abort_handle = spawn_abortable(runtime, async move {
         match ergo_lib::ergo_rest::api::node::get_nipopow_proof_by_header_id(
             node_conf,
@@ -122,7 +131,7 @@ pub unsafe fn rest_api_node_get_nipopow_proof_by_header_id(
             Err(e) => callback.failed(e.into()),
         }
     })?;
-    let request_handle = RequestHandle::new(abort_handle, abort_callback);
+    let request_handle = RequestHandle::with_gate(abort_handle, abort_callback, callback_gate);
     *request_handle_out = Box::into_raw(Box::new(request_handle));
     Ok(())
 }
@@ -165,6 +174,8 @@ pub unsafe fn rest_api_node_peer_discovery(
         .ok_or_else(|| Error::Misc("max_parallel_requests must be > 0".into()))?;
     let runtime = const_ptr_as_ref(runtime_ptr, "runtime_ptr")?;
     let abort_callback: AbortCallback = (&callback).into();
+    let callback = GatedCompletionCallback::new(callback);
+    let callback_gate = callback.gate();
     let abort_handle = spawn_abortable(runtime, async move {
         match ergo_lib::ergo_rest::api::node::peer_discovery(
             seeds_bounded_vec,
@@ -195,7 +206,7 @@ pub unsafe fn rest_api_node_peer_discovery(
             Err(e) => callback.failed(e.into()),
         }
     })?;
-    let request_handle = RequestHandle::new(abort_handle, abort_callback);
+    let request_handle = RequestHandle::with_gate(abort_handle, abort_callback, callback_gate);
     *request_handle_out = Box::into_raw(Box::new(request_handle));
     Ok(())
 }

--- a/bindings/ergo-lib-c-core/src/rest/api/request_handle.rs
+++ b/bindings/ergo-lib-c-core/src/rest/api/request_handle.rs
@@ -1,30 +1,44 @@
+use std::sync::Arc;
+
 use futures_util::future::AbortHandle;
 
 use crate::util::const_ptr_as_ref;
 use crate::Error;
 
-use super::callback::AbortCallback;
+use super::callback::{AbortCallback, CallbackGate};
 
 /// A "receipt" of the spawned task
 pub struct RequestHandle {
     /// A handle to abort this task
     abort_handle: AbortHandle,
-    /// A callback which is called on abort action
+    /// Caller-owned callback invoked only when abort wins the terminal race
     abort_callback: AbortCallback,
+    /// Shared terminal gate for the completion/abort callback context
+    callback_gate: Arc<CallbackGate>,
 }
 
 impl RequestHandle {
-    pub fn new(abort_handle: AbortHandle, release_callback: AbortCallback) -> Self {
+    /// Construct a request handle from its legacy abort callback.
+    pub fn new(abort_handle: AbortHandle, abort_callback: AbortCallback) -> Self {
+        Self::with_gate(abort_handle, abort_callback, CallbackGate::new())
+    }
+
+    pub(crate) fn with_gate(
+        abort_handle: AbortHandle,
+        abort_callback: AbortCallback,
+        callback_gate: Arc<CallbackGate>,
+    ) -> Self {
         Self {
             abort_handle,
-            abort_callback: release_callback,
+            abort_callback,
+            callback_gate,
         }
     }
 
     /// Aborts the task and calls abort callback
     pub fn abort(&self) {
-        self.abort_handle.abort();
-        self.abort_callback.abort_callback();
+        self.callback_gate
+            .abort_with(&self.abort_callback, || self.abort_handle.abort());
     }
 }
 

--- a/bindings/ergo-lib-c-core/src/rest/node_conf.rs
+++ b/bindings/ergo-lib-c-core/src/rest/node_conf.rs
@@ -26,3 +26,23 @@ pub unsafe fn node_conf_from_addr(addr: &str, ptr_out: *mut NodeConfPtr) -> Resu
 }
 
 // pub unsafe fn node_conf_builder_new(addr: &str, builder_out: *mut )
+
+#[cfg(test)]
+mod tests {
+    use std::ptr;
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn node_conf_from_addr_sets_default_timeout() {
+        let mut ptr_out: NodeConfPtr = ptr::null_mut();
+
+        unsafe {
+            node_conf_from_addr("127.0.0.1:9053", &mut ptr_out).unwrap();
+            let node_conf = Box::from_raw(ptr_out);
+
+            assert_eq!(node_conf.0.timeout, Some(Duration::from_secs(30)));
+        }
+    }
+}

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/Common.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/Common.swift
@@ -115,6 +115,27 @@ func externalNodeAvailabilityReason(for error: Error) -> String? {
     return reason
 }
 
+func effectiveNodeIdentity(_ url: URL) throws -> String {
+    guard url.scheme == "http" || url.scheme == "https" else {
+        throw NodeConfError.InvalidScheme
+    }
+    guard let host = url.host else { throw NodeConfError.MissingHost }
+    guard let port = url.port else { throw NodeConfError.MissingPort }
+    return host + ":" + String(port)
+}
+
+func distinctNodeUrlsByEffectiveIdentity(_ urls: [URL]) throws -> [URL] {
+    var identities = Set<String>()
+    var distinctUrls: [URL] = []
+    for url in urls {
+        let identity = try effectiveNodeIdentity(url)
+        if identities.insert(identity).inserted {
+            distinctUrls.append(url)
+        }
+    }
+    return distinctUrls
+}
+
 private func nodeOperationErrorDescription(_ error: Error) -> String {
     if let restError = error as? RestNodeApiError {
         switch restError {
@@ -136,6 +157,9 @@ func firstMainnetResult<T>(
             let restNodeApi = try RestNodeApi()
             return try await operation(url, restNodeApi, nodeConf)
         } catch {
+            guard externalNodeAvailabilityReason(for: error) != nil else {
+                throw error
+            }
             lastError = MainnetNodeFallbackError(
                 attemptedUrl: url,
                 underlyingError: error,

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/Common.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/Common.swift
@@ -40,14 +40,16 @@ func getSeeds() -> [URL] {
 }
 
 func getNipopowProof(url: URL, headerId: BlockId) async throws -> NipopowProof? {
-    let nodeConf = try NodeConf(withUrl: url)
-    let restNodeApi = try RestNodeApi()
-    let nodeInfo = try await restNodeApi.getInfoAsync(nodeConf: nodeConf)
-    if nodeInfo.isAtLeastVersion40100() {
-        let proof = try await restNodeApi.getNipopowProofByHeaderIdAsync(
-            nodeConf: nodeConf, minChainLength: UInt32(7), suffixLen: UInt32(6), headerId: headerId)
-        return proof
-    } else {
+    try await firstMainnetResult(urls: [url]) { _, restNodeApi, nodeConf in
+        let nodeInfo = try await restNodeApi.getInfoAsync(nodeConf: nodeConf)
+        if nodeInfo.isAtLeastVersion40100() {
+            return try await restNodeApi.getNipopowProofByHeaderIdAsync(
+                nodeConf: nodeConf,
+                minChainLength: UInt32(7),
+                suffixLen: UInt32(6),
+                headerId: headerId
+            )
+        }
         return nil
     }
 }
@@ -58,35 +60,96 @@ let mainnetNodeUrls = [
     "http://159.65.11.55:9053",
 ].map { URL(string: $0)! }
 
-/// Returns a NodeConf for the first mainnet node that answers a getInfo request.
-/// Throws the last error if no node is reachable.
-func reachableNodeConf() async throws -> NodeConf {
-    var lastError: Error?
-    for url in mainnetNodeUrls {
+struct MainnetNodeFallbackError: Error, LocalizedError {
+    let attemptedUrl: URL?
+    let underlyingError: Error?
+    let underlyingErrorDescription: String
+
+    var errorDescription: String? {
+        guard let attemptedUrl = attemptedUrl else {
+            return underlyingErrorDescription
+        }
+        return "Mainnet node operation failed at \(attemptedUrl.absoluteString): "
+            + underlyingErrorDescription
+    }
+}
+
+func externalNodeAvailabilityReason(for error: Error) -> String? {
+    let underlyingError: Error
+    if let fallbackError = error as? MainnetNodeFallbackError {
+        guard let fallbackUnderlyingError = fallbackError.underlyingError else {
+            return nil
+        }
+        underlyingError = fallbackUnderlyingError
+    } else {
+        underlyingError = error
+    }
+
+    guard let restError = underlyingError as? RestNodeApiError else {
+        return nil
+    }
+    let reason: String
+    switch restError {
+    case .misc(let restReason):
+        reason = restReason
+    }
+
+    guard !reason.contains("kind: Decode") else {
+        return nil
+    }
+    guard reason.contains("ReqwestError") else {
+        return nil
+    }
+
+    let externalMarkers = [
+        "kind: Request",
+        "ConnectError",
+        "ConnectionRefused",
+        "TimedOut",
+        "timed out",
+        "timeout",
+    ]
+    guard externalMarkers.contains(where: { reason.contains($0) }) else {
+        return nil
+    }
+    return reason
+}
+
+private func nodeOperationErrorDescription(_ error: Error) -> String {
+    if let restError = error as? RestNodeApiError {
+        switch restError {
+        case .misc(let reason):
+            return reason
+        }
+    }
+    return error.localizedDescription
+}
+
+func firstMainnetResult<T>(
+    urls: [URL] = mainnetNodeUrls,
+    operation: (URL, RestNodeApi, NodeConf) async throws -> T
+) async throws -> T {
+    var lastError: MainnetNodeFallbackError?
+    for url in urls {
         do {
             let nodeConf = try NodeConf(withUrl: url)
             let restNodeApi = try RestNodeApi()
-            let _ = try await restNodeApi.getInfoAsync(nodeConf: nodeConf)
-            return nodeConf
+            return try await operation(url, restNodeApi, nodeConf)
         } catch {
-            lastError = error
+            lastError = MainnetNodeFallbackError(
+                attemptedUrl: url,
+                underlyingError: error,
+                underlyingErrorDescription: nodeOperationErrorDescription(error)
+            )
         }
     }
-    throw lastError!
-}
 
-/// Blocking wrapper around `reachableNodeConf()` for non-async tests.
-func blockingReachableNodeConf() throws -> NodeConf {
-    let semaphore = DispatchSemaphore(value: 0)
-    var resolved: Result<NodeConf, Error>?
-    Task {
-        do {
-            resolved = .success(try await reachableNodeConf())
-        } catch {
-            resolved = .failure(error)
-        }
-        semaphore.signal()
+    if let lastError = lastError {
+        throw lastError
     }
-    semaphore.wait()
-    return try resolved!.get()
+    throw MainnetNodeFallbackError(
+        attemptedUrl: nil,
+        underlyingError: nil,
+        underlyingErrorDescription: "No mainnet node URLs were configured"
+    )
 }

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/RestNodeApiTests.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/RestNodeApiTests.swift
@@ -4,30 +4,139 @@ import XCTest
 @testable import ErgoLibC
 
 final class RestNodeApiTests: XCTestCase {
-    func testGetNipopowProofByHeaderIdNonAsync() throws {
+    private enum SyntheticNodeError: Error, LocalizedError {
+        case unavailable(URL)
+
+        var errorDescription: String? {
+            switch self {
+            case .unavailable(let url):
+                return "synthetic failure at \(url.absoluteString)"
+            }
+        }
+    }
+
+    func testFirstMainnetResultTriesUrlsInOrderUntilSuccess() async throws {
+        let urls = [
+            URL(string: "http://192.0.2.1:9053")!,
+            URL(string: "http://192.0.2.2:9053")!,
+        ]
+        var attemptedUrls: [URL] = []
+
+        let result: Int = try await firstMainnetResult(urls: urls) { url, _, _ in
+            attemptedUrls.append(url)
+            if url == urls[0] {
+                throw SyntheticNodeError.unavailable(url)
+            }
+            return 42
+        }
+
+        XCTAssertEqual(result, 42)
+        XCTAssertEqual(attemptedUrls, urls)
+    }
+
+    func testFirstMainnetResultThrowsExplicitFallbackError() async throws {
+        let urls = [
+            URL(string: "http://192.0.2.1:9053")!,
+            URL(string: "http://192.0.2.2:9053")!,
+        ]
+        var attemptedUrls: [URL] = []
+
+        do {
+            let _: Int = try await firstMainnetResult(urls: urls) { url, _, _ in
+                attemptedUrls.append(url)
+                throw SyntheticNodeError.unavailable(url)
+            }
+            XCTFail("Expected every synthetic node attempt to fail")
+        } catch let error as MainnetNodeFallbackError {
+            XCTAssertEqual(attemptedUrls, urls)
+            XCTAssertEqual(error.attemptedUrl, urls[1])
+            XCTAssertEqual(
+                error.underlyingErrorDescription,
+                "synthetic failure at \(urls[1].absoluteString)"
+            )
+        } catch {
+            XCTFail("Expected MainnetNodeFallbackError, got \(error)")
+        }
+    }
+
+    func testExternalNodeAvailabilityClassifierAcceptsRequestAndTimeoutReasons() {
+        let url = URL(string: "http://192.0.2.1:9053")!
+        let requestReason = "ReqwestError(reqwest::Error { kind: Request, "
+            + "source: ConnectError(\"connection refused\") })"
+        let timeoutReason = "ReqwestError(reqwest::Error { kind: Request, source: TimedOut })"
+        let timeoutError = MainnetNodeFallbackError(
+            attemptedUrl: url,
+            underlyingError: RestNodeApiError.misc(timeoutReason),
+            underlyingErrorDescription: timeoutReason
+        )
+
+        XCTAssertEqual(
+            externalNodeAvailabilityReason(for: RestNodeApiError.misc(requestReason)),
+            requestReason
+        )
+        XCTAssertEqual(externalNodeAvailabilityReason(for: timeoutError), timeoutReason)
+    }
+
+    func testExternalNodeAvailabilityClassifierRejectsDecodeAndLocalErrors() {
+        let url = URL(string: "http://192.0.2.1:9053")!
+        let decodeReason = "ReqwestError(reqwest::Error { kind: Decode, "
+            + "source: Error(\"request timed out while decoding\") })"
+        let decodeError = MainnetNodeFallbackError(
+            attemptedUrl: url,
+            underlyingError: RestNodeApiError.misc(decodeReason),
+            underlyingErrorDescription: decodeReason
+        )
+        let localError = MainnetNodeFallbackError(
+            attemptedUrl: url,
+            underlyingError: SyntheticNodeError.unavailable(url),
+            underlyingErrorDescription: "synthetic failure"
+        )
+
+        XCTAssertNil(externalNodeAvailabilityReason(for: decodeError))
+        XCTAssertNil(externalNodeAvailabilityReason(for: localError))
+        XCTAssertNil(
+            externalNodeAvailabilityReason(for: RestNodeApiError.misc("synthetic timeout"))
+        )
+    }
+
+    func testGetNipopowProofByHeaderIdNonAsync() async throws {
         let expectation = self.expectation(description: "getNipopowByHeaderIdNonAsync")
-        let nodeConf = try blockingReachableNodeConf()
-        let restNodeApi = try RestNodeApi()
         let blockHeaders = try HeaderTests.generateBlockHeadersFromJSON()
-        let _ = try restNodeApi.getNipopowProofByHeaderId(
-            nodeConf: nodeConf,
-            minChainLength: UInt32(3),
-            suffixLen: UInt32(2),
-            headerId: blockHeaders.get(index: UInt(0))!.getBlockId(),
-            closure: { (res: Result<NipopowProof, Error>) -> Void in
-                switch res {
-                case .success(_):
-                    break
-                case .failure(let error):
-                    XCTFail(error.localizedDescription)
+        let callbackTask = Task {
+            defer { expectation.fulfill() }
+            return try await firstMainnetResult { _, restNodeApi, nodeConf in
+                try await withCheckedThrowingContinuation { continuation in
+                    do {
+                        let _ = try restNodeApi.getNipopowProofByHeaderId(
+                            nodeConf: nodeConf,
+                            minChainLength: UInt32(3),
+                            suffixLen: UInt32(2),
+                            headerId: blockHeaders.get(index: UInt(0))!.getBlockId()
+                        ) { (result: Result<NipopowProof, Error>) in
+                            continuation.resume(with: result)
+                        }
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
                 }
-                expectation.fulfill()
-            })
-        waitForExpectations(timeout: 30, handler: nil)
+            }
+        }
+
+        // Allow two sequential 30-second node attempts plus callback delivery margin.
+        let waiterResult = await XCTWaiter.fulfillment(of: [expectation], timeout: 75)
+        switch waiterResult {
+        case .completed:
+            let proof = try await callbackTask.value
+            XCTAssertNoThrow(try proof.toJSON()!)
+        default:
+            callbackTask.cancel()
+            XCTFail("Callback did not complete before the waiter finished: \(waiterResult)")
+            return
+        }
     }
 
     func testGetNipopowProofByHeaderAbort() throws {
-        let nodeConf = try NodeConf(withAddrString: "213.239.193.208:9053")
+        let nodeConf = try NodeConf(withUrl: mainnetNodeUrls[0])
         let restNodeApi = try RestNodeApi()
         let blockHeaders = try HeaderTests.generateBlockHeadersFromJSON()
         let handle = try restNodeApi.getNipopowProofByHeaderId(
@@ -42,24 +151,26 @@ final class RestNodeApiTests: XCTestCase {
     }
 
     func testGetNipopowProofByHeaderIdAsync() async throws {
-        let nodeConf = try await reachableNodeConf()
-        let restNodeApi = try RestNodeApi()
         let blockHeaders = try HeaderTests.generateBlockHeadersFromJSON()
-        let proof = try await restNodeApi.getNipopowProofByHeaderIdAsync(
-            nodeConf: nodeConf,
-            minChainLength: UInt32(3),
-            suffixLen: UInt32(2),
-            headerId: blockHeaders.get(index: UInt(0))!.getBlockId()
-        )
-        XCTAssertNoThrow(try proof.toJSON()!)
+        let (proof, proofNew) = try await firstMainnetResult { _, restNodeApi, nodeConf in
+            let proof = try await restNodeApi.getNipopowProofByHeaderIdAsync(
+                nodeConf: nodeConf,
+                minChainLength: UInt32(3),
+                suffixLen: UInt32(2),
+                headerId: blockHeaders.get(index: UInt(0))!.getBlockId()
+            )
 
-        // test of re-using of tokio runtime
-        let proofNew = try await restNodeApi.getNipopowProofByHeaderIdAsync(
-            nodeConf: nodeConf,
-            minChainLength: UInt32(3),
-            suffixLen: UInt32(2),
-            headerId: blockHeaders.get(index: UInt(0))!.getBlockId()
-        )
+            // test re-use of the same Tokio runtime
+            let proofNew = try await restNodeApi.getNipopowProofByHeaderIdAsync(
+                nodeConf: nodeConf,
+                minChainLength: UInt32(3),
+                suffixLen: UInt32(2),
+                headerId: blockHeaders.get(index: UInt(0))!.getBlockId()
+            )
+            return (proof, proofNew)
+        }
+
+        XCTAssertNoThrow(try proof.toJSON()!)
         XCTAssertNoThrow(try proofNew.toJSON()!)
     }
 
@@ -107,21 +218,35 @@ final class RestNodeApiTests: XCTestCase {
             withString: "d1366f762e46b7885496aaab0c42ec2950b0422d48aec3b91f45d4d0cdeb41e5")
         let txId = try TxId(
             withString: "258ddfc09b94b8313bca724de44a0d74010cab26de379be845713cc129546b78")
-        // Get NiPoPow proofs from up to 2 separate ergo nodes, skipping unreachable ones
+        // Get NiPoPow proofs from exactly 2 separate configured Ergo nodes.
         var proofs: [NipopowProof] = []
-        var lastError: Error?
+        var proofSourceUrls = Set<URL>()
+        var externalNodeReasons: [String] = []
         for url in mainnetNodeUrls {
             if proofs.count >= 2 { break }
+            if proofSourceUrls.contains(url) { continue }
             do {
                 if let proof = try await getNipopowProof(url: url, headerId: headerId) {
                     proofs.append(proof)
+                    proofSourceUrls.insert(url)
+                } else {
+                    externalNodeReasons.append(
+                        "\(url.absoluteString): node does not expose the required NiPoPoW API"
+                    )
                 }
             } catch {
-                lastError = error
+                guard let reason = externalNodeAvailabilityReason(for: error) else {
+                    throw error
+                }
+                externalNodeReasons.append("\(url.absoluteString): \(reason)")
             }
         }
-        guard !proofs.isEmpty else {
-            throw lastError!
+        guard proofs.count == 2 else {
+            let diagnostics = externalNodeReasons.joined(separator: " | ")
+            throw XCTSkip(
+                "SPV workflow requires NiPoPoW proofs from two configured public nodes; "
+                    + "received \(proofs.count). External-node diagnostics: \(diagnostics)"
+            )
         }
 
         let genesisBlockId = try BlockId(
@@ -133,12 +258,19 @@ final class RestNodeApiTests: XCTestCase {
         let bestProof = verifier.bestProof()
         XCTAssertEqual(try bestProof.suffixHead().getHeader().getBlockId(), headerId)
 
-        // Now verify against a reachable node
-        let nodeConf = try await reachableNodeConf()
-        let restNodeApi = try RestNodeApi()
-        let header = try await restNodeApi.getHeaderAsync(nodeConf: nodeConf, blockId: headerId)
-        let merkleProof = try await restNodeApi.getBlocksHeaderIdProofForTxIdAsync(
-            nodeConf: nodeConf, blockId: headerId, txId: txId)
+        let (header, merkleProof) = try await firstMainnetResult {
+            _, restNodeApi, nodeConf in
+            let header = try await restNodeApi.getHeaderAsync(
+                nodeConf: nodeConf,
+                blockId: headerId
+            )
+            let merkleProof = try await restNodeApi.getBlocksHeaderIdProofForTxIdAsync(
+                nodeConf: nodeConf,
+                blockId: headerId,
+                txId: txId
+            )
+            return (header, merkleProof)
+        }
         XCTAssert(try merkleProof.valid(expected_root: header.getTransactionsRoot()))
     }
 }

--- a/bindings/ergo-lib-ios/Tests/ErgoLibTests/RestNodeApiTests.swift
+++ b/bindings/ergo-lib-ios/Tests/ErgoLibTests/RestNodeApiTests.swift
@@ -1,9 +1,49 @@
+import Foundation
 import XCTest
 
 @testable import ErgoLib
 @testable import ErgoLibC
 
 final class RestNodeApiTests: XCTestCase {
+    private final class CallbackResultState<Value> {
+        private enum State {
+            case pending
+            case completed(Result<Value, Error>)
+            case closed
+        }
+
+        private let lock = NSLock()
+        private var state = State.pending
+
+        @discardableResult
+        func complete(
+            _ result: Result<Value, Error>,
+            expectation: XCTestExpectation
+        ) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard case .pending = state else { return false }
+            state = .completed(result)
+            expectation.fulfill()
+            return true
+        }
+
+        func closeAndTakeResult() -> Result<Value, Error>? {
+            lock.lock()
+            defer { lock.unlock() }
+            switch state {
+            case .pending:
+                state = .closed
+                return nil
+            case .completed(let result):
+                state = .closed
+                return result
+            case .closed:
+                return nil
+            }
+        }
+    }
+
     private enum SyntheticNodeError: Error, LocalizedError {
         case unavailable(URL)
 
@@ -13,6 +53,15 @@ final class RestNodeApiTests: XCTestCase {
                 return "synthetic failure at \(url.absoluteString)"
             }
         }
+    }
+
+    private func syntheticExternalNodeReason(for url: URL) -> String {
+        "ReqwestError(reqwest::Error { kind: Request, source: "
+            + "ConnectError(\"synthetic failure at \(url.absoluteString)\") })"
+    }
+
+    private func syntheticExternalNodeError(for url: URL) -> RestNodeApiError {
+        RestNodeApiError.misc(syntheticExternalNodeReason(for: url))
     }
 
     func testFirstMainnetResultTriesUrlsInOrderUntilSuccess() async throws {
@@ -25,7 +74,7 @@ final class RestNodeApiTests: XCTestCase {
         let result: Int = try await firstMainnetResult(urls: urls) { url, _, _ in
             attemptedUrls.append(url)
             if url == urls[0] {
-                throw SyntheticNodeError.unavailable(url)
+                throw syntheticExternalNodeError(for: url)
             }
             return 42
         }
@@ -44,7 +93,7 @@ final class RestNodeApiTests: XCTestCase {
         do {
             let _: Int = try await firstMainnetResult(urls: urls) { url, _, _ in
                 attemptedUrls.append(url)
-                throw SyntheticNodeError.unavailable(url)
+                throw syntheticExternalNodeError(for: url)
             }
             XCTFail("Expected every synthetic node attempt to fail")
         } catch let error as MainnetNodeFallbackError {
@@ -52,11 +101,89 @@ final class RestNodeApiTests: XCTestCase {
             XCTAssertEqual(error.attemptedUrl, urls[1])
             XCTAssertEqual(
                 error.underlyingErrorDescription,
-                "synthetic failure at \(urls[1].absoluteString)"
+                syntheticExternalNodeReason(for: urls[1])
             )
         } catch {
             XCTFail("Expected MainnetNodeFallbackError, got \(error)")
         }
+    }
+
+    func testFirstMainnetResultDoesNotRetryLocalError() async throws {
+        let urls = [
+            URL(string: "http://192.0.2.1:9053")!,
+            URL(string: "http://192.0.2.2:9053")!,
+        ]
+        var attemptedUrls: [URL] = []
+
+        do {
+            let _: Int = try await firstMainnetResult(urls: urls) { url, _, _ in
+                attemptedUrls.append(url)
+                throw SyntheticNodeError.unavailable(url)
+            }
+            XCTFail("Expected the local error to be rethrown")
+        } catch SyntheticNodeError.unavailable(let url) {
+            XCTAssertEqual(url, urls[0])
+            XCTAssertEqual(attemptedUrls, [urls[0]])
+        } catch {
+            XCTFail("Expected the unchanged local error, got \(error)")
+        }
+    }
+
+    func testFirstMainnetResultDoesNotRetryDecodeError() async throws {
+        let urls = [
+            URL(string: "http://192.0.2.1:9053")!,
+            URL(string: "http://192.0.2.2:9053")!,
+        ]
+        let decodeReason = "ReqwestError(reqwest::Error { kind: Decode, "
+            + "source: Error(\"request timed out while decoding\") })"
+        var attemptedUrls: [URL] = []
+
+        do {
+            let _: Int = try await firstMainnetResult(urls: urls) { url, _, _ in
+                attemptedUrls.append(url)
+                throw RestNodeApiError.misc(decodeReason)
+            }
+            XCTFail("Expected the decode error to be rethrown")
+        } catch RestNodeApiError.misc(let reason) {
+            XCTAssertEqual(reason, decodeReason)
+            XCTAssertEqual(attemptedUrls, [urls[0]])
+        } catch {
+            XCTFail("Expected the unchanged decode error, got \(error)")
+        }
+    }
+
+    func testFirstMainnetResultDoesNotRetryCancellation() async throws {
+        let urls = [
+            URL(string: "http://192.0.2.1:9053")!,
+            URL(string: "http://192.0.2.2:9053")!,
+        ]
+        var attemptedUrls: [URL] = []
+
+        do {
+            let _: Int = try await firstMainnetResult(urls: urls) { url, _, _ in
+                attemptedUrls.append(url)
+                throw CancellationError()
+            }
+            XCTFail("Expected cancellation to be rethrown")
+        } catch is CancellationError {
+            XCTAssertEqual(attemptedUrls, [urls[0]])
+        } catch {
+            XCTFail("Expected the unchanged cancellation, got \(error)")
+        }
+    }
+
+    func testDistinctNodeUrlsUsesEffectiveHostAndPortIdentity() throws {
+        let first = URL(string: "http://192.0.2.1:9053/first")!
+        let sameNodeAlias = URL(string: "https://192.0.2.1:9053/second")!
+        let sameHostDifferentPort = URL(string: "http://192.0.2.1:9054/third")!
+        let second = URL(string: "http://192.0.2.2:9053/third")!
+
+        XCTAssertEqual(
+            try distinctNodeUrlsByEffectiveIdentity(
+                [first, sameNodeAlias, sameHostDifferentPort, second]
+            ),
+            [first, sameHostDifferentPort, second]
+        )
     }
 
     func testExternalNodeAvailabilityClassifierAcceptsRequestAndTimeoutReasons() {
@@ -99,37 +226,74 @@ final class RestNodeApiTests: XCTestCase {
         )
     }
 
+    func testCallbackResultStateAllowsOnlyCompletionOrCloseToWin() throws {
+        let completionWins = CallbackResultState<Int>()
+        let completionExpectation = expectation(description: "completion wins")
+        completionExpectation.assertForOverFulfill = true
+        XCTAssertTrue(
+            completionWins.complete(.success(42), expectation: completionExpectation)
+        )
+        XCTAssertFalse(
+            completionWins.complete(.success(43), expectation: completionExpectation)
+        )
+        wait(for: [completionExpectation], timeout: 0.01)
+        XCTAssertEqual(try completionWins.closeAndTakeResult()?.get(), 42)
+        XCTAssertNil(completionWins.closeAndTakeResult())
+
+        let closeWins = CallbackResultState<Int>()
+        let lateExpectation = expectation(description: "late completion is suppressed")
+        lateExpectation.isInverted = true
+        XCTAssertNil(closeWins.closeAndTakeResult())
+        XCTAssertFalse(closeWins.complete(.success(42), expectation: lateExpectation))
+        wait(for: [lateExpectation], timeout: 0.01)
+    }
+
+    private func assertValidCallbackResult(
+        _ result: Result<NipopowProof, Error>
+    ) throws {
+        switch result {
+        case .success(let proof):
+            XCTAssertNoThrow(try proof.toJSON()!)
+        case .failure(let error):
+            guard let reason = externalNodeAvailabilityReason(for: error) else {
+                throw error
+            }
+            throw XCTSkip("Public mainnet node unavailable: \(reason)")
+        }
+    }
+
     func testGetNipopowProofByHeaderIdNonAsync() async throws {
         let expectation = self.expectation(description: "getNipopowByHeaderIdNonAsync")
         let blockHeaders = try HeaderTests.generateBlockHeadersFromJSON()
-        let callbackTask = Task {
-            defer { expectation.fulfill() }
-            return try await firstMainnetResult { _, restNodeApi, nodeConf in
-                try await withCheckedThrowingContinuation { continuation in
-                    do {
-                        let _ = try restNodeApi.getNipopowProofByHeaderId(
-                            nodeConf: nodeConf,
-                            minChainLength: UInt32(3),
-                            suffixLen: UInt32(2),
-                            headerId: blockHeaders.get(index: UInt(0))!.getBlockId()
-                        ) { (result: Result<NipopowProof, Error>) in
-                            continuation.resume(with: result)
-                        }
-                    } catch {
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
+        let nodeConf = try NodeConf(withUrl: mainnetNodeUrls[0])
+        let restNodeApi = try RestNodeApi()
+        let callbackState = CallbackResultState<NipopowProof>()
+        let requestHandle = try restNodeApi.getNipopowProofByHeaderId(
+            nodeConf: nodeConf,
+            minChainLength: UInt32(3),
+            suffixLen: UInt32(2),
+            headerId: blockHeaders.get(index: UInt(0))!.getBlockId()
+        ) { result in
+            callbackState.complete(result, expectation: expectation)
         }
 
-        // Allow two sequential 30-second node attempts plus callback delivery margin.
-        let waiterResult = await XCTWaiter.fulfillment(of: [expectation], timeout: 75)
+        // The request itself has the upstream 30-second timeout; retain the handle through
+        // callback delivery and leave a bounded scheduling margin for the main queue.
+        let waiterResult = await XCTWaiter.fulfillment(of: [expectation], timeout: 45)
+        let callbackResult = callbackState.closeAndTakeResult()
         switch waiterResult {
         case .completed:
-            let proof = try await callbackTask.value
-            XCTAssertNoThrow(try proof.toJSON()!)
+            guard let result = callbackResult else {
+                XCTFail("Callback completed without recording a result")
+                return
+            }
+            try assertValidCallbackResult(result)
         default:
-            callbackTask.cancel()
+            if let result = callbackResult {
+                try assertValidCallbackResult(result)
+                return
+            }
+            requestHandle.abort()
             XCTFail("Callback did not complete before the waiter finished: \(waiterResult)")
             return
         }
@@ -220,15 +384,12 @@ final class RestNodeApiTests: XCTestCase {
             withString: "258ddfc09b94b8313bca724de44a0d74010cab26de379be845713cc129546b78")
         // Get NiPoPow proofs from exactly 2 separate configured Ergo nodes.
         var proofs: [NipopowProof] = []
-        var proofSourceUrls = Set<URL>()
         var externalNodeReasons: [String] = []
-        for url in mainnetNodeUrls {
+        for url in try distinctNodeUrlsByEffectiveIdentity(mainnetNodeUrls) {
             if proofs.count >= 2 { break }
-            if proofSourceUrls.contains(url) { continue }
             do {
                 if let proof = try await getNipopowProof(url: url, headerId: headerId) {
                     proofs.append(proof)
-                    proofSourceUrls.insert(url)
                 } else {
                     externalNodeReasons.append(
                         "\(url.absoluteString): node does not expose the required NiPoPoW API"

--- a/bindings/ergo-lib-python/ergo_lib_python/chain/__init__.pyi
+++ b/bindings/ergo-lib-python/ergo_lib_python/chain/__init__.pyi
@@ -415,9 +415,6 @@ class ErgoBoxCandidate:
                 :param mint_token_decimals: Decimals of token to be minted
             """
             ...
-    def __init__(self, /, *args, **kwargs) -> None:
-        """Constructor signature is enforced by :py:meth:`__new__`."""
-        ...
     @property
     def value(self) -> int:
         """Amount of nanoErgs in the box"""

--- a/bindings/ergo-lib-python/tests/typing/ergo_box_candidate_constructor.py
+++ b/bindings/ergo-lib-python/tests/typing/ergo_box_candidate_constructor.py
@@ -1,0 +1,16 @@
+from typing import Union
+
+from ergo_lib_python.chain import Address, ErgoBoxCandidate
+from ergo_lib_python.ergo_tree import ErgoTree
+
+Script = Union[Address, ErgoTree]
+
+
+def accepts_valid(script: Script) -> ErgoBoxCandidate:
+    return ErgoBoxCandidate(value=1_000_000, script=script, creation_height=0)
+
+
+def rejects_invalid(script: Script) -> None:
+    ErgoBoxCandidate(bogus=True)  # type: ignore[call-arg]
+    ErgoBoxCandidate(value="bad", script=script, creation_height="bad")  # type: ignore[arg-type]
+    ErgoBoxCandidate(1, script, 0)  # type: ignore[misc]

--- a/bindings/ergo-lib-wasm/package.json
+++ b/bindings/ergo-lib-wasm/package.json
@@ -12,6 +12,7 @@
         "build-nodejs-alpha": "rm -rf ./pkg-nodejs && cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --dev --target nodejs --out-dir pkg-nodejs && cd pkg-nodejs && node ../scripts/publish_helper -nodejs && npm version minor && node ../scripts/set_alpha_version -nodejs $(git rev-parse --short HEAD)",
         "build-browser": "rm -rf ./pkg-browser && cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --target browser --out-dir pkg-browser --features rest && cd pkg-browser && node ../scripts/publish_helper -browser && node ../scripts/set_exports",
         "build-browser-alpha": "rm -rf ./pkg-browser && cross-env WASM_BINDGEN_WEAKREF=1 wasm-pack build --dev --target browser --out-dir pkg-browser --features rest && cd pkg-browser && node ../scripts/publish_helper -browser && node ../scripts/set_exports && npm version minor && node ../scripts/set_alpha_version -browser $(git rev-parse --short HEAD)",
+        "test-types": "npx --yes --package=typescript@4.5.4 -- tsc -p tests/typescript/tsconfig.es2020.json && npx --yes --package=typescript@5.1.6 -- tsc -p tests/typescript/tsconfig.es2020.json && npx --yes --package=typescript@5.9.3 -- tsc -p tests/typescript/tsconfig.es2020.json && npx --yes --package=typescript@5.9.3 -- tsc -p tests/typescript/tsconfig.disposable.json",
         "publish-nodejs": "npm run build-nodejs &&  cd pkg-nodejs && npm publish",
         "publish-browser": "npm run build-browser && cd pkg-browser && npm publish"
     },

--- a/bindings/ergo-lib-wasm/src/lib.rs
+++ b/bindings/ergo-lib-wasm/src/lib.rs
@@ -20,6 +20,18 @@
 #![deny(clippy::todo)]
 #![deny(clippy::unimplemented)]
 
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TYPESCRIPT_SYMBOL_DISPOSE_COMPAT: &str = r#"
+declare const __wbg_dispose_fallback: unique symbol;
+declare const Symbol: {
+    readonly dispose: typeof globalThis.Symbol extends {
+        readonly dispose: infer T;
+    } ? T : typeof __wbg_dispose_fallback;
+};
+"#;
+
 pub mod address;
 pub mod ast;
 pub mod batchmerkleproof;

--- a/bindings/ergo-lib-wasm/tests/typescript/disposable.ts
+++ b/bindings/ergo-lib-wasm/tests/typescript/disposable.ts
@@ -1,0 +1,12 @@
+import { Address as BrowserAddress } from "../../pkg-browser/ergo_lib_wasm";
+import { Address as NodeAddress } from "../../pkg-nodejs/ergo_lib_wasm";
+
+type Assert<T extends true> = T;
+type BrowserAddressIsDisposable = Assert<BrowserAddress extends Disposable ? true : false>;
+type NodeAddressIsDisposable = Assert<NodeAddress extends Disposable ? true : false>;
+
+declare const browserAddress: BrowserAddress;
+declare const nodeAddress: NodeAddress;
+
+browserAddress[Symbol.dispose]();
+nodeAddress[Symbol.dispose]();

--- a/bindings/ergo-lib-wasm/tests/typescript/es2020.ts
+++ b/bindings/ergo-lib-wasm/tests/typescript/es2020.ts
@@ -1,0 +1,8 @@
+import { Address as BrowserAddress } from "../../pkg-browser/ergo_lib_wasm";
+import { Address as NodeAddress } from "../../pkg-nodejs/ergo_lib_wasm";
+
+declare const browserAddress: BrowserAddress;
+declare const nodeAddress: NodeAddress;
+
+browserAddress.free();
+nodeAddress.free();

--- a/bindings/ergo-lib-wasm/tests/typescript/tsconfig.disposable.json
+++ b/bindings/ergo-lib-wasm/tests/typescript/tsconfig.disposable.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.es2020.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "DOM", "ESNext.Disposable"]
+  },
+  "files": ["disposable.ts"]
+}

--- a/bindings/ergo-lib-wasm/tests/typescript/tsconfig.es2020.json
+++ b/bindings/ergo-lib-wasm/tests/typescript/tsconfig.es2020.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false,
+    "types": [],
+    "lib": ["ES2020", "DOM"]
+  },
+  "files": ["es2020.ts"]
+}

--- a/bindings/ergo-lib-wasm/tests_browser/test_rest_api.js
+++ b/bindings/ergo-lib-wasm/tests_browser/test_rest_api.js
@@ -1,9 +1,204 @@
-import { expect, assert } from "chai";
+import { expect, assert, AssertionError } from "chai";
 
 import * as ergo from "..";
 let ergo_wasm;
 beforeEach(async () => {
     ergo_wasm = await ergo;
+});
+
+it('node REST helpers: ordered fallback tries each distinct host once', async () => {
+    const first = new URL("http://127.0.0.1:19053/first");
+    const same_endpoint = new URL("https://127.0.0.1:19053/second");
+    const second = new URL("http://127.0.0.1:29053");
+    const attempts = [];
+
+    const result = await with_fallback_node((_node_conf, url) => {
+        attempts.push(url.href);
+        if (url.href === first.href) {
+            throw fixture_node_error("reqwest error: error sending request");
+        }
+        return "success";
+    }, [first, same_endpoint, second]);
+
+    expect(result).to.equal("success");
+    expect(attempts).to.deep.equal([first.href, second.href]);
+});
+
+it('node REST helpers: all-fail fallback reports every attempted URL and final cause', async () => {
+    const urls = [
+        new URL("http://127.0.0.1:19053"),
+        new URL("http://127.0.0.1:29053"),
+    ];
+
+    let failure;
+    try {
+        await with_fallback_node((_node_conf, url) => {
+            throw fixture_node_error("reqwest error: error sending request");
+        }, urls);
+    } catch (e) {
+        failure = e;
+    }
+
+    expect(failure).to.be.an("error");
+    expect(failure.name).to.equal("NodeFallbackError");
+    expect(failure.attemptedUrls).to.deep.equal(urls.map(url => url.href));
+    expect(failure.message).to.include(urls[0].href);
+    expect(failure.message).to.include(urls[1].href);
+    expect(failure.message).to.include("reqwest error: error sending request");
+});
+
+it('node REST helpers: empty fallback reports that no URL was attempted', async () => {
+    let failure;
+    try {
+        await with_fallback_node(() => "unused", []);
+    } catch (e) {
+        failure = e;
+    }
+
+    expect(failure).to.be.an("error");
+    expect(failure.name).to.equal("NodeFallbackError");
+    expect(failure.attemptedUrls).to.deep.equal([]);
+    expect(failure.message).to.include("attempted URLs: none");
+});
+
+it('node REST helpers: proof collection skips one failed URL then returns two distinct proofs', async () => {
+    const urls = [
+        new URL("http://127.0.0.1:19053"),
+        new URL("http://127.0.0.1:29053"),
+        new URL("http://127.0.0.1:39053"),
+    ];
+    const attempts = [];
+
+    const proofs = await collect_two_nipopow_proofs(urls, async url => {
+        attempts.push(url.href);
+        if (url.href === urls[0].href) {
+            throw fixture_node_error("reqwest error: error sending request");
+        }
+        return `proof from ${url.href}`;
+    });
+
+    expect(proofs).to.deep.equal([
+        `proof from ${urls[1].href}`,
+        `proof from ${urls[2].href}`,
+    ]);
+    expect(attempts).to.deep.equal(urls.map(url => url.href));
+});
+
+it('node REST helpers: URLs with the same effective host cannot satisfy the two-source precondition', async () => {
+    const first = new URL("http://127.0.0.1:19053/first");
+    const same_endpoint = new URL("https://127.0.0.1:19053/second");
+    let calls = 0;
+    let failure;
+
+    try {
+        await collect_two_nipopow_proofs([first, same_endpoint], async () => {
+            calls += 1;
+            return "one proof";
+        });
+    } catch (e) {
+        failure = e;
+    }
+
+    expect(calls).to.equal(1);
+    expect(failure).to.be.an("error");
+    expect(failure.name).to.equal("InsufficientNipopowSourcesError");
+    expect(failure.attemptedUrls).to.deep.equal([first.href]);
+    expect(failure.successfulUrls).to.deep.equal([first.href]);
+    expect(is_external_node_unavailability(failure)).to.equal(false);
+});
+
+it('node REST helpers: one proof plus one unavailable source remains insufficient', async () => {
+    const urls = [
+        new URL("http://127.0.0.1:19053"),
+        new URL("http://127.0.0.1:29053"),
+    ];
+    let failure;
+
+    try {
+        await collect_two_nipopow_proofs(urls, async url => {
+            if (url.href === urls[0].href) {
+                return "one proof";
+            }
+            throw fixture_node_error("reqwest error: error sending request");
+        });
+    } catch (e) {
+        failure = e;
+    }
+
+    expect(failure).to.be.an("error");
+    expect(failure.name).to.equal("InsufficientNipopowSourcesError");
+    expect(failure.successfulUrls).to.deep.equal([urls[0].href]);
+    expect(is_external_node_unavailability(failure)).to.equal(true);
+});
+
+it('node REST helpers: only the REST binding sending-request error classifies as external', () => {
+    expect(is_recognizable_external_node_error(
+        fixture_node_error("reqwest error: error sending request")
+    )).to.equal(true);
+    expect(is_recognizable_external_node_error(
+        fixture_node_error("reqwest error: error decoding response body")
+    )).to.equal(false);
+    expect(is_recognizable_external_node_error(new TypeError("Failed to fetch"))).to.equal(false);
+    expect(is_recognizable_external_node_error(new Error("connection refused"))).to.equal(false);
+    expect(is_recognizable_external_node_error(new Error("request timed out"))).to.equal(false);
+
+    const assertion_failure = new Error("expected timeout assertion to hold");
+    assertion_failure.name = "AssertionError";
+    expect(is_recognizable_external_node_error(assertion_failure)).to.equal(false);
+});
+
+it('node REST helpers: fallback rethrows local errors unchanged without trying another host', async () => {
+    const urls = [
+        new URL("http://127.0.0.1:19053"),
+        new URL("http://127.0.0.1:29053"),
+    ];
+    const local_errors = [
+        fixture_node_error("reqwest error: error decoding response body"),
+        new AssertionError("local assertion failure"),
+    ];
+
+    for (const expected_error of local_errors) {
+        const attempts = [];
+        let failure;
+        try {
+            await with_fallback_node((_node_conf, url) => {
+                attempts.push(url.href);
+                throw expected_error;
+            }, urls);
+        } catch (e) {
+            failure = e;
+        }
+
+        expect(failure).to.equal(expected_error);
+        expect(attempts).to.deep.equal([urls[0].href]);
+    }
+});
+
+it('node REST helpers: proof collection rethrows local errors unchanged without trying another host', async () => {
+    const urls = [
+        new URL("http://127.0.0.1:19053"),
+        new URL("http://127.0.0.1:29053"),
+    ];
+    const local_errors = [
+        fixture_node_error("reqwest error: error decoding response body"),
+        new AssertionError("local assertion failure"),
+    ];
+
+    for (const expected_error of local_errors) {
+        const attempts = [];
+        let failure;
+        try {
+            await collect_two_nipopow_proofs(urls, async url => {
+                attempts.push(url.href);
+                throw expected_error;
+            });
+        } catch (e) {
+            failure = e;
+        }
+
+        expect(failure).to.equal(expected_error);
+        expect(attempts).to.deep.equal([urls[0].href]);
+    }
 });
 
 // Note that the REST API tests are here due to the WASM implementation of `reqwest-wrap`. In
@@ -50,58 +245,78 @@ it('node REST API: get_nipopow_proof_by_header_id endpoint', async () => {
     assert(res != null);
 });
 
-it('node REST API: example SPV workflow', async () => {
-    const header_id = ergo_wasm.BlockId.from_str("d1366f762e46b7885496aaab0c42ec2950b0422d48aec3b91f45d4d0cdeb41e5")
-    assert(header_id != null);
-    let tx_id = ergo_wasm.TxId.from_str("258ddfc09b94b8313bca724de44a0d74010cab26de379be845713cc129546b78");
-    assert(tx_id != null);
+it('node REST API: example SPV workflow', async function () {
+    try {
+        const header_id = ergo_wasm.BlockId.from_str("d1366f762e46b7885496aaab0c42ec2950b0422d48aec3b91f45d4d0cdeb41e5")
+        assert(header_id != null);
+        let tx_id = ergo_wasm.TxId.from_str("258ddfc09b94b8313bca724de44a0d74010cab26de379be845713cc129546b78");
+        assert(tx_id != null);
 
-    // Get NiPoPow proofs from up to 2 separate ergo nodes, skipping unreachable ones
-    let proofs = [];
-    let last_err;
-    for (const url of MAINNET_NODE_URLS) {
-        if (proofs.length >= 2) break;
-        try {
-            proofs.push(await get_nipopow_proof(url, header_id));
-        } catch (e) {
-            console.log("get_nipopow_proof failed for", url.href, e);
-            last_err = e;
+        const proofs = await collect_two_nipopow_proofs(
+            MAINNET_NODE_URLS,
+            url => get_nipopow_proof(url, header_id),
+        );
+        assert.strictEqual(proofs.length, 2, "SPV workflow requires two distinct proof sources");
+
+        const genesis_block_id = ergo_wasm.BlockId.from_str("b0244dfc267baca974a4caee06120321562784303a8a688976ae56170e4d175b");
+        let verifier = new ergo_wasm.NipopowVerifier(genesis_block_id);
+        assert(verifier != null, "verifier should be non-null");
+        for (const proof of proofs) {
+            verifier.process(proof);
         }
-    }
-    assert(proofs.length > 0, `all nodes failed: ${last_err}`);
+        let best_proof = verifier.best_proof();
+        assert(best_proof != null, "best proof should exist");
+        assert(best_proof.suffix_head().id().equals(header_id), "equality");
 
-    const genesis_block_id = ergo_wasm.BlockId.from_str("b0244dfc267baca974a4caee06120321562784303a8a688976ae56170e4d175b");
-    let verifier = new ergo_wasm.NipopowVerifier(genesis_block_id);
-    assert(verifier != null, "verifier should be non-null");
-    for (const proof of proofs) {
-        verifier.process(proof);
+        // Verify against a reachable node
+        let header = await with_fallback_node(node_conf => ergo_wasm.get_header(node_conf, header_id));
+        assert(header != null, "header should be non-null");
+        let merkle_proof = await with_fallback_node(node_conf =>
+            ergo_wasm.get_blocks_header_id_proof_for_tx_id(node_conf, header_id, tx_id));
+        assert(merkle_proof != null, "merkle_proof should be non-null");
+        assert(merkle_proof.valid(header.transactions_root()), "merkle_proof should be valid");
+    } catch (e) {
+        if (is_external_node_unavailability(e)) {
+            console.warn("Skipping SPV workflow because public nodes are unavailable:", e.message);
+            this.skip();
+            return;
+        }
+        throw e;
     }
-    let best_proof = verifier.best_proof();
-    assert(best_proof != null, "best proof should exist");
-    assert(best_proof.suffix_head().id().equals(header_id), "equality");
-
-    // Verify against a reachable node
-    let header = await with_fallback_node(node_conf => ergo_wasm.get_header(node_conf, header_id));
-    assert(header != null, "header should be non-null");
-    let merkle_proof = await with_fallback_node(node_conf =>
-        ergo_wasm.get_blocks_header_id_proof_for_tx_id(node_conf, header_id, tx_id));
-    assert(merkle_proof != null, "merkle_proof should be non-null");
-    assert(merkle_proof.valid(header.transactions_root()), "merkle_proof should be valid");
 });
 
-// Run `fn` against each known mainnet node, returning the first success.
-// Throws the last error if all nodes fail.
-async function with_fallback_node(fn) {
-    let last_err;
-    for (const url of MAINNET_NODE_URLS) {
+// Run `fn` against each distinct node URL, returning the first success.
+async function with_fallback_node(fn, urls = MAINNET_NODE_URLS) {
+    const attempted_urls = [];
+    const failures = [];
+    for (const url of distinct_urls(urls)) {
+        attempted_urls.push(url.href);
         try {
-            return await fn(new ergo_wasm.NodeConf(url));
+            const node_conf = new ergo_wasm.NodeConf(url);
+            return await fn(node_conf, url);
         } catch (e) {
             console.log("node request failed for", url.href, e);
-            last_err = e;
+            if (!is_recognizable_external_node_error(e)) {
+                throw e;
+            }
+            failures.push({ url: url.href, cause: e });
         }
     }
-    throw last_err;
+
+    const final_cause = failures.length > 0
+        ? describe_error(failures[failures.length - 1].cause)
+        : "none";
+    const error = new Error(
+        `node fallback failed; attempted URLs: ${format_urls(attempted_urls)}; final cause: ${final_cause}`
+    );
+    error.name = "NodeFallbackError";
+    error.attemptedUrls = attempted_urls;
+    error.causes = failures.map(failure => ({
+        url: failure.url,
+        cause: describe_error(failure.cause),
+    }));
+    error.externalFailuresOnly = failures.length > 0;
+    throw error;
 }
 
 async function get_nipopow_proof(url, header_id) {
@@ -115,6 +330,90 @@ async function get_nipopow_proof(url, header_id) {
     let proof = await ergo_wasm.get_nipopow_proof_by_header_id(node_conf, 7, 6, header_id);
     assert(proof != null);
     return proof;
+}
+
+async function collect_two_nipopow_proofs(urls, fetch_proof) {
+    const attempted_urls = [];
+    const successful_urls = [];
+    const proofs = [];
+    const failures = [];
+
+    for (const url of distinct_urls(urls)) {
+        attempted_urls.push(url.href);
+        try {
+            const proof = await fetch_proof(url);
+            proofs.push(proof);
+            successful_urls.push(url.href);
+            if (proofs.length === 2) {
+                return proofs;
+            }
+        } catch (e) {
+            console.log("get_nipopow_proof failed for", url.href, e);
+            if (!is_recognizable_external_node_error(e)) {
+                throw e;
+            }
+            failures.push({ url: url.href, cause: e });
+        }
+    }
+
+    const causes = failures.length > 0
+        ? failures.map(failure => `${failure.url}: ${describe_error(failure.cause)}`).join("; ")
+        : "none";
+    const error = new Error(
+        `insufficient distinct NiPoPoW sources: ${proofs.length} success(es); ` +
+        `attempted URLs: ${format_urls(attempted_urls)}; causes: ${causes}`
+    );
+    error.name = "InsufficientNipopowSourcesError";
+    error.attemptedUrls = attempted_urls;
+    error.successfulUrls = successful_urls;
+    error.causes = failures.map(failure => ({
+        url: failure.url,
+        cause: describe_error(failure.cause),
+    }));
+    error.externalFailuresOnly = failures.length > 0;
+    throw error;
+}
+
+function distinct_urls(urls) {
+    const seen = new Set();
+    return urls.filter(url => {
+        // NodeConf retains only URL.host, so scheme and path do not identify a new node.
+        if (seen.has(url.host)) {
+            return false;
+        }
+        seen.add(url.host);
+        return true;
+    });
+}
+
+function format_urls(urls) {
+    return urls.length > 0 ? urls.join(", ") : "none";
+}
+
+function describe_error(error) {
+    if (error instanceof Error) {
+        return `${error.name}: ${error.message}`;
+    }
+    return String(error);
+}
+
+function is_recognizable_external_node_error(error) {
+    return error instanceof Error &&
+        error.name === "NodeError" &&
+        error.message === "reqwest error: error sending request";
+}
+
+function is_external_node_unavailability(error) {
+    return error instanceof Error &&
+        (error.name === "NodeFallbackError" ||
+            error.name === "InsufficientNipopowSourcesError") &&
+        error.externalFailuresOnly === true;
+}
+
+function fixture_node_error(message) {
+    const error = new Error(message);
+    error.name = "NodeError";
+    return error;
 }
 
 function get_ergo_node_seeds() {


### PR DESCRIPTION
## Context

This is a focused follow-up stacked on #916 (`ci-fixes`). It incorporates the actionable binding/test findings from [Odiseus's review](https://github.com/ergoplatform/sigma-rust/pull/916#issuecomment-5494671644) while preserving the upstream 30-second `NodeConf` default added in `45e4b412`.

No dependency manifest or custom timeout API is changed here.

## Changes

- Preserve ordinary ES2020 TypeScript consumption of generated WASM declarations while retaining `Disposable` identity when consumers enable `esnext.disposable`.
- Restore the typed Python `ErgoBoxCandidate` constructor stub and exercise it with mypy in Python CI.
- Arbitrate C-core REST completion versus abort through a shared one-shot terminal gate, so repeated or concurrent abort/completion can invoke caller-owned callback state only once without changing the C ABI.
- Remove the iOS main-queue semaphore deadlock, retain and abort the callback request handle on a bounded waiter timeout, and suppress callbacks that arrive after the test has closed.
- Retry Swift public-node operations only for recognized transport availability errors; local, decode, and cancellation failures remain fail-fast.
- Require the Swift and WASM SPV workflows to obtain exactly two proofs from distinct effective node identities (`host:port`), with deterministic alias/deduplication coverage.
- Add bounded, fail-closed WASM public-node fallback tests and CI checks for the TypeScript/Python contracts.
- Move the Python `x86_64` wheel job from the retired `macos-13` runner to `macos-15-intel`.

## Related PRs

- #845 makes the iOS SPV workflow opt-in in CI. This PR instead keeps that coverage active, bounds external failures, and preserves the two-source assertion, so the approaches are related but not duplicates.
- #863 remains the separate dependency-custody alternative. The explicit exact `core3` pin in #916 removes hidden aliasing/direct semver drift, but does not establish Ergo-controlled custody or eliminate future yank risk.

## Validation

- `ergo-lib-c-core --features rest`: 7 passed, including completion-first, abort-first, repeated abort, synchronous validation ownership, drop semantics, and 128 completion/abort races.
- `ergo-lib-c --features rest`: consumer test/check passed; Clippy with warnings denied and rustfmt passed.
- TypeScript: 4.5.4, 5.1.6, and 5.9.3 with ES2020, plus 5.9.3 with `esnext.disposable`.
- Python: mypy constructor fixture passed; 11 unit tests passed.
- WASM deterministic node REST suite: 9 passed.
- Full local browser suite: 58 of 59 executed tests passed. The only failure was the pre-existing devnet-only `/info` test because no node was running at `127.0.0.1:9053`; peer discovery, public NiPoPoW, and the two-proof SPV workflow passed.
- GitHub Actions on `c34be562`: 27 checks passed, including Swift/iOS, browser JS and generated TypeScript declarations, every Python wheel lane, and `macos-15-intel`/`x86_64`. The release job and npm publication steps were skipped as intended for a pull request.
- Swift is not available on the local validation host; the pull-request Swift/iOS job is the executable Swift gate.

## Scope

This does not redesign the production Swift async wrappers or change pre-existing panic/runtime-shutdown semantics. It does not select a dependency-custody strategy, merge #916, tag a version, publish packages, or perform a release.
