### PR TITLE
Fix checked arithmetic, reduced signing, and release preflight regressions

### DIFF
--- a/.github/workflows/release_preflight.yml
+++ b/.github/workflows/release_preflight.yml
@@ -25,9 +25,9 @@ jobs:
   rust-package:
     name: Package Rust workspace candidates
     runs-on: ubuntu-latest
-    env:
-      CARGO_TARGET_DIR: ${{ runner.temp }}/cargo-target
     steps:
+      - name: Set Cargo target directory
+        run: echo "CARGO_TARGET_DIR=$RUNNER_TEMP/cargo-target" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.91.1
       - name: Package workspace candidates
@@ -42,9 +42,9 @@ jobs:
   wasm-packages:
     name: Package final WASM artifacts
     runs-on: ubuntu-latest
-    env:
-      CARGO_TARGET_DIR: ${{ runner.temp }}/cargo-target
     steps:
+      - name: Set Cargo target directory
+        run: echo "CARGO_TARGET_DIR=$RUNNER_TEMP/cargo-target" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.91.1
       - uses: actions/setup-node@v4

--- a/.github/workflows/release_preflight.yml
+++ b/.github/workflows/release_preflight.yml
@@ -65,7 +65,7 @@ jobs:
           install --directory "$RUNNER_TEMP/bin"
           install "$RUNNER_TEMP/wasm-pack-v0.14.0-x86_64-unknown-linux-musl/wasm-pack" "$RUNNER_TEMP/bin/wasm-pack"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
-          test "$(wasm-pack --version)" = "wasm-pack 0.14.0"
+          test "$("$RUNNER_TEMP/bin/wasm-pack" --version)" = "wasm-pack 0.14.0"
       - name: Install WASM package dependencies
         working-directory: bindings/ergo-lib-wasm
         run: npm ci

--- a/bindings/ergo-lib-c/src/unsignedbigint256.rs
+++ b/bindings/ergo-lib-c/src/unsignedbigint256.rs
@@ -1,8 +1,8 @@
 use std::ffi::CStr;
 
 use ergo_lib_c_core::unsignedbigint256::{
-    CheckedAdd, CheckedMul, CheckedRem, CheckedSub, ConstUnsignedBigIntPtr, Num, UnsignedBigInt,
-    UnsignedBigIntPtr, UnsignedBigIntRaw,
+    CheckedAdd, CheckedDiv, CheckedMul, CheckedRem, CheckedSub, ConstUnsignedBigIntPtr, Num,
+    UnsignedBigInt, UnsignedBigIntPtr, UnsignedBigIntRaw,
 };
 
 unsafe fn cast_ptr<'a>(ptr: ConstUnsignedBigIntPtr) -> Option<&'a UnsignedBigIntRaw> {
@@ -81,14 +81,14 @@ pub unsafe extern "C" fn ergo_lib_u256_mul(
 }
 
 /// Divide a by b, putting result in out
-/// Arithmetic is checked, so if the result overflowed 1 will be returned and nothing will be written to out
+/// Returns 1 if b is zero and nothing will be written to out
 #[no_mangle]
 pub unsafe extern "C" fn ergo_lib_u256_div(
     a: ConstUnsignedBigIntPtr,
     b: ConstUnsignedBigIntPtr,
     out: UnsignedBigIntPtr,
 ) -> u32 {
-    wrap_arith_op(out, || cast_ptr(a)?.checked_mul(cast_ptr(b)?))
+    wrap_arith_op(out, || cast_ptr(a)?.checked_div(cast_ptr(b)?))
 }
 
 /// Compute (a + b) mod modulus
@@ -183,9 +183,87 @@ pub unsafe extern "C" fn ergo_lib_u256_cmp(
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use super::{ergo_lib_u256_add, ergo_lib_u256_new};
+    use super::{
+        ergo_lib_u256_add, ergo_lib_u256_div, ergo_lib_u256_mod_inv, ergo_lib_u256_mod_sub,
+        ergo_lib_u256_new,
+    };
     use crate::{ergo_lib_u256_cmp, ergo_lib_u256_from_long, ergo_lib_u256_from_str_radix};
     use std::ffi::CString;
+
+    #[test]
+    fn division_returns_quotient() {
+        // Inputs and output are distinct, initialized, correctly aligned values.
+        unsafe {
+            let a = ergo_lib_u256_from_long(10);
+            let b = ergo_lib_u256_from_long(2);
+            let mut out = ergo_lib_u256_from_long(99);
+            assert_eq!(ergo_lib_u256_div(&a, &b, &mut out), 0);
+            assert_eq!(out.0, [5, 0, 0, 0]);
+        }
+    }
+
+    #[test]
+    fn division_truncates_remainder() {
+        // Inputs and output are distinct, initialized, correctly aligned values.
+        unsafe {
+            let a = ergo_lib_u256_from_long(11);
+            let b = ergo_lib_u256_from_long(2);
+            let mut out = ergo_lib_u256_from_long(99);
+            assert_eq!(ergo_lib_u256_div(&a, &b, &mut out), 0);
+            assert_eq!(out.0, [5, 0, 0, 0]);
+        }
+    }
+
+    #[test]
+    fn division_by_zero_preserves_output() {
+        // Inputs and output are distinct, initialized, correctly aligned values.
+        unsafe {
+            let a = ergo_lib_u256_from_long(10);
+            let zero = ergo_lib_u256_new();
+            let mut out = ergo_lib_u256_from_long(99);
+            assert_eq!(ergo_lib_u256_div(&a, &zero, &mut out), 1);
+            assert_eq!(out.0, [99, 0, 0, 0]);
+        }
+    }
+
+    fn assert_mod_sub_zero_preserves_output(a: u64, b: u64) {
+        // Inputs and output are distinct, initialized, correctly aligned values.
+        unsafe {
+            let a = ergo_lib_u256_from_long(a);
+            let b = ergo_lib_u256_from_long(b);
+            let zero = ergo_lib_u256_new();
+            let mut out = ergo_lib_u256_from_long(99);
+            assert_eq!(ergo_lib_u256_mod_sub(&a, &b, &zero, &mut out), 1);
+            assert_eq!(out.0, [99, 0, 0, 0]);
+        }
+    }
+
+    #[test]
+    fn mod_sub_zero_modulus_greater_operands_preserves_output() {
+        assert_mod_sub_zero_preserves_output(5, 3);
+    }
+
+    #[test]
+    fn mod_sub_zero_modulus_equal_operands_preserves_output() {
+        assert_mod_sub_zero_preserves_output(3, 3);
+    }
+
+    #[test]
+    fn mod_sub_zero_modulus_less_operands_preserves_output() {
+        assert_mod_sub_zero_preserves_output(1, 3);
+    }
+
+    #[test]
+    fn mod_inv_zero_modulus_preserves_output() {
+        // Inputs and output are distinct, initialized, correctly aligned values.
+        unsafe {
+            let a = ergo_lib_u256_from_long(5);
+            let zero = ergo_lib_u256_new();
+            let mut out = ergo_lib_u256_from_long(99);
+            assert_eq!(ergo_lib_u256_mod_inv(&a, &zero, &mut out), 1);
+            assert_eq!(out.0, [99, 0, 0, 0]);
+        }
+    }
 
     #[test]
     fn test_ops() {

--- a/bindings/ergo-lib-wasm/src/unsignedbigint256.rs
+++ b/bindings/ergo-lib-wasm/src/unsignedbigint256.rs
@@ -19,7 +19,7 @@ fn wrap_arith_op(
 
 #[wasm_bindgen]
 impl UnsignedBigInt {
-    /// Create a new UnsignedBigInt from Number or JS BigInt
+    /// Create a new UnsignedBigInt from a nonnegative safe integer Number or JS BigInt
     #[wasm_bindgen(constructor)]
     pub fn new(number: wasm_bindgen::JsValue) -> Result<Self, JsError> {
         match number.dyn_into::<js_sys::BigInt>() {
@@ -31,11 +31,18 @@ impl UnsignedBigInt {
                     .map_err(|_| JsError::new("failed to convert to UnsignedBigInt"))
             }
             Err(number) => {
-                let num: u64 = number
+                let num = number
                     .as_f64()
-                    .ok_or_else(|| JsError::new("UnsignedBigInt.new: expected numeric type"))?
-                    as u64;
-                Ok(Self(unsignedbigint256::UnsignedBigInt::from(num)))
+                    .ok_or_else(|| JsError::new("UnsignedBigInt.new: expected numeric type"))?;
+                if !num.is_finite()
+                    || !(0.0..=9_007_199_254_740_991.0).contains(&num)
+                    || num.fract() != 0.0
+                {
+                    return Err(JsError::new(
+                        "UnsignedBigInt.new: expected nonnegative safe integer Number; use BigInt for larger integers",
+                    ));
+                }
+                Ok(Self(unsignedbigint256::UnsignedBigInt::from(num as u64)))
             }
         }
     }

--- a/bindings/ergo-lib-wasm/tests/test_unsignedbigint.js
+++ b/bindings/ergo-lib-wasm/tests/test_unsignedbigint.js
@@ -6,6 +6,57 @@ beforeEach(async () => {
   ergo_wasm = await ergo;
 });
 
+for (const [name, value] of [
+  ["negative Number", -1],
+  ["NaN", NaN],
+  ["positive infinity", Infinity],
+  ["negative infinity", -Infinity],
+  ["fractional Number", 1.5],
+  ["unsafe Number", Number.MAX_SAFE_INTEGER + 1],
+]) {
+  it(`UnsignedBigInt rejects ${name}`, () => {
+    expect(() => new ergo_wasm.UnsignedBigInt(value)).to.throw(Error);
+  });
+}
+
+for (const value of [0, Number.MAX_SAFE_INTEGER]) {
+  it(`UnsignedBigInt accepts safe Number ${value} exactly`, () => {
+    const actual = new ergo_wasm.UnsignedBigInt(value);
+    const expected = new ergo_wasm.UnsignedBigInt(BigInt(value));
+    try {
+      assert(actual.eq(expected));
+    } finally {
+      actual.free();
+      expected.free();
+    }
+  });
+}
+
+for (const [name, value] of [
+  ["above u64", BigInt(1) << BigInt(64)],
+  ["maximum u256", (BigInt(1) << BigInt(256)) - BigInt(1)],
+]) {
+  it(`UnsignedBigInt accepts BigInt ${name} exactly`, () => {
+    const actual = new ergo_wasm.UnsignedBigInt(value);
+    const expected = ergo_wasm.UnsignedBigInt.from_str_radix(value.toString(), 10);
+    try {
+      assert(actual.eq(expected));
+    } finally {
+      actual.free();
+      expected.free();
+    }
+  });
+}
+
+for (const [name, value] of [
+  ["negative BigInt", -BigInt(1)],
+  ["BigInt above u256", BigInt(1) << BigInt(256)],
+]) {
+  it(`UnsignedBigInt rejects ${name}`, () => {
+    expect(() => new ergo_wasm.UnsignedBigInt(value)).to.throw(Error);
+  });
+}
+
 it("unsignedbigint tests", async () => {
   const bigint = new ergo_wasm.UnsignedBigInt(5)
   const bigint2 = new ergo_wasm.UnsignedBigInt(BigInt(5))
@@ -14,3 +65,26 @@ it("unsignedbigint tests", async () => {
   const modulus = new ergo_wasm.UnsignedBigInt(7)
   assert(bigint.mod_mul(bigint.mod_inv(modulus), modulus).eq(new ergo_wasm.UnsignedBigInt(1)))
 });
+
+for (const [method, a, b] of [
+  ["mod_sub", 5, 3],
+  ["mod_sub", 3, 3],
+  ["mod_sub", 1, 3],
+  ["mod_inv", 5, 0],
+]) {
+  it(`UnsignedBigInt ${method}(${a}, ${b}) rejects zero modulus with an ordinary Error`, () => {
+    const value = new ergo_wasm.UnsignedBigInt(a);
+    const other = new ergo_wasm.UnsignedBigInt(b);
+    const zero = new ergo_wasm.UnsignedBigInt(0);
+    try {
+      const operation = method === "mod_inv"
+        ? () => value.mod_inv(zero)
+        : () => value.mod_sub(other, zero);
+      expect(operation).to.throw(Error).with.property("name", "Error");
+    } finally {
+      value.free();
+      other.free();
+      zero.free();
+    }
+  });
+}

--- a/ergo-chain-types/src/header.rs
+++ b/ergo-chain-types/src/header.rs
@@ -7,6 +7,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core3::io::Write;
 use num_bigint::{BigUint, ToBigInt};
+use num_traits::Zero;
 use sigma_ser::vlq_encode::{ReadSigmaVlqExt, WriteSigmaVlqExt};
 use sigma_ser::{
     ScorexParsingError, ScorexSerializable, ScorexSerializationError, ScorexSerializeResult,
@@ -99,10 +100,15 @@ impl Header {
         Ok(data)
     }
     /// Check that proof of work was valid for header. Only Autolykos2 is supported
+    /// Returns [`AutolykosPowSchemeError::OutOfBounds`] if the decoded difficulty is zero.
     pub fn check_pow(&self) -> Result<bool, AutolykosPowSchemeError> {
         if self.version != 1 {
             let hit = AutolykosPowScheme::default().pow_hit(self)?;
-            let target = order_bigint() / decode_compact_bits(self.n_bits);
+            let difficulty = decode_compact_bits(self.n_bits);
+            if difficulty.is_zero() {
+                return Err(AutolykosPowSchemeError::OutOfBounds);
+            }
+            let target = order_bigint() / difficulty;
             #[allow(clippy::unwrap_used)] // unsigned -> signed conversion never fails
             Ok(hit.to_bigint().unwrap() < target)
         } else {
@@ -404,6 +410,72 @@ mod arbitrary {
                 )
                 .boxed()
         }
+    }
+}
+
+#[cfg(test)]
+mod pow_boundary_tests {
+    use super::*;
+
+    fn header(n_bits: u32) -> Header {
+        Header {
+            version: 2,
+            id: BlockId(Digest32::zero()),
+            parent_id: BlockId(Digest32::zero()),
+            ad_proofs_root: Digest32::zero(),
+            state_root: ADDigest::zero(),
+            transaction_root: Digest32::zero(),
+            timestamp: 0,
+            n_bits,
+            height: 1,
+            extension_root: Digest32::zero(),
+            autolykos_solution: AutolykosSolution {
+                miner_pk: Box::new(crate::ec_point::generator()),
+                pow_onetime_pk: None,
+                nonce: vec![0; 8],
+                pow_distance: None,
+            },
+            votes: Votes([0; 3]),
+            unparsed_bytes: Box::new([]),
+        }
+    }
+
+    #[test]
+    fn check_pow_zero_difficulty_returns_error() {
+        assert_eq!(
+            header(0).check_pow(),
+            Err(AutolykosPowSchemeError::OutOfBounds)
+        );
+    }
+
+    #[test]
+    fn check_pow_truncated_zero_difficulty_returns_error() {
+        assert_eq!(
+            header(0x01003456).check_pow(),
+            Err(AutolykosPowSchemeError::OutOfBounds)
+        );
+    }
+
+    #[test]
+    fn check_pow_signed_zero_difficulty_returns_error() {
+        assert_eq!(
+            header(0x03800000).check_pow(),
+            Err(AutolykosPowSchemeError::OutOfBounds)
+        );
+    }
+
+    #[test]
+    fn check_pow_nonzero_compact_boundaries_preserved() {
+        assert_eq!(header(0x01010000).check_pow(), Ok(true));
+        assert_eq!(header(0x03000001).check_pow(), Ok(true));
+        assert_eq!(header(0x01810000).check_pow(), Ok(false));
+        assert_eq!(header(0xff7fffff).check_pow(), Ok(false));
+        let mut unsupported = header(0);
+        unsupported.version = 1;
+        assert_eq!(
+            unsupported.check_pow(),
+            Err(AutolykosPowSchemeError::Unsupported)
+        );
     }
 }
 

--- a/ergo-lib/CHANGELOG.md
+++ b/ergo-lib/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Serialization I/O traits now use the exact-pinned `core3` 0.1.2 successor instead of `core2`; downstream implementations using those traits may need to update their I/O imports and error types.
+- The WASM `UnsignedBigInt` constructor accepts only nonnegative safe integers as JavaScript Numbers. Use BigInt for larger values.
+
+### Fixed
+- Correct unsigned 256-bit division in the C API and return errors for zero-modulus subtraction and inversion.
+- Return an error when `Header.check_pow` receives a compact difficulty that decodes to zero.
+- Validate reduced-transaction input counts and serialized context extensions before JSON acceptance, binary serialization, signing, and deterministic commitment generation.
+- Reject unsupported reductions and missing keys in deterministic signing instead of falling back to random proofs. Single-key DLog and trivial-true inputs remain supported.
+- Repair release-preflight environment setup so GitHub can schedule the package validation jobs.
 
 ## [0.28.0] - 2024-08-09
 ## [0.27.1] - 2023-12-02

--- a/ergo-lib/src/chain/transaction/reduced.rs
+++ b/ergo-lib/src/chain/transaction/reduced.rs
@@ -8,6 +8,7 @@ use ergotree_ir::serialization::sigma_byte_reader::SigmaByteRead;
 use ergotree_ir::serialization::sigma_byte_writer::SigmaByteWrite;
 use ergotree_ir::serialization::SigmaParsingError;
 use ergotree_ir::serialization::SigmaSerializable;
+use ergotree_ir::serialization::SigmaSerializationError;
 use ergotree_ir::serialization::SigmaSerializeResult;
 use ergotree_ir::sigma_protocol::sigma_boolean::SigmaBoolean;
 
@@ -54,6 +55,7 @@ pub struct ReducedInput {
 /// <https://github.com/ergoplatform/ergo-appkit/blob/1b7347caa863ecb0b9ba49ae57b090d1f386c906/common/src/main/java/org/ergoplatform/appkit/AppkitProvingInterpreter.scala#L261-L266>
 #[derive(PartialEq, Eq, Debug, Clone)]
 #[cfg_attr(feature = "json", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "json", serde(try_from = "ReducedTransactionUnchecked"))]
 pub struct ReducedTransaction {
     /// Unsigned transation
     #[cfg_attr(feature = "json", serde(rename = "unsignedTx"))]
@@ -66,7 +68,57 @@ pub struct ReducedTransaction {
     reduced_inputs: TxIoVec<ReducedInput>,
 }
 
+#[cfg(feature = "json")]
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReducedTransactionUnchecked {
+    unsigned_tx: UnsignedTransaction,
+    tx_cost: u32,
+    reduced_inputs: TxIoVec<ReducedInput>,
+}
+
+#[cfg(feature = "json")]
+impl TryFrom<ReducedTransactionUnchecked> for ReducedTransaction {
+    type Error = SigmaSerializationError;
+
+    fn try_from(value: ReducedTransactionUnchecked) -> Result<Self, Self::Error> {
+        let tx = Self {
+            unsigned_tx: value.unsigned_tx,
+            tx_cost: value.tx_cost,
+            reduced_inputs: value.reduced_inputs,
+        };
+        tx.validate()?;
+        Ok(tx)
+    }
+}
+
 impl ReducedTransaction {
+    // Recheck at consumers because unsigned_tx is public and can be replaced.
+    pub(crate) fn validate(&self) -> Result<(), SigmaSerializationError> {
+        if self.unsigned_tx.inputs.len() != self.reduced_inputs.len() {
+            return Err(SigmaSerializationError::NotSupported(
+                "reduced input count must match unsigned input count".into(),
+            ));
+        }
+        for (idx, (input, reduced)) in self
+            .unsigned_tx
+            .inputs
+            .iter()
+            .zip(self.reduced_inputs.iter())
+            .enumerate()
+        {
+            // Map equality ignores insertion order, which affects bytes_to_sign.
+            if input.extension.sigma_serialize_bytes()?
+                != reduced.extension.sigma_serialize_bytes()?
+            {
+                return Err(SigmaSerializationError::NotSupported(format!(
+                    "reduced input extension must match unsigned input extension at index {idx}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Returns reduction results for each unsigned tx input
     pub fn reduced_inputs(&self) -> TxIoVec<ReducedInput> {
         self.reduced_inputs.clone()
@@ -107,6 +159,7 @@ pub fn reduce_tx(
 
 impl SigmaSerializable for ReducedTransaction {
     fn sigma_serialize<W: SigmaByteWrite>(&self, w: &mut W) -> SigmaSerializeResult {
+        self.validate()?;
         let msg = self.unsigned_tx.bytes_to_sign()?;
         w.put_usize_as_u32_unwrapped(msg.len())?;
         w.write_all(&msg)?;
@@ -185,12 +238,205 @@ pub mod arbitrary {
 }
 
 #[cfg(test)]
-#[allow(clippy::panic)]
+#[allow(clippy::panic, clippy::unwrap_used)]
 mod tests {
     use super::*;
 
+    use crate::chain::ergo_box::box_builder::ErgoBoxCandidateBuilder;
+    use crate::wallet::Wallet;
+    use ergo_chain_types::Digest32;
+    use ergotree_ir::chain::ergo_box::{box_value::BoxValue, BoxId};
+    use ergotree_ir::ergo_tree::ErgoTree;
+    use ergotree_ir::mir::{constant::Constant, expr::Expr};
     use ergotree_ir::serialization::sigma_serialize_roundtrip;
     use proptest::prelude::*;
+
+    fn fixture(input_count: usize, reduction_count: usize) -> ReducedTransaction {
+        let output = ErgoBoxCandidateBuilder::new(
+            BoxValue::SAFE_USER_MIN,
+            ErgoTree::try_from(Expr::Const(Constant::from(true))).unwrap(),
+            0,
+        )
+        .build()
+        .unwrap();
+        let inputs = (0..input_count)
+            .map(|i| {
+                UnsignedInput::new(
+                    BoxId::from(Digest32::from([i as u8; 32])),
+                    ContextExtension::empty(),
+                )
+            })
+            .collect();
+        ReducedTransaction {
+            unsigned_tx: UnsignedTransaction::new_from_vec(inputs, vec![], vec![output]).unwrap(),
+            tx_cost: 0,
+            reduced_inputs: (0..reduction_count)
+                .map(|_| ReducedInput {
+                    sigma_prop: true.into(),
+                    cost: 0,
+                    extension: ContextExtension::empty(),
+                })
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        }
+    }
+
+    fn changed_extension(reverse: bool) -> ContextExtension {
+        let mut extension = ContextExtension::empty();
+        for key in if reverse { [2, 1] } else { [1, 2] } {
+            extension.values.insert(key, Constant::from(key as i32));
+        }
+        extension
+    }
+
+    fn with_extensions(
+        unsigned: ContextExtension,
+        reduced: ContextExtension,
+    ) -> ReducedTransaction {
+        let mut tx = fixture(1, 1);
+        tx.unsigned_tx = UnsignedTransaction::new(
+            tx.unsigned_tx.inputs.mapped(|mut input| {
+                input.extension = unsigned.clone();
+                input
+            }),
+            tx.unsigned_tx.data_inputs,
+            tx.unsigned_tx.output_candidates,
+        )
+        .unwrap();
+        tx.reduced_inputs = tx.reduced_inputs.mapped(|mut input| {
+            input.extension = reduced.clone();
+            input
+        });
+        tx
+    }
+
+    #[test]
+    fn reduced_transaction_valid_signing_and_serialization() {
+        let tx = fixture(2, 2);
+        assert_eq!(sigma_serialize_roundtrip(&tx), tx);
+        assert!(Wallet::from_secrets(vec![])
+            .sign_reduced_transaction(tx, None)
+            .is_ok());
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn reduced_transaction_valid_extensions_preserve_bytes() {
+        let tx = with_extensions(changed_extension(true), changed_extension(true));
+        let bytes = tx.sigma_serialize_bytes().unwrap();
+        let json = serde_json::to_string(&tx).unwrap();
+        let parsed: ReducedTransaction = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, tx);
+        assert_eq!(parsed.sigma_serialize_bytes().unwrap(), bytes);
+        assert_eq!(sigma_serialize_roundtrip(&tx), tx);
+        let message = tx.unsigned_tx.bytes_to_sign().unwrap();
+        let signed = Wallet::from_secrets(vec![])
+            .sign_reduced_transaction(tx, None)
+            .unwrap();
+        assert_eq!(signed.bytes_to_sign().unwrap(), message);
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn reduced_transaction_json_rejects_missing_reduction() {
+        assert!(serde_json::from_value::<ReducedTransaction>(
+            serde_json::to_value(fixture(2, 1)).unwrap()
+        )
+        .is_err());
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn reduced_transaction_json_rejects_excess_reduction() {
+        assert!(serde_json::from_value::<ReducedTransaction>(
+            serde_json::to_value(fixture(1, 2)).unwrap()
+        )
+        .is_err());
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn reduced_transaction_json_rejects_extension_mismatch() {
+        let tx = with_extensions(changed_extension(false), ContextExtension::empty());
+        assert!(
+            serde_json::from_value::<ReducedTransaction>(serde_json::to_value(tx).unwrap())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn reduced_transaction_signing_rejects_mutated_input_count() {
+        let mut tx = fixture(1, 1);
+        tx.unsigned_tx = fixture(2, 2).unsigned_tx;
+        assert!(Wallet::from_secrets(vec![])
+            .generate_deterministic_commitments(&tx, &[])
+            .is_err());
+        assert!(Wallet::from_secrets(vec![])
+            .sign_reduced_transaction(tx, None)
+            .is_err());
+    }
+
+    #[test]
+    fn reduced_transaction_signing_rejects_excess_reduction() {
+        assert!(Wallet::from_secrets(vec![])
+            .sign_reduced_transaction(fixture(1, 2), None)
+            .is_err());
+    }
+
+    #[test]
+    fn reduced_transaction_signing_rejects_extension_mismatch() {
+        let tx = with_extensions(changed_extension(false), ContextExtension::empty());
+        assert!(Wallet::from_secrets(vec![])
+            .generate_deterministic_commitments(&tx, &[])
+            .is_err());
+        assert!(Wallet::from_secrets(vec![])
+            .sign_reduced_transaction(tx, None)
+            .is_err());
+    }
+
+    #[test]
+    fn reduced_transaction_serialization_rejects_missing_reduction() {
+        assert!(fixture(2, 1).sigma_serialize_bytes().is_err());
+    }
+
+    #[test]
+    fn reduced_transaction_serialization_rejects_excess_reduction() {
+        assert!(fixture(1, 2).sigma_serialize_bytes().is_err());
+    }
+
+    #[test]
+    fn reduced_transaction_serialization_rejects_extension_mismatch() {
+        assert!(
+            with_extensions(changed_extension(false), ContextExtension::empty())
+                .sigma_serialize_bytes()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn reduced_transaction_signing_rejects_extension_order_mismatch() {
+        let unsigned = changed_extension(false);
+        let reduced = changed_extension(true);
+        assert_eq!(unsigned, reduced);
+        assert_ne!(
+            unsigned.sigma_serialize_bytes().unwrap(),
+            reduced.sigma_serialize_bytes().unwrap()
+        );
+        let tx = with_extensions(unsigned, reduced);
+        assert!(tx.sigma_serialize_bytes().is_err());
+        assert!(Wallet::from_secrets(vec![])
+            .generate_deterministic_commitments(&tx, &[])
+            .is_err());
+        #[cfg(feature = "json")]
+        assert!(
+            serde_json::from_str::<ReducedTransaction>(&serde_json::to_string(&tx).unwrap())
+                .is_err()
+        );
+        assert!(Wallet::from_secrets(vec![])
+            .sign_reduced_transaction(tx, None)
+            .is_err());
+    }
 
     proptest! {
 

--- a/ergo-lib/src/wallet.rs
+++ b/ergo-lib/src/wallet.rs
@@ -158,23 +158,26 @@ impl Wallet {
     }
 
     /// Generate commitments for P2PK inputs using deterministic nonces. \
+    /// Rejects unsupported reductions and inputs without a matching secret key.
+    /// Trivial true inputs need no commitments; trivial false inputs are rejected.
     /// See: [`Wallet::sign_transaction_deterministic`]
     pub fn generate_deterministic_commitments(
         &self,
         reduced_tx: &ReducedTransaction,
         aux_rand: &[u8],
     ) -> Result<TransactionHintsBag, TxSigningError> {
+        reduced_tx.validate()?;
         let mut tx_hints = TransactionHintsBag::empty();
         let msg = reduced_tx.unsigned_tx.bytes_to_sign()?;
         for (index, input) in reduced_tx.reduced_inputs().iter().enumerate() {
-            if let Some(bag) = self::deterministic::generate_commitments_for(
+            let bag = self::deterministic::generate_commitments_for(
                 &*self.prover,
                 &input.sigma_prop,
                 &msg,
                 aux_rand,
-            ) {
-                tx_hints.add_hints_for_input(index, bag)
-            };
+            )
+            .map_err(|error| TxSigningError::ProverError(error, index))?;
+            tx_hints.add_hints_for_input(index, bag);
         }
         Ok(tx_hints)
     }
@@ -185,7 +188,8 @@ impl Wallet {
     /// is not available, `sign_transaction_deterministic` can be used to generate the nonce using a hash of the private key and message. \
     /// Additionally `aux_rand` can be optionally supplied with up 32 bytes of entropy.
     /// # Limitations
-    /// Only inputs that reduce to a single public key can be signed. Thus proveDhTuple, n-of-n and t-of-n signatures can not be produced using this method
+    /// Inputs must reduce to a single public key with a matching wallet secret, or to trivial true.
+    /// Other reductions, including proveDhTuple, n-of-n, t-of-n and trivial false, are rejected before proving.
     pub fn sign_transaction_deterministic(
         &self,
         tx_context: TransactionContext<UnsignedTransaction>,

--- a/ergo-lib/src/wallet/deterministic.rs
+++ b/ergo-lib/src/wallet/deterministic.rs
@@ -3,7 +3,7 @@ use ergotree_interpreter::sigma_protocol::{
     private_input::PrivateInput,
     prover::{
         hint::{CommitmentHint, Hint, HintsBag, OwnCommitment, RealCommitment},
-        Prover,
+        Prover, ProverError,
     },
     unproven_tree::NodePosition,
     FirstProverMessage,
@@ -15,17 +15,18 @@ pub(super) fn generate_commitments_for<P: Prover + ?Sized>(
     sigma_tree: &SigmaBoolean,
     msg: &[u8],
     aux_rand: &[u8],
-) -> Option<HintsBag> {
+) -> Result<HintsBag, ProverError> {
     let position = NodePosition::crypto_tree_prefix();
     match sigma_tree {
         SigmaBoolean::ProofOfKnowledge(SigmaProofOfKnowledgeTree::ProveDlog(pk)) => {
             let PrivateInput::DlogProverInput(sk) = prover
                 .secrets()
                 .iter()
-                .find(|secret| secret.public_image() == *sigma_tree)?
+                .find(|secret| secret.public_image() == *sigma_tree)
+                .ok_or(ProverError::SecretNotFound)?
                 .clone()
             else {
-                return None;
+                return Err(ProverError::SecretNotFound);
             };
             let (r, a) = first_message_deterministic(&sk, msg, aux_rand);
             let mut bag = HintsBag::empty();
@@ -44,11 +45,15 @@ pub(super) fn generate_commitments_for<P: Prover + ?Sized>(
                 }));
             bag.add_hint(real_commitment);
             bag.add_hint(own_commitment);
-            Some(bag)
+            Ok(bag)
         }
-        SigmaBoolean::TrivialProp(_)
-        | SigmaBoolean::ProofOfKnowledge(_)
-        | SigmaBoolean::SigmaConjecture(_) => None,
+        SigmaBoolean::TrivialProp(true) => Ok(HintsBag::empty()),
+        SigmaBoolean::TrivialProp(false) => Err(ProverError::ReducedToFalse),
+        SigmaBoolean::ProofOfKnowledge(_) | SigmaBoolean::SigmaConjecture(_) => {
+            Err(ProverError::Unexpected(
+                "deterministic signing requires a single ProveDlog or trivial true reduction",
+            ))
+        }
     }
 }
 
@@ -75,6 +80,176 @@ mod test {
     use crate::wallet::secret_key::SecretKey;
     use crate::wallet::signing::TransactionContext;
     use crate::wallet::Wallet;
+
+    fn fixed_dlog(value: u8) -> SecretKey {
+        let mut bytes = [0; 32];
+        bytes[31] = value;
+        SecretKey::dlog_from_bytes(&bytes).unwrap()
+    }
+
+    fn public_image(secret: &SecretKey) -> super::SigmaBoolean {
+        super::PrivateInput::from(secret.clone()).public_image()
+    }
+
+    fn contract_context(
+        sigma: super::SigmaBoolean,
+    ) -> (
+        TransactionContext<UnsignedTransaction>,
+        crate::chain::ergo_state_context::ErgoStateContext,
+    ) {
+        use ergotree_ir::{
+            chain::tx_id::TxId,
+            mir::{constant::Constant, expr::Expr},
+        };
+        let expr: Expr = Constant::from(sigma).into();
+        let tree = expr.try_into().unwrap();
+        let candidate = ErgoBoxCandidateBuilder::new(BoxValue::SAFE_USER_MIN, tree, 0)
+            .build()
+            .unwrap();
+        let input_box = ErgoBox::from_box_candidate(&candidate, TxId::zero(), 0).unwrap();
+        let tx = UnsignedTransaction::new_from_vec(
+            vec![UnsignedInput::new(
+                input_box.box_id(),
+                ContextExtension::empty(),
+            )],
+            vec![],
+            vec![candidate],
+        )
+        .unwrap();
+        (
+            TransactionContext::new(tx, vec![input_box], vec![]).unwrap(),
+            force_any_val(),
+        )
+    }
+
+    fn assert_contract_rejected(wallet: &Wallet, sigma: super::SigmaBoolean) {
+        let (context, state) = contract_context(sigma);
+        let reduced =
+            crate::chain::transaction::reduced::reduce_tx(context.clone(), &state).unwrap();
+        assert!(wallet
+            .generate_deterministic_commitments(&reduced, &[])
+            .is_err());
+        assert!(wallet
+            .sign_reduced_transaction_deterministic(reduced, &[])
+            .is_err());
+        assert!(wallet
+            .sign_transaction_deterministic(context, &state, &[])
+            .is_err());
+    }
+
+    #[test]
+    fn deterministic_contract_rejects_two_key_and() {
+        use ergotree_ir::sigma_protocol::sigma_boolean::cand::Cand;
+        let keys = vec![fixed_dlog(1), fixed_dlog(2)];
+        let sigma = Cand::normalized(
+            keys.iter()
+                .map(public_image)
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap(),
+        );
+        let wallet = Wallet::from_secrets(keys);
+        let (context, state) = contract_context(sigma.clone());
+        if let Ok(first) = wallet.sign_transaction_deterministic(context.clone(), &state, &[]) {
+            let second = wallet
+                .sign_transaction_deterministic(context, &state, &[])
+                .unwrap();
+            assert!(first.inputs.first().spending_proof.proof == second.inputs.first().spending_proof.proof,
+                "unsupported two-key AND produced different proofs for identical deterministic signing inputs");
+            panic!("unsupported two-key AND was signed");
+        }
+        assert_contract_rejected(&wallet, sigma);
+    }
+
+    #[test]
+    fn deterministic_contract_rejects_dhtuple() {
+        use ergotree_interpreter::sigma_protocol::private_input::DhTupleProverInput;
+        use ergotree_ir::sigma_protocol::sigma_boolean::ProveDhTuple;
+        let super::PrivateInput::DlogProverInput(secret) = super::PrivateInput::from(fixed_dlog(3))
+        else {
+            unreachable!()
+        };
+        let generator = ergo_chain_types::ec_point::generator();
+        let point = *secret.public_image().h;
+        let key = SecretKey::DhtSecretKey(DhTupleProverInput {
+            w: secret.w,
+            common_input: ProveDhTuple::new(generator, generator, point, point),
+        });
+        let sigma = public_image(&key);
+        assert_contract_rejected(&Wallet::from_secrets(vec![key]), sigma);
+    }
+
+    #[test]
+    fn deterministic_contract_rejects_missing_key() {
+        assert_contract_rejected(&Wallet::from_secrets(vec![]), public_image(&fixed_dlog(1)));
+    }
+
+    #[test]
+    fn deterministic_contract_rejects_false() {
+        assert_contract_rejected(&Wallet::from_secrets(vec![]), false.into());
+    }
+
+    #[test]
+    fn deterministic_contract_single_dlog_is_repeatable() {
+        let key = fixed_dlog(1);
+        let sigma = public_image(&key);
+        let (context, state) = contract_context(sigma.clone());
+        let message = context.spending_tx.bytes_to_sign().unwrap();
+        let wallet = Wallet::from_secrets(vec![key]);
+        let reduced =
+            crate::chain::transaction::reduced::reduce_tx(context.clone(), &state).unwrap();
+        let first = wallet
+            .sign_transaction_deterministic(context.clone(), &state, &[])
+            .unwrap();
+        let second = wallet
+            .sign_transaction_deterministic(context, &state, &[])
+            .unwrap();
+        let from_reduced = wallet
+            .sign_reduced_transaction_deterministic(reduced, &[])
+            .unwrap();
+        assert_eq!(first, second);
+        assert_eq!(first, from_reduced);
+        assert!(!first
+            .inputs
+            .first()
+            .spending_proof
+            .proof
+            .clone()
+            .to_bytes()
+            .is_empty());
+        assert!(
+            ergotree_interpreter::sigma_protocol::verifier::verify_signature(
+                sigma,
+                &message,
+                &first.inputs.first().spending_proof.proof.clone().to_bytes(),
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn deterministic_contract_true_needs_no_witness() {
+        let (context, state) = contract_context(true.into());
+        let wallet = Wallet::from_secrets(vec![]);
+        let reduced =
+            crate::chain::transaction::reduced::reduce_tx(context.clone(), &state).unwrap();
+        let first = wallet
+            .sign_transaction_deterministic(context, &state, &[])
+            .unwrap();
+        let from_reduced = wallet
+            .sign_reduced_transaction_deterministic(reduced, &[])
+            .unwrap();
+        assert_eq!(first, from_reduced);
+        assert!(first
+            .inputs
+            .first()
+            .spending_proof
+            .proof
+            .clone()
+            .to_bytes()
+            .is_empty());
+    }
+
     fn gen_boxes() -> impl Strategy<Value = (SecretKey, Vec<ErgoBox>)> {
         any::<Wscalar>()
             .prop_map(|s| SecretKey::DlogSecretKey(DlogProverInput::new(s)))

--- a/ergo-lib/src/wallet/signing.rs
+++ b/ergo-lib/src/wallet/signing.rs
@@ -173,12 +173,12 @@ pub fn sign_reduced_transaction(
     reduced_tx: ReducedTransaction,
     tx_hints: Option<&TransactionHintsBag>,
 ) -> Result<Transaction, TxSigningError> {
+    reduced_tx.validate()?;
     let tx = reduced_tx.unsigned_tx.clone();
     let message_to_sign = tx.bytes_to_sign()?;
+    let inputs = reduced_tx.reduced_inputs();
     let signed_inputs = tx.inputs.enumerated().try_mapped(|(idx, input)| {
-        let inputs = reduced_tx.reduced_inputs();
-
-        // `idx` is valid since it's indexing over `tx.inputs`
+        // validate() checked that every unsigned input has a reduction.
         #[allow(clippy::unwrap_used)]
         let reduced_input = inputs.get(idx).unwrap();
         let mut hints_bag = HintsBag::empty();

--- a/ergotree-interpreter/src/eval/snumeric.rs
+++ b/ergotree-interpreter/src/eval/snumeric.rs
@@ -495,6 +495,25 @@ mod test {
         .into();
         try_eval_out_wo_ctx(&mc)
     }
+    #[test]
+    fn eval_subtract_mod_zero_modulus_arithmetic_exception() {
+        assert!(matches!(
+            eval_modular_op(
+                &SUBTRACT_MOD_METHOD_DESC,
+                &[5u32.into(), 3u32.into(), 0u32.into()]
+            ),
+            Err(EvalError::Spanned(err)) if matches!(*err.error, EvalError::ArithmeticException(_))
+        ));
+    }
+
+    #[test]
+    fn eval_mod_inverse_zero_modulus_arithmetic_exception() {
+        assert!(matches!(
+            eval_modular_op(&MOD_INVERSE_METHOD_DESC, &[3u32.into(), 0u32.into()]),
+            Err(EvalError::Spanned(err)) if matches!(*err.error, EvalError::ArithmeticException(_))
+        ));
+    }
+
     trait Numeric:
         LiftIntoSType
         + TryExtractFrom<Value<'static>>

--- a/ergotree-ir/src/unsignedbigint256.rs
+++ b/ergotree-ir/src/unsignedbigint256.rs
@@ -78,9 +78,9 @@ impl UnsignedBigInt {
         Some(Self::from_wide((self_wide + other_wide).checked_rem(modulus_wide)?).unwrap())
     }
 
-    /// Calculate (self - other) % modulus
+    /// Calculate (self - other) % modulus. Returns None if modulus == 0
     pub fn checked_mod_sub(&self, other: Self, modulus: Self) -> Option<Self> {
-        let other_inv = modulus.checked_sub(&(other % modulus))?;
+        let other_inv = modulus.checked_sub(&other.checked_rem(&modulus)?)?;
         self.checked_mod_add(other_inv, modulus)
     }
 
@@ -96,6 +96,9 @@ impl UnsignedBigInt {
     /// Compute modular inverse x such that (self * x) mod modulus = 1
     /// Returns None if modulus == 0 or inverse does not exist
     pub fn mod_inv(&self, modulus: Self) -> Option<Self> {
+        if modulus.is_zero() {
+            return None;
+        }
         /// Run the extended euclidean algorithm ax + by = gcd(a, b). Returns (gcd(a, b), x).
         fn extended_euclidean(a: UnsignedBigInt, b: UnsignedBigInt) -> (BInt<5>, BInt<5>) {
             let mut a = (a % b).widen_to().cast_signed();
@@ -354,6 +357,53 @@ mod arbitrary {
                 .prop_map(|bytes| Self::from_be_slice(&bytes[..]).unwrap())
                 .boxed()
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod modular_boundary_tests {
+    use super::UnsignedBigInt;
+
+    #[test]
+    fn mod_sub_zero_modulus_returns_none() {
+        assert_eq!(
+            UnsignedBigInt::from(5u32).checked_mod_sub(3u32.into(), 0u32.into()),
+            None
+        );
+    }
+
+    #[test]
+    fn mod_inv_zero_modulus_returns_none() {
+        assert_eq!(UnsignedBigInt::from(3u32).mod_inv(0u32.into()), None);
+    }
+
+    #[test]
+    fn modular_nonzero_boundaries() {
+        let max = UnsignedBigInt::from_be_slice(&[0xff; 32]).unwrap();
+        assert_eq!(
+            max.checked_mod_sub(1u32.into(), 1u32.into()),
+            Some(0u32.into())
+        );
+        assert_eq!(
+            UnsignedBigInt::from(1u32).checked_mod_sub(3u32.into(), 5u32.into()),
+            Some(3u32.into())
+        );
+        assert_eq!(
+            UnsignedBigInt::from(0u32).checked_mod_sub(1u32.into(), max),
+            Some(max - 1u32.into())
+        );
+        assert_eq!(
+            UnsignedBigInt::from(3u32).mod_inv(1u32.into()),
+            Some(0u32.into())
+        );
+        assert_eq!(
+            UnsignedBigInt::from(3u32).mod_inv(7u32.into()),
+            Some(5u32.into())
+        );
+        assert_eq!(UnsignedBigInt::from(2u32).mod_inv(4u32.into()), None);
+        assert_eq!(UnsignedBigInt::from(0u32).mod_inv(7u32.into()), None);
+        assert_eq!(UnsignedBigInt::from(1u32).mod_inv(max), Some(1u32.into()));
     }
 }
 


### PR DESCRIPTION
The review since 0.28.0 found checked APIs that can panic or return the wrong result, inconsistent reduced transactions reaching signing, and deterministic signing silently falling back to random proofs. This corrects those paths and the release-preflight workflow in six separate commits.

### Changes

- C U256 division now divides; zero divisors preserve the caller's output.
- U256 modular subtraction and inversion reject zero modulus before unchecked arithmetic. Interpreter and binding consumers return errors.
- Header proof-of-work checking returns an error when compact difficulty decodes to zero, including signed and truncated zero encodings.
- Reduced-transaction JSON parsing validates reduction count and serialized context extensions. Binary serialization, signing, and deterministic commitment generation recheck after public-field mutation.
- The WASM U256 constructor accepts only nonnegative safe-integer Numbers. JS BigInt retains the full U256 range.
- Deterministic signing rejects unsupported propositions, missing keys, and trivial false before proving. Single DLog and trivial true remain supported.
- Release preflight initializes `CARGO_TARGET_DIR` through `GITHUB_ENV`; job-level `runner.temp` expressions previously prevented both package jobs from being scheduled. The installer checks `wasm-pack` by its installed path because additions to `GITHUB_PATH` take effect in subsequent steps.

### Validation

Rust 1.91.1 on Windows x64 with a frozen dependency lock:

- 731 affected Rust library tests, 8 C crate tests, and 17 optimized Node WASM regressions passed.
- 63 tests passed in Chrome against the exact optimized browser package, including transaction construction/signing and the U256 regressions.
- 12 cases passed through an external MSVC C caller with a feature-matched generated header.
- The true `thumbv7m-none-eabi` no-default-features rlib build, Clippy, rustfmt, and whitespace checks passed.
- All 16 selected Rust packages passed packaging and publish dry-run verification. Final Node/browser 0.29.0 packages passed `npm pack --dry-run`.
- Eight numerical controls passed against SigmaState 6.0.6. Two distinct Rust-produced cold-wallet proof tuples verified in the JVM, with isolated changed-message and changed-proof cases rejected.
- Four cold-wallet workflow tests passed using reduced byte/JSON import into separate wallet instances, deterministic signing, and proof verification.

The original five commits received independent review by scope. The additional one-line installer correction in `80cd0efd` has a failing-before/passing-after Bash check and passes actionlint; its independent review remains pending. The first hosted run confirmed installation and checksum verification, then failed at the original same-step version lookup. These checks do not establish node admission, complete costing, or activation consensus.

Hosted CI is now green on `80cd0efd16ea06d37cef685b1e1252655c20dd70`: [Tests](https://github.com/ergoplatform/sigma-rust/actions/runs/34623297985) passed 12 jobs, [Python CI](https://github.com/ergoplatform/sigma-rust/actions/runs/34623298159) passed 16 jobs with Release skipped, and [release preflight](https://github.com/ergoplatform/sigma-rust/actions/runs/34623298055) passed both jobs. The JS job passed 61 Node tests and 75 browser tests, built the alpha variants, and skipped both npm publishing steps. The GitHub merge commit `f8af792dd6777316844bd4e16a4aeaebd36c2a71` has the same source tree as the PR head.

### Related work and remaining release checks

- #875 remains separate. Its exact production hunk combined with these corrections passed 22 focused checks, including mixed V3/V0/V3 transaction reduction. The cold-wallet workflow also exercised that combination.
- #843 changes extension serialization order. This change checks that the two transaction representations produce identical serialized extensions; it does not choose a different ordering rule.
- The workflow correction follows merged #919. The source base is `f9ea8f3e5a069e136ee47e754d47275be91c5d3d`.
- The repository cbindgen configuration expands REST exports; a consumer must align its generated header and macros with the library features. The default C check above used a task-local configuration omitting REST expansion. No REST-header behavior is changed here.
- The existing npm alpha publication E404/access failure and the maintainer node/manual release round remain outstanding. PR-triggered checks do not publish packages.
